### PR TITLE
test(socket.io): add Stryker mutation suite at 100%

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,6 +237,7 @@ Append durable findings to **Agent notes** below (API quirks, migration status, 
 
 _Append learnings for the next agent. Newest first._
 
+- **2026-07-18** — Mutation testing on `@tao.js/socket.io`: `pnpm test:mutation:socket.io` — score **100%** (Node jest-env; client/server via `window` + `isolateModules`).
 - **2026-07-18** — Mutation testing on `@tao.js/react`: `pnpm test:mutation:react` (`packages/react-tao/stryker.config.json`, same `inPlace` + jest-runner pattern as core). Score **100%**. Explicit `testEnvironment: 'jsdom'` required — Stryker does not merge preset env under `perTest` coverage analysis.
 - **2026-07-18** — Mutation testing on `@tao.js/core` via Stryker: `pnpm test:mutation:core` (`packages/tao/stryker.config.json`, `inPlace: true`). Score raised to **~99.8%** (behavioral survivors killed; equivalents ignored via `// Stryker disable … : reason`). Thresholds high=95. Reports gitignored under `packages/tao/reports/mutation/`.
 - **2026-07-18** — Stryker disable reasons must use `:` not `--`, or the directive is ignored. Disable-inside-`try` does not cover the following `catch` (block scope); put `disable` _before_ the `try`.

--- a/FUTURE.md
+++ b/FUTURE.md
@@ -16,7 +16,7 @@ TODO
 - [x] finish the transformation to nx.js (Nx 23.1.0; alpha ladder `0.16.3-alpha.nx{21,22,23}` on npm `alpha` tag)
 - [ ] implement the TypeScript library wrapper
 - [x] complete all tests for 100% code coverage
-- [ ] create a mutation test suite and exercise it (Stryker: `@tao.js/core` + `@tao.js/react` at 100% — `pnpm test:mutation:core` / `test:mutation:react`)
+- [ ] create a mutation test suite and exercise it (Stryker: core, react, socket.io at 100%; more packages rolling out)
 - [ ] rewrite documentation site
 - [x] update to React 19 implementation for @taojs/react
 - [ ] transfer ownership to tao-land

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:coverage:view": "open packages/docs/src/content/coverage/index.html",
     "test:mutation:core": "pnpm --filter @tao.js/core test:mutation",
     "test:mutation:react": "pnpm --filter @tao.js/react test:mutation",
+    "test:mutation:socket.io": "pnpm --filter @tao.js/socket.io test:mutation",
     "test:watch": "nx run-many --target=test:watch --all --exclude=patois.*,react19-smoke",
     "lint": "nx run-many --target=lint --all --exclude=patois.*,react19-smoke",
     "lint:packages": "nx run-many --target=lint --all",

--- a/packages/tao-socket-io/README.mutation.md
+++ b/packages/tao-socket-io/README.mutation.md
@@ -1,0 +1,25 @@
+# Mutation testing (`@tao.js/socket.io`)
+
+StrykerJS + Jest for the socket.io bridge package.
+
+## Run
+
+From repo root:
+
+```sh
+pnpm test:mutation:socket.io
+```
+
+Or from this package:
+
+```sh
+pnpm test:mutation
+```
+
+HTML/JSON reports land in `reports/mutation/` (gitignored).
+
+## Notes
+
+- Config: `stryker.config.json` — `inPlace: true`; Jest env is Node (client vs server is simulated via `window` in tests + `jest.isolateModules`).
+- Disable equivalent mutants with `// Stryker disable … : reason` (colon required).
+- Latest score (2026-07-18): **100%**.

--- a/packages/tao-socket-io/package.json
+++ b/packages/tao-socket-io/package.json
@@ -21,7 +21,8 @@
   "scripts": {
     "build:clean": "rimraf dist lib bundles",
     "build:package": "rollup --config",
-    "build": "npm run build:clean && npm run build:package"
+    "build": "npm run build:clean && npm run build:package",
+    "test:mutation": "stryker run"
   },
   "author": "eudaimos",
   "license": "Apache-2.0",

--- a/packages/tao-socket-io/stryker.config.json
+++ b/packages/tao-socket-io/stryker.config.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "../../node_modules/@stryker-mutator/core/schema/stryker-schema.json",
+  "packageManager": "pnpm",
+  "plugins": ["@stryker-mutator/jest-runner"],
+  "testRunner": "jest",
+  "coverageAnalysis": "perTest",
+  "mutate": ["src/**/*.js"],
+  "ignoreStatic": true,
+  "inPlace": true,
+  "jest": {
+    "projectType": "custom",
+    "configFile": "jest.config.js",
+    "enableFindRelatedTests": true,
+    "config": {
+      "testEnvironment": "@stryker-mutator/jest-runner/jest-env/node"
+    }
+  },
+  "reporters": ["html", "clear-text", "progress", "json"],
+  "htmlReporter": {
+    "fileName": "reports/mutation/mutation.html"
+  },
+  "jsonReporter": {
+    "fileName": "reports/mutation/mutation.json"
+  },
+  "tempDirName": "stryker-tmp",
+  "timeoutMS": 20000,
+  "timeoutFactor": 2,
+  "concurrency": 4,
+  "thresholds": {
+    "high": 95,
+    "low": 90,
+    "break": null
+  }
+}

--- a/packages/tao-socket-io/test/tao-socket-io.spec.js
+++ b/packages/tao-socket-io/test/tao-socket-io.spec.js
@@ -174,6 +174,13 @@ describe('@tao.js/socket.io', () => {
       expect(() => socket.events.disconnect('bye')).not.toThrow();
     });
 
+    it('returns middleware when io.of exists but is not a function', () => {
+      const wireTaoJsToSocketIO = loadWire({ browser: false });
+      const middleware = wireTaoJsToSocketIO({}, { of: 'not-a-function' });
+      expect(middleware).toBeInstanceOf(Function);
+      expect(() => middleware(makeSocket())).not.toThrow();
+    });
+
     it('accepts plain inbound events without authTransform', () => {
       const wireTaoJsToSocketIO = loadWire({ browser: false });
       const socket = makeSocket();


### PR DESCRIPTION
## Summary
- Add Stryker mutation suite for `@tao.js/socket.io` (`pnpm test:mutation:socket.io`)
- Strengthen test for non-function `io.of` to reach **100%** mutation score

## Test plan
- [x] `pnpm nx test @tao.js/socket.io`
- [x] `pnpm test:mutation:socket.io` → 100%


Made with [Cursor](https://cursor.com)