### PR TITLE
feat(typed): @tao.js/typed v1 prototype — typed trigram vocabularies (§7 reference, do not merge)

### DIFF
--- a/TYPED-SPEC.md
+++ b/TYPED-SPEC.md
@@ -1,0 +1,146 @@
+# Typed Trigram Vocabularies — Design Spec (@tao.js/typed)
+
+Status: draft (branch `feat/typescript-wrapper`, off `feat/chain-transport`).
+Companion to `ENVELOPE-SPEC.md` (signal plane), `VISION.md` §3 (the
+meta-framework thesis this executes), `AGENTIC.md` (the "typed trigram
+vocabularies" checklist item this closes).
+
+## 1. Motivation
+
+TAO's string-keyed dispatch has one failure mode that disproportionately
+hurts both agents and humans: **a typo'd trigram is a silent no-op, not an
+error**. The paradigm's whole bet is that the app's vocabulary is its
+protocol; today that vocabulary lives in strings the compiler cannot see.
+
+The wrapper makes the vocabulary a **type**: each trigram becomes a typed
+signal constructor whose datagram type is captured with it — the `tao` and
+`data` parameters of the JS contract fused into one typed value. Mistyped
+trigrams and mis-shaped datagrams become compile errors. The JS engine
+underneath is unchanged: the wrapper _translates_ typed messages into
+trigram signals, never reimplements dispatch.
+
+Non-goals: no new runtime semantics (phases, chaining, envelope untouched);
+no TS requirement for JS consumers (pure additive package); no codegen step
+(types are declared, not generated — the protocol extractor may later emit
+a vocabulary skeleton).
+
+## 2. The shape
+
+```ts
+import { defineVocabulary, signal } from '@tao.js/typed';
+
+// The app's protocol as a value — TAO.md as code
+const App = defineVocabulary({
+  UserFind: signal('User', 'Find', 'Portal').data<{ User: { id: string } }>(),
+  UserView: signal('User', 'View', 'Portal').data<{ User: UserRecord }>(),
+  UserFail: signal('User', 'Fail', 'Portal').data<{
+    User: { reason: string };
+  }>(),
+});
+
+// A typed signal IS the trigram + datagram, one value
+const s = App.UserFind({ User: { id: '42' } });
+s.t;
+s.a;
+s.o; // literal types 'User' / 'Find' / 'Portal'
+s.data.User.id; // string — datagram type captured per trigram
+
+// Typed kernel facade over any existing Kernel
+const tao = typedKernel(TAO, App);
+
+tao.set(App.UserFind({ User: { id: '42' } })); // = setCtx underneath
+
+tao.onInline(App.UserFind, (s) => {
+  //  s.data is { User: { id: string } } — no casts
+  return App.UserView({ User: load(s.data.User.id) }); // typed chaining
+});
+
+tao.onIntercept(App.UserFind, (s) => {
+  if (!authorized(s)) return App.UserFail({ User: { reason: 'denied' } });
+});
+```
+
+Key decisions the shape encodes:
+
+1. **Signal constructors, not string keys.** `App.UserFind(data)` produces
+   `{ t, a, o, data }` with literal trigram types. Referencing a signal that
+   doesn't exist is a compile error — the silent-no-op failure mode is gone
+   at authoring time.
+2. **The vocabulary is a plain value.** `defineVocabulary` does no
+   registration and touches no kernel; it is importable by any module,
+   serializable to `TAO.md`, and diffable in review. One vocabulary can be
+   shared by client and server (the protocol artifact, typed).
+3. **Handlers receive the typed signal**, not `(tao, data)` — the fusion
+   Jeff described. The wrapper adapts to the JS `(tao, data)` handler
+   underneath; handler returns may be any signal from the vocabulary
+   (typed chaining) or void.
+4. **Phase-explicit registration** (`onIntercept`/`onAsync`/`onInline`)
+   mirrors the JS contract; returns a dispose function (typed wrapper owns
+   the handler-fn identity mapping so removal works).
+
+## 3. Wildcards, typed
+
+Wildcard subscription is a _projection of the vocabulary_, not a stringly
+escape hatch:
+
+```ts
+tao.onInline(App.match({ t: 'User' }), (s) => {
+  // s: UserFind | UserView | UserFail — discriminated union on (a)
+  switch (s.a) {
+    case 'Find':
+      s.data.User.id;
+      break; // narrowed
+    case 'View':
+      s.data.User;
+      break;
+  }
+});
+tao.onInline(App.any(), (s) => {
+  /* union of the whole vocabulary */
+});
+```
+
+`match` filters the vocabulary at the type level (template-literal /
+conditional types over the declared signals) and registers the equivalent
+wildcard trigram underneath. Signals outside the vocabulary (other
+libraries, untyped app code on the same kernel) simply don't reach typed
+handlers' type space — at runtime they still dispatch per JS semantics;
+`onUnvocabularied` (escape hatch, `unknown` data) is available for
+observability code.
+
+## 4. Translation layer (runtime)
+
+Tiny and dumb by design: `typedKernel(kernel, vocab)` wraps
+`setCtx`/`add*Handler`/`remove*Handler`. `set(signal)` →
+`kernel.setCtx({t,a,o}, data)`. `onX(sigOrMatch, h)` →
+`kernel.addXHandler(trigram, (tao, data) => h(reify(tao, data)))` where
+`reify` rebuilds the typed signal (a plain object; no classes, no
+prototypes across boundaries). Chained returns translate back via their own
+trigram. Transport/telemetry/envelope: untouched — typed signals are
+ordinary signals on the wire and in traces.
+
+Promise surfaces follow: `typedTransponder(transponder, vocab).set(signal)`
+resolves with the vocabulary union (or a `resolveOn`-projected subset).
+
+## 5. Files & packaging
+
+- New package `@tao.js/typed` (`packages/tao-typed`), TypeScript source,
+  emits ESM+CJS+d.ts; peer on `@tao.js/core >=0.20.0`.
+- Tests: type-level tests (`tsd` or `expect-type`) for the vocabulary
+  algebra + runtime jest tests for translation fidelity (a typed cascade
+  observed by a Tracer is identical to its untyped equivalent).
+- JSDoc pass on existing JS packages precedes this (separate commits):
+  typedefs for the public surfaces (Kernel, Network envelope/decoration
+  shapes, adapters, telemetry records, wire envelope), enabling
+  `tsc --allowJs --declaration` d.ts emission for JS consumers and giving
+  the wrapper authoritative shapes to align with.
+
+## 6. Open questions (for Jeff)
+
+1. Naming: `@tao.js/typed` vs `@tao.js/ts`? (spec assumes `typed`)
+2. Should `defineVocabulary` also emit the runtime list of trigrams for the
+   protocol extractor / TAO.md generation (vocab.toProtocol())? (leaning
+   yes — it's free and closes the loop with AGENTIC.md)
+3. Datagram convention: enforce `{ [Term]: ... }` keying at the type level,
+   or leave datagram shapes fully free per signal? (leaning free, with a
+   helper for the term-keyed convention)

--- a/TYPED-SPEC.md
+++ b/TYPED-SPEC.md
@@ -1,9 +1,13 @@
 # Typed Trigram Vocabularies — Design Spec (@tao.js/typed)
 
-Status: draft (branch `feat/typescript-wrapper`, off `feat/chain-transport`).
-Companion to `ENVELOPE-SPEC.md` (signal plane), `VISION.md` §3 (the
-meta-framework thesis this executes), `AGENTIC.md` (the "typed trigram
-vocabularies" checklist item this closes).
+Status: **v1 implemented, superseded in direction by §7 (v2)** — the v1
+surface (§2–§4, `defineVocabulary`/`signal().data<D>()`) is built, tested
+(100% coverage, trace-identity proof), and working, but the design
+conversation recorded in §7 replaces it as the front door. A new session
+should implement §7; the v1 translation layer, toolchain, and invariant
+tests carry over. Companion to `ENVELOPE-SPEC.md` (signal plane),
+`VISION.md` §3 (the meta-framework thesis this executes), `AGENTIC.md`
+(the "typed trigram vocabularies" checklist item this closes).
 
 ## 1. Motivation
 
@@ -144,3 +148,159 @@ resolves with the vocabulary union (or a `resolveOn`-projected subset).
 3. Datagram convention: enforce `{ [Term]: ... }` keying at the type level,
    or leave datagram shapes fully free per signal? (leaning free, with a
    helper for the term-keyed convention)
+
+---
+
+## 7. v2 direction — transparent DX (design conversation record, 2026-07-23/24)
+
+The v1 surface makes the wrapper _visible_: you know you are wrapping
+signal and handler generation. The design goal that replaces it (author's
+framing): **the DX should read as strongly-typed `@tao.js/core`** — same
+method names, quotes deleted, trigrams _inferred_ from the types.
+
+### 7.1 The erasure split (what's possible without tooling)
+
+TypeScript types are erased; **classes are values**. That splits the ideal
+syntax into:
+
+- `tao.setCtx(user, find, portal)` — **works with vanilla tsc**: the
+  arguments are instances, `user.constructor.name` supplies the runtime
+  trigram while inference supplies the types. Explicit-generic and
+  inferred forms are equivalent for free.
+- `tao.addInlineHandler<User, Find, Portal>(fn)` — **impossible without a
+  transform** (type arguments are erased; nothing at runtime names the
+  trigram). The value-carrying form is the vanilla equivalent and is
+  _better_ (zero annotations, full inference):
+  `tao.addInlineHandler(User, Find, Portal, (user, find, portal) => …)`.
+
+### 7.2 Part carriers (the core contract)
+
+A **part carrier** is anything supplying a runtime name + a datagram type
+for one trigram position. Two implementations, one contract:
+
+1. **Classes (front door)** — `class User extends Part<User> { id!: number }`.
+   The `Part<Self>` base solves the four class problems in ~4 lines each:
+   - _nominality_: a `private declare` brand — TS is structurally typed,
+     so without it a plain literal `{id: 1}` typechecks where `User` is
+     expected but has `constructor.name === 'Object'` at runtime (the
+     compile-passes/runtime-explodes trap);
+   - _construction_: `constructor(data: Fields<Self>)` gives
+     `new User({ id: 1 })` without per-class boilerplate;
+   - _minification_: optional `static tao = 'User'` override
+     (name resolution: `static tao ?? class name`; runtime throws loudly
+     on `'Object'`); document `keep_classnames`;
+   - _wire rehydration_: received JSON re-attaches the registered class's
+     prototype, so methods on parts work in handlers — including for
+     signals that crossed a transport.
+2. **Factories (escape hatch)** — `const User = part('User').data<{id: number}>()`,
+   the zod/valibot idiom: name appears once, no `new`, minification-proof,
+   nominal by construction. More idiomatic TS, less transparent.
+
+Datagram mapping revives the **original AppCtx three-datum convention**
+(`data[t]`, `data[a]`, `data[o]` — one datum per position), so typed and
+untyped code interoperate byte-for-byte on one kernel. Dataless positions
+accept the class itself (`tao.setCtx(user, Find, Portal)`).
+
+### 7.3 Open mode vs protocol mode
+
+Transparent calls permit any combination of declared parts (wrong-position
+triples typecheck). Two modes:
+
+- **open** (default): any triple; datagram shapes still enforced.
+- **protocol**: `typedTAO(kernel, { protocol: [[User, Find, Portal], …] as const })`
+  — undeclared trigram = compile error, restoring v1's closed-vocabulary
+  guarantee with transparent call sites. `tao.protocol()` emits the triple
+  list for TAO.md/extractor. Subsumes v1's `defineVocabulary`.
+
+### 7.4 Ergonomics tiers (proposed implementation order)
+
+| tier | mechanism                                                       | pipeline cost                                  | notes                                     |
+| ---- | --------------------------------------------------------------- | ---------------------------------------------- | ----------------------------------------- |
+| 0    | value-carrying API (`addInlineHandler(User, Find, Portal, fn)`) | none                                           | canonical contract everything lowers to   |
+| 1a   | **decorators**                                                  | none (stage-3 native in tsc/esbuild/swc/babel) | build FIRST — biggest ergonomics per cost |
+| 1b   | type-arg transform (`<User, Find, Portal>` sugar)               | opt-in plugin                                  | see 7.6                                   |
+| 2    | TAO.md path DSL                                                 | runtime loader; build plugin optional          | see 7.7                                   |
+
+### 7.5 Decorators (tier 1a)
+
+```ts
+class UserHandlers {
+  constructor(private repo: UserRepo) {} // DI-friendly
+
+  @(onInline(User, Find, Portal).chain(Found)) // declared output edge
+  find(user: User, find: Find) {
+    return new Found({ user: this.repo.find(find.by) }); // just the new part
+  }
+
+  @(onInline(User, Find, Portal).chains(Found, NotFound)) // branching:
+  findOrFail(user: User, find: Find) {
+    // return TYPE picks
+    const hit = this.repo.find(find.by); // the edge
+    return hit ? new Found({ user: hit }) : new NotFound({ query: find.by });
+  }
+}
+const dispose = tao.attach(new UserHandlers(repo)); // group lifecycle
+```
+
+Decorator factories take **values** (no erasure problem, no build tooling);
+`context.addInitializer` collects registrations per instance for
+`attach`/`dispose` group lifecycle (per-request Channels, per-connection
+sockets). The decorator type constrains the method signature against the
+declared parts. `.chain()/.chains()` declared outputs make chain edges
+**statically extractable** (closing part of AGENTIC.md's
+emergent-control-flow friction); guardrails: (a) one mode per handler —
+declared outputs XOR dynamic `chain(t, a, o)` returns (the formalized
+explicit constructor); (b) carried-position semantics fixed at
+`transferToAppCtx` copy rules, never configurable. Support stage-3
+decorators first; legacy `experimentalDecorators` detectable by argument
+shape if Nest/Angular demand it.
+
+### 7.6 The type-arg transform (tier 1b)
+
+Universal _because constrained to a syntactic rewrite_: type arguments must
+be identifiers of value-imported part carriers in scope (no aliases,
+`typeof`, mapped types — diagnostics otherwise; `import type` is a
+diagnostic since it erases the value). Then every toolchain can host it:
+one core transform wrapped by **`@tao.js/unplugin`** (Vite/Rollup/webpack/
+esbuild/rspack), **`@tao.js/babel-plugin`** (babel/Metro/jest), and a
+ts-patch transformer (raw tsc). swc-native pipelines (default Next.js)
+need a wasm plugin eventually or their babel fallback. Editor needs no
+plugin (the sugar overload typechecks standalone); forgetting the plugin
+fails loudly (the untransformed overload's runtime throws a setup error).
+The sugar lowers into tier 0.
+
+### 7.7 `@tao.js/path` revival (tier 2)
+
+Author's original vision: chains declared in one place, forwarding
+handlers auto-wired. Fenced ```tao blocks in TAO.md itself:
+
+    {User, Find, Portal}   => {User, Found, Portal}    # inline forward
+    {User, Found, Portal}  ~> {Analytics, Track, App}  # async forward
+    {User, Delete, Portal} !> {Auth, Check, Portal}    # intercept
+
+Runtime loader parses fences at boot and wires via the existing
+`forward-chain` helpers; the build plugin (same unplugin infra as 7.6)
+validates every trigram against the typed protocol at compile time. The
+DSL stays for _pure_ forwards (transferToAppCtx copy semantics) — logic
+stays in code or in decorator `.chain()` transforms; the two are the same
+primitive in two syntaxes. TAO.md becomes simultaneously docs, declared
+protocol, chain topology, and (via the tracer) verifiable against
+observed behavior.
+
+### 7.8 What carries over from v1 / resolved questions
+
+- Carries over: the dumb-translation-layer philosophy (dispatch untouched),
+  the typed-cascade-traces-identically invariant test, the toolchain
+  (`typescript@^5.9` pin — bare `typescript` resolves to the native TS7
+  compiler with no JS API, breaking ts-jest; ts-jest self-contained jest
+  config — the shared babel preset's transform proved unreliable for .ts),
+  and the JSDoc typedef pass (independent of surface, already committed).
+- Resolved: classes are acceptable _with_ the `Part<T>` base (nominality +
+  construction are the price of transparency; factories remain for teams
+  that refuse classes); `chain(t, a, o)` is the one explicit dynamic
+  escape hatch; typed handlers inherit the 0.20 async-phase contract
+  unchanged (calls scheduled on the event loop, called-before-inline).
+- Open for the author: package name (`typed` vs `ts`); enforce term-keyed
+  datagrams at the type level or leave free (leaning free + helper);
+  protocol mode as the _recommended_ default in docs (leaning yes) or
+  quick-start-first; decorator legacy-flavor support priority.

--- a/package.json
+++ b/package.json
@@ -72,21 +72,21 @@
     "@tao.js/core": "file:packages/tao",
     "@tao.js/feature": "file:packages/tao-feature",
     "@tao.js/koa": "file:packages/koa-tao",
+    "@tao.js/opentelemetry": "file:packages/tao-opentelemetry",
     "@tao.js/path": "file:packages/tao-path",
     "@tao.js/react": "file:packages/react-tao",
     "@tao.js/router": "file:packages/tao-router",
-    "@tao.js/opentelemetry": "file:packages/tao-opentelemetry",
     "@tao.js/routing-core": "file:packages/tao-routing-core",
     "@tao.js/routing-next": "file:packages/tao-routing-next",
     "@tao.js/routing-react-router": "file:packages/tao-routing-react-router",
     "@tao.js/routing-tanstack-router": "file:packages/tao-routing-tanstack",
     "@tao.js/socket.io": "file:packages/tao-socket-io",
+    "@tao.js/telemetry": "file:packages/tao-telemetry",
+    "@tao.js/transport-tck": "file:packages/tao-transport-tck",
     "@tao.js/utils": "file:packages/tao-utils",
     "docs": "file:packages/docs",
     "patois.api": "file:examples/patois.api",
-    "patois.web": "file:examples/patois.web",
-    "@tao.js/telemetry": "file:packages/tao-telemetry",
-    "@tao.js/transport-tck": "file:packages/tao-transport-tck"
+    "patois.web": "file:examples/patois.web"
   },
   "devDependencies": {
     "@babel/cli": "7.1.5",
@@ -99,6 +99,7 @@
     "@babel/plugin-transform-object-rest-spread": "^7.28.0",
     "@babel/preset-env": "7.28.0",
     "@babel/preset-react": "7.27.1",
+    "@babel/preset-typescript": "^8.0.1",
     "@eslint/eslintrc": "^3.3.1",
     "@eslint/js": "^9.32.0",
     "@jest/globals": "^30.1.2",
@@ -145,7 +146,9 @@
     "rollup": "4.62.2",
     "rollup-plugin-node-builtins": "^2.1.2",
     "rollup-plugin-node-globals": "^1.4.0",
-    "rollup-plugin-peer-deps-external": "^2.2.4"
+    "rollup-plugin-peer-deps-external": "^2.2.4",
+    "ts-jest": "^29.4.12",
+    "typescript": "^5.9.3"
   },
   "packageManager": "pnpm@10.13.1+sha512.37ebf1a5c7a30d5fabe0c5df44ee8da4c965ca0c5af3dbab28c3a1681b70a256218d05c81c9c0dcf767ef6b8551eb5b960042b9ed4300c59242336377e01cfad"
 }

--- a/packages/tao-opentelemetry/README.md
+++ b/packages/tao-opentelemetry/README.md
@@ -19,7 +19,7 @@ const otelTracer = trace.getTracer('my-app'); // from your configured SDK
 const tracer = new Tracer(TAO, {
   sinks: [new OpenTelemetrySink(otelTracer)],
 });
-tracer.instrument(TAO);
+// that's it — the Tracer is a pure decoration; nothing to instrument
 ```
 
 Every AppCon becomes a span named `Term.Action.Orient` with attributes

--- a/packages/tao-opentelemetry/src/OpenTelemetrySink.js
+++ b/packages/tao-opentelemetry/src/OpenTelemetrySink.js
@@ -5,6 +5,8 @@ import {
   TraceFlags,
 } from '@opentelemetry/api';
 
+/** @typedef {import('@tao.js/telemetry').TraceRecord} TraceRecord */
+
 /**
  * A `@tao.js/telemetry` sink that exports each signal record as an OpenTelemetry
  * span, preserving causal parentage.
@@ -28,14 +30,20 @@ export default class OpenTelemetrySink {
    * Creates an instance of OpenTelemetrySink.
    * @param {import('@opentelemetry/api').Tracer} tracer - an OTel Tracer from your TracerProvider
    * @param {Object} [opts]
-   * @param {function} [opts.rootContext] - returns the OTel Context to parent
-   *        root signals under; defaults to `() => context.active()` so TAO
-   *        cascades nest beneath an ambient span (e.g. an incoming HTTP request)
+   * @param {function(): import('@opentelemetry/api').Context} [opts.rootContext] -
+   *        returns the OTel Context to parent root signals under; defaults to
+   *        `() => context.active()` so TAO cascades nest beneath an ambient
+   *        span (e.g. an incoming HTTP request). Also used when a record's
+   *        parent is unseen locally (see `_parentage`)
    * @param {boolean} [opts.endImmediately=true] - end each span at the signal
    *        timestamp (point-in-time semantics); pass false to end spans yourself
-   * @param {Object} [opts.attributes] - static attributes added to every span
+   * @param {Object<string, *>} [opts.attributes] - static attributes added to
+   *        every span; applied last, so a static key wins over an emitted
+   *        `tao.*` attribute on collision
    * @param {number} [opts.maxRetainedSignals=10000] - size of the
-   *        signalId → SpanContext map used for parentage (FIFO eviction)
+   *        signalId → SpanContext map used for parentage (FIFO eviction; a
+   *        child arriving after its parent's eviction degrades to a span link)
+   * @throws when `tracer` is absent or is not an OTel Tracer (no `startSpan`)
    * @memberof OpenTelemetrySink
    */
   constructor(
@@ -63,6 +71,33 @@ export default class OpenTelemetrySink {
     this._spanContexts = new Map();
   }
 
+  /**
+   * Sink interface: export one signal record as a span named
+   * `Term.Action.Orient`, started (and, unless `endImmediately: false`,
+   * ended) at the record's timestamp. Emitted attributes:
+   *
+   * - `tao.term` / `tao.action` / `tao.orient` — the signal's trigram
+   * - `tao.trace.id` — the tao-internal W3C-shaped trace id (32 hex) shared
+   *   by the whole causal tree, including its remote continuations
+   * - `tao.signal.id` — this signal's tao-internal id (16 hex); distinct
+   *   from the OTel span id the SDK assigns
+   * - `tao.signal.parent_id` — the causing signal's id; omitted on trace
+   *   roots
+   * - `tao.signal.via` — the handler phase that chained this signal
+   *   (`Intercept` | `Async` | `Inline`); omitted on entry hops, which no
+   *   phase produced
+   * - `tao.handlers.intercept` / `tao.handlers.async` / `tao.handlers.inline`
+   *   — counts of handlers matching the trigram at dispatch time on the main
+   *   network only (wildcard registrations included; Channels' private
+   *   registries are not); omitted when the record carries no counts
+   *
+   * Parentage and the span-link fallback are resolved by `_parentage`.
+   *
+   * @param {TraceRecord} record
+   * @returns {import('@opentelemetry/api').Span} the started span (already
+   *          ended unless `endImmediately: false`)
+   * @memberof OpenTelemetrySink
+   */
   signal(record) {
     const { ctx, links } = this._parentage(record);
     const attributes = {
@@ -100,6 +135,23 @@ export default class OpenTelemetrySink {
     return span;
   }
 
+  /**
+   * Resolve a record's OTel parentage, in fallback order:
+   *
+   * 1. no `parentId` — a root: parent under `rootContext()` (ambient
+   *    nesting beneath e.g. an instrumented HTTP request's span);
+   * 2. parent seen locally — a real child: the remembered parent
+   *    SpanContext set on ROOT_CONTEXT (explicit parent; ambient context
+   *    deliberately ignored);
+   * 3. parent unseen (remote hop, or evicted past `maxRetainedSignals`) —
+   *    parent under `rootContext()` and keep the causal reference as a span
+   *    *link* built from the W3C-shaped tao ids (`traceId`,
+   *    `spanId: parentId`, sampled) — honest linkage, never a guessed
+   *    parent.
+   *
+   * @param {TraceRecord} record
+   * @returns {{ ctx: import('@opentelemetry/api').Context, links: (Array<{context: Object}>|undefined) }}
+   */
   _parentage(record) {
     if (!record.parentId) {
       return { ctx: this._rootContext(), links: undefined };
@@ -127,6 +179,13 @@ export default class OpenTelemetrySink {
     };
   }
 
+  /**
+   * Retain a signal's SpanContext for future child parentage, evicting the
+   * oldest entry (FIFO) once the map reaches `maxRetainedSignals`.
+   *
+   * @param {string} signalId
+   * @param {import('@opentelemetry/api').SpanContext} spanContext
+   */
   _remember(signalId, spanContext) {
     if (this._spanContexts.size >= this._max) {
       this._spanContexts.delete(this._spanContexts.keys().next().value);

--- a/packages/tao-telemetry/README.md
+++ b/packages/tao-telemetry/README.md
@@ -45,6 +45,8 @@ Each signal produces one record:
   parentId,  // 16 hex | null — the signal whose handler chained this one
   t, a, o, key,
   timestamp,
+  via,       // 'Intercept' | 'Async' | 'Inline' — the phase that produced
+             // this hop; absent on entry hops (0.20)
   handlers: { intercept, async, inline },  // matching-handler counts
   data,      // only with the captureData option (true | (data, ac) => any)
 }

--- a/packages/tao-telemetry/src/ConsoleSink.js
+++ b/packages/tao-telemetry/src/ConsoleSink.js
@@ -1,3 +1,5 @@
+/** @typedef {import('./Tracer').TraceRecord} TraceRecord */
+
 /**
  * Streams signals to a console-like logger as they occur, indented by causal
  * depth — the live-logging successor to `TaoLogger`'s full-wildcard idiom.
@@ -6,6 +8,17 @@
  * @class ConsoleSink
  */
 export default class ConsoleSink {
+  /**
+   * Creates an instance of ConsoleSink.
+   * @param {Object} [opts]
+   * @param {{ info: function }} [opts.logger=console] - console-like target
+   * @param {boolean} [opts.showData=false] - also log each record's captured
+   *        data on a second line
+   * @param {number} [opts.limit=10000] - cap on the signalId → depth map used
+   *        for indentation (FIFO eviction; a child of an evicted parent logs
+   *        at root depth)
+   * @memberof ConsoleSink
+   */
   constructor({ logger = console, showData = false, limit = 10000 } = {}) {
     this._logger = logger;
     this._showData = showData;
@@ -13,6 +26,13 @@ export default class ConsoleSink {
     this._depths = new Map();
   }
 
+  /**
+   * Sink interface: log one signal as it occurs, indented beneath its cause
+   * (with its producing phase when present).
+   *
+   * @param {TraceRecord} record
+   * @memberof ConsoleSink
+   */
   signal(record) {
     const depth =
       record.parentId && this._depths.has(record.parentId)

--- a/packages/tao-telemetry/src/InMemorySink.js
+++ b/packages/tao-telemetry/src/InMemorySink.js
@@ -1,3 +1,22 @@
+/** @typedef {import('./Tracer').TraceRecord} TraceRecord */
+
+/**
+ * A node of the reassembled causal tree returned by
+ * {@link InMemorySink#toTree}.
+ *
+ * @typedef {Object} TraceTreeNode
+ * @property {TraceRecord} record
+ * @property {TraceTreeNode[]} children
+ */
+
+/**
+ * Render one record as a tree-node label: the trigram, its producing phase
+ * when present, and (optionally) its captured data.
+ *
+ * @param {TraceRecord} record
+ * @param {boolean} showData
+ * @returns {string}
+ */
 function nodeLabel(record, showData) {
   let label = `☯ {${record.t}, ${record.a}, ${record.o}}`;
   if (record.via) {
@@ -22,11 +41,26 @@ function nodeLabel(record, showData) {
  * @class InMemorySink
  */
 export default class InMemorySink {
+  /**
+   * Creates an instance of InMemorySink.
+   * @param {Object} [opts]
+   * @param {number} [opts.limit=10000] - ring-buffer capacity: at capacity
+   *        the oldest record is evicted, and its orphaned children surface
+   *        as roots
+   * @memberof InMemorySink
+   */
   constructor({ limit = 10000 } = {}) {
     this._limit = limit;
     this.clear();
   }
 
+  /**
+   * Sink interface: retain one dispatched signal and index it by id and by
+   * parent.
+   *
+   * @param {TraceRecord} record
+   * @memberof InMemorySink
+   */
   signal(record) {
     if (this._records.length >= this._limit) {
       this._evictOldest();
@@ -41,18 +75,47 @@ export default class InMemorySink {
     }
   }
 
+  /**
+   * All retained records in arrival order (a fresh copy).
+   *
+   * @type {TraceRecord[]}
+   * @readonly
+   * @memberof InMemorySink
+   */
   get records() {
     return [...this._records];
   }
 
+  /**
+   * Number of records currently retained.
+   *
+   * @type {number}
+   * @readonly
+   * @memberof InMemorySink
+   */
   get size() {
     return this._records.length;
   }
 
+  /**
+   * Look up a retained record by its signal id.
+   *
+   * @param {string} signalId
+   * @returns {TraceRecord|undefined} undefined when never seen or evicted
+   * @memberof InMemorySink
+   */
   byId(signalId) {
     return this._byId.get(signalId);
   }
 
+  /**
+   * Records chained by the given signal's handlers, in arrival order
+   * (a fresh copy).
+   *
+   * @param {string} signalId
+   * @returns {TraceRecord[]}
+   * @memberof InMemorySink
+   */
   childrenOf(signalId) {
     return [...(this._children.get(signalId) || [])];
   }
@@ -60,6 +123,9 @@ export default class InMemorySink {
   /**
    * Local roots: records with no parent, or whose parent was never seen
    * locally (remote continuation) or has been evicted.
+   *
+   * @returns {TraceRecord[]}
+   * @memberof InMemorySink
    */
   roots() {
     return this._records.filter(
@@ -67,6 +133,12 @@ export default class InMemorySink {
     );
   }
 
+  /**
+   * Reassemble the retained records into causal trees, one per local root.
+   *
+   * @returns {TraceTreeNode[]}
+   * @memberof InMemorySink
+   */
   toTree() {
     const toNode = (record) => ({
       record,
@@ -75,6 +147,15 @@ export default class InMemorySink {
     return this.roots().map(toNode);
   }
 
+  /**
+   * Render the causal trees as an ASCII tree, one line per signal.
+   *
+   * @param {Object} [opts]
+   * @param {boolean} [opts.showData=false] - append each record's captured
+   *        data to its label
+   * @returns {string}
+   * @memberof InMemorySink
+   */
   format({ showData = false } = {}) {
     const lines = [];
     const walk = (node, prefix, childPrefix) => {
@@ -94,12 +175,21 @@ export default class InMemorySink {
     return lines.join('\n');
   }
 
+  /**
+   * Drop every retained record and index.
+   *
+   * @memberof InMemorySink
+   */
   clear() {
     this._records = [];
     this._byId = new Map();
     this._children = new Map();
   }
 
+  /**
+   * Evict the oldest record (ring-buffer overflow), unindexing it from its
+   * parent's children and releasing its own child index.
+   */
   _evictOldest() {
     const evicted = this._records.shift();
     this._byId.delete(evicted.signalId);

--- a/packages/tao-telemetry/src/TaoLogger.js
+++ b/packages/tao-telemetry/src/TaoLogger.js
@@ -1,3 +1,44 @@
+/**
+ * Runtime control surface returned by {@link TaoLogger}. Every option is
+ * live-switchable after construction.
+ *
+ * @typedef {Object} TaoLoggerControls
+ * @property {function(Object, Object): void} handler - the signal handler to
+ *           attach (full-wildcard intercept idiom); receives `(tao, data)`
+ *           and always returns undefined — pure observation, never halts
+ * @property {function(boolean): void} doLogging - toggle logging entirely
+ * @property {function(boolean): void} verbose - toggle datagram logging
+ * @property {function(?number): void} depth - set the inspection depth
+ * @property {function(boolean): void} group - toggle grouped output
+ * @property {function(Object): void} setLogger - swap the console-like target
+ * @property {function(?function(*, number): *): void} setInspect - swap the
+ *           object formatter
+ */
+
+/**
+ * The classic live signal logger (moved here from `@tao.js/utils`): logs
+ * each signal's trigram — and, when verbose or grouped, the t/a/o portions
+ * of its datagram — as it dispatches. Attach the returned `handler` as a
+ * full-wildcard intercept: `TAO.addInterceptHandler({}, logger.handler)`.
+ *
+ * Shows the sequence of signals; the `Tracer` shows their causality.
+ *
+ * @export
+ * @param {boolean} [doLogging=true] - master switch; the handler is a no-op
+ *        when false
+ * @param {Object} [opts]
+ * @param {boolean} [opts.verbose=false] - also log the datagram portions
+ *        (grouped output always does)
+ * @param {?number} [opts.depth=0] - depth handed to `inspect`; when unset the
+ *        datagram portions are logged raw
+ * @param {boolean} [opts.group=false] - wrap each signal in
+ *        `logger.groupCollapsed` / `logger.groupEnd`
+ * @param {{ info: function, groupCollapsed?: function, groupEnd?: function }} [opts.logger=console] -
+ *        console-like target
+ * @param {?function(*, number): *} [opts.inspect] - object formatter (e.g.
+ *        `util.inspect`) applied to each datagram portion at `depth`
+ * @returns {TaoLoggerControls}
+ */
 export function TaoLogger(
   doLogging = true,
   {

--- a/packages/tao-telemetry/src/Tracer.js
+++ b/packages/tao-telemetry/src/Tracer.js
@@ -2,11 +2,49 @@ import { AppCtx } from '@tao.js/core';
 import { newTraceId, newSignalId, parseTraceparent } from './ids';
 
 /**
+ * One traced signal, as delivered to every sink's `signal(record)`.
+ *
+ * A record describes a network dispatch, not a handler execution — a
+ * channel's mirrored dispatch of the same AppCon on its private registry is
+ * not a second record.
+ *
+ * @typedef {Object} TraceRecord
+ * @property {string} traceId - 32 lowercase hex chars (W3C trace id), shared
+ *           by every signal in the causal tree
+ * @property {string} signalId - 16 lowercase hex chars (W3C span id) naming
+ *           this signal
+ * @property {string|null} parentId - `signalId` of the signal whose handler
+ *           chained this one; null for a trace root
+ * @property {string} t - term of the signal's trigram
+ * @property {string} a - action of the signal's trigram
+ * @property {string} o - orient of the signal's trigram
+ * @property {string} key - the trigram's AppCtx key (`t|a|o`)
+ * @property {number} timestamp - ms-epoch time from the tracer's clock
+ * @property {'Intercept'|'Async'|'Inline'} [via] - handler phase that chained
+ *           this signal (ENVELOPE-SPEC.md §4); entry hops carry no `via`
+ * @property {{ intercept: number, async: number, inline: number }} [handlers] -
+ *           counts of handlers matching this trigram (wildcard registrations
+ *           included) on the decorated network at dispatch time; handlers
+ *           attached to Channels' private registries are not counted
+ * @property {*} [data] - the AppCon data, only with the `captureData` option
+ */
+
+/**
  * Namespaced chain key under which trace context is derived per hop by the
- * envelope engine (see ENVELOPE-SPEC.md).
+ * envelope engine (see ENVELOPE-SPEC.md). Chain keys are exclusive — a
+ * Network accepts one reducer per key — so constructing a second Tracer on
+ * the same network throws. This is also the key transports carry across
+ * process boundaries (§9): an inbound W3C `traceparent` maps to
+ * `chain: { [TRACE_CHAIN]: { traceId, signalId } }` on entry.
  */
 export const TRACE_CHAIN = 'taoTrace';
 
+/**
+ * Count a handler iterator without materializing it.
+ *
+ * @param {Iterable<function>} iterator
+ * @returns {number}
+ */
 function countHandlers(iterator) {
   let count = 0;
   for (const handler of iterator) {
@@ -30,13 +68,21 @@ function countHandlers(iterator) {
 export default class Tracer {
   /**
    * Creates an instance of Tracer.
-   * @param {Kernel|Network} kernel - Kernel (or raw Network) whose signals to trace
+   * @param {Object} kernel - Kernel (or Channel, or raw Network) whose signals
+   *        to trace; anything exposing the shared network via `_network`, or a
+   *        Network itself, is decorated
    * @param {Object} [opts]
-   * @param {Array<{signal: function}>} [opts.sinks] - sinks receiving one record per signal
-   * @param {function} [opts.clock] - returns a ms-epoch timestamp (defaults to Date.now)
-   * @param {boolean|function} [opts.captureData] - false (default) omits AppCon data;
-   *        true attaches `ac.data` by reference; a function receives `(data, ac)` and
-   *        its return value is attached (use to redact / clone)
+   * @param {Array<{signal: function(TraceRecord): void}>} [opts.sinks] - sinks
+   *        receiving one record per signal
+   * @param {function(): number} [opts.clock] - returns a ms-epoch timestamp
+   *        (defaults to Date.now)
+   * @param {boolean|function(*, AppCtx): *} [opts.captureData] - false (default)
+   *        omits AppCon data; true attaches `ac.data` by reference; a function
+   *        receives `(data, ac)` and its return value is attached (use to
+   *        redact / clone)
+   * @throws when `kernel` is absent, when the core predates envelope support,
+   *         or when the network's {@link TRACE_CHAIN} chain key is already
+   *         reduced by another decoration (one Tracer per network)
    * @memberof Tracer
    */
   // Stryker disable next-line ArrayDeclaration: junk entries in the sinks default are call-guarded by the per-sink try
@@ -77,6 +123,13 @@ export default class Tracer {
     });
   }
 
+  /**
+   * Attach a sink to receive one {@link TraceRecord} per signal.
+   *
+   * @param {{ signal: function(TraceRecord): void }} sink
+   * @returns {this}
+   * @memberof Tracer
+   */
   addSink(sink) {
     if (!sink || typeof sink.signal !== 'function') {
       throw new Error('a sink must implement signal(record)');
@@ -85,6 +138,13 @@ export default class Tracer {
     return this;
   }
 
+  /**
+   * Detach a previously attached sink (a no-op when not attached).
+   *
+   * @param {{ signal: function(TraceRecord): void }} sink
+   * @returns {this}
+   * @memberof Tracer
+   */
   removeSink(sink) {
     this._sinks.delete(sink);
     return this;
@@ -97,10 +157,15 @@ export default class Tracer {
    * Plain `kernel.setCtx` entries are traced identically — this entry point
    * only adds the continuation capability.
    *
-   * @param {Object} trigram - `{ t, a, o }` or `{ term, action, orient }`
-   * @param {Object} [data]
-   * @param {Object} [traceContext] - `{ traceparent }` (W3C header value) or
-   *        `{ traceId, parentId }` to continue a trace started elsewhere
+   * @param {{ t?: string, a?: string, o?: string, term?: string, action?: string, orient?: string }} trigram -
+   *        `{ t, a, o }` or `{ term, action, orient }` (long forms win when
+   *        both are present)
+   * @param {*} [data]
+   * @param {{ traceparent?: string, traceId?: string, parentId?: string|null }} [traceContext] -
+   *        `{ traceparent }` (W3C header value) or `{ traceId, parentId }` to
+   *        continue a trace started elsewhere: the entry keeps the remote
+   *        `traceId` and is parented to `parentId`. An absent or malformed
+   *        context starts a new root trace instead
    * @memberof Tracer
    */
   setCtx({ t, term, a, action, o, orient }, data, traceContext) {
@@ -113,8 +178,15 @@ export default class Tracer {
   /**
    * Set an AppCtx on the network, optionally continuing a remote trace.
    *
-   * @param {AppCtx} ac
-   * @param {Object} [traceContext]
+   * A continuation seeds the entry's chain with
+   * `{ [TRACE_CHAIN]: { traceId, signalId: parentId } }`, which the chain
+   * reducer treats exactly like a parent hop's stamp — the remote signal
+   * becomes the entry's parent.
+   *
+   * @param {AppCtx} ac - dropped silently when wildcard and the attached
+   *        kernel disallows wildcard entry (parity with `Kernel.setAppCtx`)
+   * @param {{ traceparent?: string, traceId?: string, parentId?: string|null }} [traceContext] -
+   *        see {@link Tracer#setCtx}
    * @memberof Tracer
    */
   setAppCtx(ac, traceContext) {
@@ -137,6 +209,14 @@ export default class Tracer {
     );
   }
 
+  /**
+   * Normalize a continuation context to `{ traceId, parentId }`, preferring
+   * a W3C `traceparent` header when given. Returns null (start a new root)
+   * when absent or malformed.
+   *
+   * @param {{ traceparent?: string, traceId?: string, parentId?: string|null }} [traceContext]
+   * @returns {{ traceId: string, parentId: string|null }|null}
+   */
   _remoteContext(traceContext) {
     if (!traceContext) {
       return null;
@@ -153,6 +233,17 @@ export default class Tracer {
     return null;
   }
 
+  /**
+   * The `onDispatch` observer: assemble one {@link TraceRecord} from the
+   * hop's {@link TRACE_CHAIN} chain stamp and fan it out to every sink.
+   * Handler counts are taken from the matched registry entry at dispatch
+   * time (the decorated main network only); a throwing sink is isolated so
+   * it never breaks signal dispatch.
+   *
+   * @param {AppCtx} ac
+   * @param {{ cascade: Object, hop: Object, chain: Object }} envelope
+   * @param {Object} handler - the matched AppCtxHandlers registry entry
+   */
   _record(ac, envelope, handler) {
     const stamp = envelope.chain[TRACE_CHAIN];
     const record = {

--- a/packages/tao-telemetry/src/ids.js
+++ b/packages/tao-telemetry/src/ids.js
@@ -4,6 +4,14 @@ const TRACE_ID_RX = /^[0-9a-f]{32}$/;
 const SPAN_ID_RX = /^[0-9a-f]{16}$/;
 const VERSION_RX = /^[0-9a-f]{2}$/;
 
+/**
+ * Produce `chars` random lowercase hex characters, cryptographically strong
+ * when the platform provides `crypto.getRandomValues` (Math.random fallback
+ * for exotic embedders).
+ *
+ * @param {number} chars - even count of hex characters to produce
+ * @returns {string}
+ */
 function randomHex(chars) {
   // Stryker disable next-line ConditionalExpression,StringLiteral: equivalent - globalThis always exists in every runnable JS environment we can test; the guard is for exotic embedders
   const cryptoObj = typeof globalThis !== 'undefined' && globalThis.crypto;
@@ -24,7 +32,10 @@ function randomHex(chars) {
 }
 
 /**
- * Generate a new W3C-compatible trace id (32 lowercase hex chars, non-zero).
+ * Generate a new W3C-compatible trace id (32 lowercase hex chars; the
+ * all-zero id is invalid per Trace Context and is never produced).
+ *
+ * @returns {string}
  */
 export function newTraceId() {
   let id;
@@ -35,7 +46,10 @@ export function newTraceId() {
 }
 
 /**
- * Generate a new W3C-compatible span/signal id (16 lowercase hex chars, non-zero).
+ * Generate a new W3C-compatible span/signal id (16 lowercase hex chars; the
+ * all-zero id is invalid per Trace Context and is never produced).
+ *
+ * @returns {string}
  */
 export function newSignalId() {
   let id;
@@ -46,9 +60,11 @@ export function newSignalId() {
 }
 
 /**
- * Format a signal stamp or record as a W3C `traceparent` header value.
+ * Format a signal stamp or record as a W3C `traceparent` header value:
+ * `00-<traceId>-<signalId>-01` (version `00`, flags `01` = sampled).
  *
- * @param {{ traceId: string, signalId: string }} stamp
+ * @param {{ traceId: string, signalId: string }} stamp - a chain stamp or a
+ *        `TraceRecord` (structurally compatible)
  * @returns {string} e.g. `00-<32 hex>-<16 hex>-01`
  */
 export function toTraceparent({ traceId, signalId }) {
@@ -57,6 +73,12 @@ export function toTraceparent({ traceId, signalId }) {
 
 /**
  * Parse a W3C `traceparent` header value into trace continuation context.
+ *
+ * Tolerant per the Trace Context spec: case and surrounding whitespace are
+ * normalized, and future versions with extra dash-separated fields are
+ * accepted (at least 4 parts; extras ignored). Rejected as malformed: a
+ * non-hex or forbidden (`ff`) version, and non-hex, wrong-length, or
+ * all-zero trace/parent ids.
  *
  * @param {string} header
  * @returns {{ traceId: string, parentId: string } | null} null when malformed

--- a/packages/tao-telemetry/src/index.js
+++ b/packages/tao-telemetry/src/index.js
@@ -9,6 +9,9 @@ import {
   parseTraceparent,
 } from './ids';
 
+/** @typedef {import('./Tracer').TraceRecord} TraceRecord */
+/** @typedef {import('./InMemorySink').TraceTreeNode} TraceTreeNode */
+
 export default Tracer;
 export {
   Tracer,

--- a/packages/tao-transport-tck/src/compliance.js
+++ b/packages/tao-transport-tck/src/compliance.js
@@ -1,6 +1,29 @@
 import { AppCtx } from '@tao.js/core';
 import { Tracer, InMemorySink } from '@tao.js/telemetry';
 
+/**
+ * A connected pair of Kernels bridged by the transport under test —
+ * what the `makeLink` factory must produce (a fresh one per check).
+ *
+ * @typedef {Object} Link
+ * @property {Object} a - Kernel on the near side; each check enters signals here
+ * @property {Object} b - Kernel on the far side; entries on `a` must reach it
+ * @property {function(): (void|Promise<void>)} [close] - tear the link down;
+ *           awaited after the check when provided
+ */
+
+/**
+ * Outcome of a single conformance check.
+ *
+ * @typedef {Object} ComplianceResult
+ * @property {string} name - the check's name, stable across releases
+ *           ('delivery', 'echo suppression + bidirectional reflex',
+ *           'multi-hop emission', 'chain continuity', 'cascade scoping')
+ * @property {boolean} pass
+ * @property {string|null} detail - failure explanation (including a thrown
+ *           check's message); null on pass
+ */
+
 const DEFAULT_TIMEOUT = 2000;
 const SETTLE_MS = 25;
 
@@ -8,6 +31,13 @@ function wait(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/**
+ * Poll the predicate every 10ms until truthy or the timeout elapses.
+ *
+ * @param {function(): boolean} predicate
+ * @param {number} timeoutMs
+ * @returns {Promise<boolean>} the predicate's final verdict
+ */
 async function waitUntil(predicate, timeoutMs) {
   const deadline = Date.now() + timeoutMs;
   // Stryker disable next-line EqualityOperator: off-by-one on the deadline only shifts the final poll by one interval
@@ -20,6 +50,14 @@ async function waitUntil(predicate, timeoutMs) {
   return predicate();
 }
 
+/**
+ * Like {@link waitUntil}, followed by a settle window so exactly-once
+ * assertions can catch late duplicate deliveries.
+ *
+ * @param {function(): boolean} predicate
+ * @param {number} timeoutMs
+ * @returns {Promise<boolean>}
+ */
 async function settled(predicate, timeoutMs) {
   // reach the condition, then give late (incorrect) deliveries time to land
   const reached = await waitUntil(predicate, timeoutMs);
@@ -27,10 +65,23 @@ async function settled(predicate, timeoutMs) {
   return reached;
 }
 
+/**
+ * Build a probe trigram in the kit's reserved `{ *, run, tck }` namespace.
+ *
+ * @param {string} t
+ * @returns {{ t: string, a: string, o: string }}
+ */
 function trigram(t) {
   return { t, a: 'run', o: 'tck' };
 }
 
+/**
+ * Resolve a link side to its envelope surface (`enter`/`decorate`): the
+ * Kernel's shared network, or the object itself when it already is one.
+ *
+ * @param {Object} kernel
+ * @returns {Object} the underlying Network
+ */
 function surfaceOf(kernel) {
   // Stryker disable next-line all: defensive resolution - the makeLink contract supplies Kernels (no enter), so only the _network branch is reachable
   return typeof kernel.enter === 'function' ? kernel : kernel._network;
@@ -38,7 +89,13 @@ function surfaceOf(kernel) {
 
 /**
  * Delivery: a signal entered on A reaches handlers on B with its trigram and
- * datagram intact.
+ * datagram intact, exactly once. The executable form of the §9 wire envelope
+ * itself — `{ tao: { t, a, o }, data, envelope }` crossing the boundary with
+ * trigram and datagram verbatim, delivered once per hop.
+ *
+ * @param {Link} link
+ * @param {number} timeoutMs
+ * @returns {Promise<string|null>} failure detail, or null on pass
  */
 async function checkDelivery({ a, b }, timeoutMs) {
   const seen = [];
@@ -70,6 +127,14 @@ async function checkDelivery({ a, b }, timeoutMs) {
 /**
  * Echo suppression + bidirectional reflex: the arriving signal is not sent
  * back to its origin, but descendants chained on the receiving side are.
+ * Verifies §10 invariant 4 — descendants of a received signal must be
+ * re-emitted to the sender, because the receiver's `hop.source` marker is
+ * hop-scoped (suppressing only the stamped arrival hop), never
+ * cascade-scoped.
+ *
+ * @param {Link} link
+ * @param {number} timeoutMs
+ * @returns {Promise<string|null>} failure detail, or null on pass
  */
 async function checkReflex({ a, b }, timeoutMs) {
   let aPingDispatches = 0;
@@ -103,7 +168,14 @@ async function checkReflex({ a, b }, timeoutMs) {
 
 /**
  * Multi-hop emission: every hop of a chain produced on the receiving side
- * crosses back, not just the first.
+ * crosses back, not just the first. Verifies §10 invariant 1 — every chained
+ * AppCon is observable on every hop, so the transport's emit path sees (and
+ * forwards) chained signals; losing later hops breaks forwarding of
+ * multi-hop chains.
+ *
+ * @param {Link} link
+ * @param {number} timeoutMs
+ * @returns {Promise<string|null>} failure detail, or null on pass
  */
 async function checkMultiHop({ a, b }, timeoutMs) {
   const arrivals = [];
@@ -140,6 +212,14 @@ async function checkMultiHop({ a, b }, timeoutMs) {
 /**
  * Chain continuity: with a Tracer on both ends, one cascade crossing
  * A→B→A carries one traceId end-to-end with exact cross-process parentage.
+ * Verifies the §9 chain rules — `envelope.chain` crosses the boundary
+ * verbatim and the receiver re-enters with it, so a reducer continues the
+ * `taoTrace` key it owns instead of re-rooting: B's entry parents to A's
+ * emitting hop, and A's continuation parents to B's reply hop.
+ *
+ * @param {Link} link
+ * @param {number} timeoutMs
+ * @returns {Promise<string|null>} failure detail, or null on pass
  */
 async function checkChainContinuity({ a, b }, timeoutMs) {
   const sinkA = new InMemorySink();
@@ -199,7 +279,14 @@ async function checkChainContinuity({ a, b }, timeoutMs) {
 
 /**
  * Cascade scoping: sender-side cascade tags (process-local affinity, live
- * references) must not appear in the receiver's cascade.
+ * references) must not appear in the receiver's cascade. Verifies the §9
+ * rule that `cascade` never crosses a process boundary — the transport must
+ * *translate* affinity, not copy it — which is what keeps the §10 scoping
+ * invariants (2, 3, 7) intact across processes.
+ *
+ * @param {Link} link
+ * @param {number} timeoutMs
+ * @returns {Promise<string|null>} failure detail, or null on pass
  */
 async function checkCascadeScoping({ a, b }, timeoutMs) {
   const cascades = [];
@@ -254,16 +341,18 @@ const CHECKS = [
 ];
 
 /**
- * Run the transport conformance kit (ENVELOPE-SPEC.md §9) against a
- * transport. Framework-agnostic: returns structured results for any test
- * runner.
+ * Run the transport conformance kit (ENVELOPE-SPEC.md §9 plus the
+ * transport-relevant §10 invariants) against a transport. Framework-agnostic:
+ * returns structured results for any test runner instead of throwing.
  *
- * @param {function} makeLink - async factory producing a connected pair
- *        `{ a, b, close }` of Kernels bridged by the transport under test
- *        (loopback in-process is fine). A fresh link is created per check.
+ * @param {function(): (Link|Promise<Link>)} makeLink - factory producing a
+ *        connected pair `{ a, b, close }` of Kernels bridged by the
+ *        transport under test (loopback in-process is fine). A fresh link is
+ *        created per check and closed after it.
  * @param {Object} [opts]
  * @param {number} [opts.timeoutMs=2000] - per-check delivery timeout
- * @returns {Promise<{ pass: boolean, results: Array<{name, pass, detail}> }>}
+ * @returns {Promise<{ pass: boolean, results: ComplianceResult[] }>} one
+ *          result per check, in the order run; `pass` is the conjunction
  */
 export async function runTransportCompliance(
   makeLink,
@@ -295,6 +384,12 @@ export async function runTransportCompliance(
 /**
  * Convenience for test suites: runs the kit and throws a formatted error
  * naming every failed check.
+ *
+ * @param {function(): (Link|Promise<Link>)} makeLink - see {@link runTransportCompliance}
+ * @param {Object} [opts]
+ * @param {number} [opts.timeoutMs=2000] - per-check delivery timeout
+ * @returns {Promise<ComplianceResult[]>} every check's result (all passing)
+ * @throws {Error} listing each failed check with its detail
  */
 export async function assertTransportCompliance(makeLink, opts) {
   const { pass, results } = await runTransportCompliance(makeLink, opts);

--- a/packages/tao-transport-tck/src/index.js
+++ b/packages/tao-transport-tck/src/index.js
@@ -1,3 +1,6 @@
+/** @typedef {import('./compliance').Link} Link */
+/** @typedef {import('./compliance').ComplianceResult} ComplianceResult */
+
 export {
   runTransportCompliance,
   assertTransportCompliance,

--- a/packages/tao-typed/.gitignore
+++ b/packages/tao-typed/.gitignore
@@ -1,0 +1,2 @@
+lib
+dist

--- a/packages/tao-typed/README.md
+++ b/packages/tao-typed/README.md
@@ -1,0 +1,79 @@
+# @tao.js/typed
+
+TypeScript-first wrapper for tao.js: **typed trigram vocabularies**. Each
+protocol message is a typed signal fusing the trigram and its datagram into
+one value; the implementation underneath translates typed messages to the
+untyped Kernel and never reimplements dispatch. Design: `TYPED-SPEC.md` at
+the repo root.
+
+String-keyed dispatch has one failure mode that hurts most: a typo'd
+trigram is a silent no-op. With a vocabulary, referencing an undeclared
+signal or mis-shaping a datagram is a **compile error**.
+
+## Usage
+
+```ts
+import { Kernel } from '@tao.js/core';
+import { signal, defineVocabulary, typedKernel } from '@tao.js/typed';
+
+// The app's protocol as a value — TAO.md as code
+const App = defineVocabulary({
+  UserFind: signal('User', 'Find', 'Portal').data<{ User: { id: string } }>(),
+  UserView: signal('User', 'View', 'Portal').data<{ User: UserRecord }>(),
+  UserFail: signal('User', 'Fail', 'Portal').data<{
+    User: { reason: string };
+  }>(),
+});
+
+const tao = typedKernel(new Kernel(), App);
+
+tao.onInline(App.UserFind, (s) => {
+  // s.data is { User: { id: string } } — no casts
+  return App.UserView({ User: load(s.data.User.id) }); // typed chaining
+});
+
+tao.onIntercept(App.UserFind, (s) => {
+  if (!authorized(s)) return App.UserFail({ User: { reason: 'denied' } });
+});
+
+tao.set(App.UserFind({ User: { id: '42' } }));
+```
+
+Typed wildcards are projections of the vocabulary — discriminated unions,
+not stringly escape hatches:
+
+```ts
+tao.onInline(App.match({ t: 'User' }), (s) => {
+  switch (s.a) {
+    case 'Find':
+      s.data.User.id;
+      break; // narrowed per action
+    case 'View':
+      s.data.User;
+      break;
+  }
+});
+tao.onInline(App.any(), (s) => log(s.t, s.a, s.o));
+```
+
+## Semantics
+
+- The kernel underneath is unchanged: phases, chaining, envelopes,
+  transports, and traces behave identically to untyped signals — a typed
+  cascade produces byte-identical trace trees to its untyped equivalent
+  (pinned by test).
+- Multiple vocabularies (and untyped code) may share one kernel; matcher
+  registrations only invoke typed handlers for trigrams their vocabulary
+  declares.
+- Intercept verdicts pass through: return `true` to halt, a signal to
+  divert, nothing to observe.
+- Every registration returns a dispose function.
+- `App.toProtocol()` returns the declared trigram list — the input for
+  `TAO.md` generation and the protocol extractor (`AGENTIC.md`).
+
+## Notes
+
+- Peer: `@tao.js/core >= 0.20`. Ships CJS (`lib`, with `.d.ts`) and ESM
+  (`dist`).
+- Compile-time behavior is itself tested: `npm run typecheck` includes
+  `test-d/` where `@ts-expect-error` assertions pin what must not compile.

--- a/packages/tao-typed/jest.config.js
+++ b/packages/tao-typed/jest.config.js
@@ -1,0 +1,15 @@
+// Self-contained (no jest.preset.cjs): this package is TypeScript and
+// node-only; the shared preset's jsdom/react/babel setup does not apply.
+module.exports = {
+  testEnvironment: 'node',
+  testMatch: ['**/test/**/*.spec.ts'],
+  moduleFileExtensions: ['ts', 'js', 'json'],
+  collectCoverageFrom: ['src/**/*.ts', '!src/index.ts'],
+  coverageReporters: ['text', 'html'],
+  transform: {
+    '^.+\\.ts$': [
+      require.resolve('ts-jest'),
+      { tsconfig: '<rootDir>/tsconfig.json', diagnostics: false },
+    ],
+  },
+};

--- a/packages/tao-typed/package.json
+++ b/packages/tao-typed/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@tao.js/typed",
+  "version": "0.19.1",
+  "description": "TypeScript-first wrapper for tao.js - typed trigram vocabularies: each protocol message is a typed signal fusing trigram + datagram; translation to the untyped Kernel underneath",
+  "homepage": "https://tao.js.org/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/zzyzxlab/tao.js.git",
+    "directory": "packages/tao-typed"
+  },
+  "main": "lib/index.js",
+  "module": "dist/index.js",
+  "types": "lib/index.d.ts",
+  "sideEffects": false,
+  "files": [
+    "lib",
+    "dist"
+  ],
+  "scripts": {
+    "build:clean": "rimraf dist lib",
+    "build:package": "tsc -p tsconfig.cjs.json && tsc -p tsconfig.esm.json",
+    "build": "npm run build:clean && npm run build:package",
+    "typecheck": "tsc -p tsconfig.typecheck.json"
+  },
+  "author": "eudaimos",
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
+  "peerDependencies": {
+    "@tao.js/core": ">=0.20.0"
+  },
+  "devDependencies": {
+    "@tao.js/core": "file:../tao",
+    "@tao.js/telemetry": "file:../tao-telemetry"
+  }
+}

--- a/packages/tao-typed/src/core.d.ts
+++ b/packages/tao-typed/src/core.d.ts
@@ -1,0 +1,17 @@
+/**
+ * Minimal ambient types for @tao.js/core, scoped to what this package
+ * consumes. Temporary: replaced by declaration emission from the JSDoc'd
+ * JS sources once that lands (see TYPED-SPEC.md §5).
+ */
+declare module '@tao.js/core' {
+  export class AppCtx {
+    constructor(t: string, a: string, o: string, ...datum: unknown[]);
+    readonly t: string;
+    readonly a: string;
+    readonly o: string;
+    readonly key: string;
+    readonly data: Record<string, unknown>;
+    readonly isWildcard: boolean;
+    unwrapCtx(verbose?: boolean): { t: string; a: string; o: string };
+  }
+}

--- a/packages/tao-typed/src/index.ts
+++ b/packages/tao-typed/src/index.ts
@@ -1,0 +1,30 @@
+/**
+ * @tao.js/typed — typed trigram vocabularies for tao.js (TYPED-SPEC.md).
+ *
+ * Declare the app's protocol as typed signal constructors
+ * (`defineVocabulary` + `signal`), then wrap any Kernel in a typed facade
+ * (`typedKernel`). Mistyped trigrams and mis-shaped datagrams become
+ * compile errors; the JS engine underneath is unchanged.
+ */
+export { signal, keyOf, isTypedSignal } from './signal';
+export type { TypedSignal, SignalSpec, SignalBuilder } from './signal';
+export { defineVocabulary, isMatcher } from './vocabulary';
+export type {
+  Vocabulary,
+  VocabularyMeta,
+  VocabularySignals,
+  SignalCtor,
+  SignalOf,
+  Matcher,
+  MatchFilter,
+  MatchedSignals,
+  SpecMap,
+} from './vocabulary';
+export { typedKernel } from './kernel';
+export type {
+  TypedKernel,
+  TypedHandler,
+  TypedHandlerResult,
+  UntypedKernel,
+  Dispose,
+} from './kernel';

--- a/packages/tao-typed/src/kernel.ts
+++ b/packages/tao-typed/src/kernel.ts
@@ -1,0 +1,216 @@
+/**
+ * The translation layer (TYPED-SPEC.md §4): a typed facade over an
+ * existing Kernel. Deliberately dumb — adapts typed signals to
+ * `setCtx`/`add*Handler` and never reimplements dispatch, so phases,
+ * chaining, envelopes, transports, and tracing behave identically to
+ * untyped signals on the same kernel.
+ */
+import { AppCtx } from '@tao.js/core';
+import { SignalSpec, TypedSignal, isTypedSignal } from './signal';
+import {
+  Matcher,
+  MatchFilter,
+  SignalCtor,
+  SpecMap,
+  Vocabulary,
+  VocabularySignals,
+  isMatcher,
+} from './vocabulary';
+
+/** The untyped kernel surface the facade adapts to (structural). */
+export interface UntypedKernel {
+  setCtx(
+    trigram: { t: string; a: string; o: string },
+    data?: unknown,
+  ): void;
+  addInterceptHandler(trigram: object, handler: UntypedHandler): unknown;
+  addAsyncHandler(trigram: object, handler: UntypedHandler): unknown;
+  addInlineHandler(trigram: object, handler: UntypedHandler): unknown;
+  removeInterceptHandler(trigram: object, handler: UntypedHandler): unknown;
+  removeAsyncHandler(trigram: object, handler: UntypedHandler): unknown;
+  removeInlineHandler(trigram: object, handler: UntypedHandler): unknown;
+}
+
+type UntypedHandler = (
+  tao: { t: string; a: string; o: string },
+  data: unknown,
+) => unknown;
+
+/**
+ * What a typed handler may return: nothing, a chained signal (any typed
+ * signal — cross-vocabulary chaining is legal, it is all one network), or
+ * for intercept handlers a truthy verdict to halt.
+ */
+export type TypedHandlerResult =
+  | void
+  | undefined
+  | null
+  | boolean
+  | TypedSignal
+  | Promise<void | undefined | null | boolean | TypedSignal>;
+
+/** A typed handler: receives the fused signal, not `(tao, data)`. */
+export type TypedHandler<S extends TypedSignal> = (
+  signal: S,
+) => TypedHandlerResult;
+
+/** Either a single declared signal or a matcher projection. */
+type Subscribable<V extends SpecMap> =
+  | SignalCtor<SignalSpec>
+  | Matcher<VocabularySignals<V>>;
+
+/** Dispose function returned by every registration. */
+export type Dispose = () => void;
+
+/** The typed kernel facade. */
+export interface TypedKernel<V extends SpecMap> {
+  /** Signal a typed message (translates to `kernel.setCtx`). */
+  set(signal: VocabularySignals<V>): void;
+  /** Register an intercept handler for one signal or a projection. */
+  onIntercept<T extends string, A extends string, O extends string, D>(
+    target: SignalSpec<T, A, O, D>,
+    handler: TypedHandler<TypedSignal<T, A, O, D>>,
+  ): Dispose;
+  onIntercept<M extends TypedSignal>(
+    target: Matcher<M>,
+    handler: TypedHandler<M>,
+  ): Dispose;
+  /** Register an async handler for one signal or a projection. */
+  onAsync<T extends string, A extends string, O extends string, D>(
+    target: SignalSpec<T, A, O, D>,
+    handler: TypedHandler<TypedSignal<T, A, O, D>>,
+  ): Dispose;
+  onAsync<M extends TypedSignal>(
+    target: Matcher<M>,
+    handler: TypedHandler<M>,
+  ): Dispose;
+  /** Register an inline handler for one signal or a projection. */
+  onInline<T extends string, A extends string, O extends string, D>(
+    target: SignalSpec<T, A, O, D>,
+    handler: TypedHandler<TypedSignal<T, A, O, D>>,
+  ): Dispose;
+  onInline<M extends TypedSignal>(
+    target: Matcher<M>,
+    handler: TypedHandler<M>,
+  ): Dispose;
+  /** The wrapped kernel — escape hatch to the untyped world. */
+  readonly kernel: UntypedKernel;
+  /** The vocabulary this facade types against. */
+  readonly vocabulary: Vocabulary<V>;
+}
+
+type Phase = 'Intercept' | 'Async' | 'Inline';
+
+function toTrigram(target: { t?: string; a?: string; o?: string }): {
+  t?: string;
+  a?: string;
+  o?: string;
+} {
+  const trigram: { t?: string; a?: string; o?: string } = {};
+  if (target.t) trigram.t = target.t;
+  if (target.a) trigram.a = target.a;
+  if (target.o) trigram.o = target.o;
+  return trigram;
+}
+
+/**
+ * Adapt a typed handler to the `(tao, data)` contract.
+ *
+ * - The fused signal is reified from the dispatch arguments.
+ * - Matcher registrations only invoke the typed handler for trigrams the
+ *   vocabulary declares (out-of-vocabulary signals on the same kernel
+ *   never reach the typed handler's type space); exact registrations are
+ *   declared trigrams by construction.
+ * - A returned typed signal is translated to an AppCtx so chaining works
+ *   exactly as the JS contract defines; all other returns pass through
+ *   untouched (intercept truthy-halt verdicts included).
+ */
+function adapt<V extends SpecMap>(
+  vocab: Vocabulary<V>,
+  handler: TypedHandler<TypedSignal>,
+  vocabOnly: boolean,
+): UntypedHandler {
+  return (tao, data) => {
+    if (vocabOnly && !vocab.has(tao)) {
+      return undefined;
+    }
+    const result = handler({ t: tao.t, a: tao.a, o: tao.o, data });
+    return translateResult(result);
+  };
+}
+
+function translateResult(result: TypedHandlerResult): unknown {
+  if (result != null && typeof (result as Promise<unknown>).then === 'function') {
+    return (result as Promise<unknown>).then((settled) =>
+      translateResult(settled as TypedHandlerResult),
+    );
+  }
+  if (isTypedSignal(result)) {
+    return new AppCtx(result.t, result.a, result.o, result.data);
+  }
+  return result;
+}
+
+/**
+ * Wrap an existing Kernel in a typed facade for one vocabulary. Multiple
+ * facades (and untyped code) may share the same kernel — it is all one
+ * signal network.
+ */
+export function typedKernel<V extends SpecMap>(
+  kernel: UntypedKernel,
+  vocabulary: Vocabulary<V>,
+): TypedKernel<V> {
+  if (
+    !kernel ||
+    typeof kernel.setCtx !== 'function' ||
+    typeof kernel.addInlineHandler !== 'function'
+  ) {
+    throw new Error('typedKernel requires a @tao.js/core Kernel');
+  }
+  if (!vocabulary || typeof vocabulary.has !== 'function') {
+    throw new Error('typedKernel requires a vocabulary from defineVocabulary');
+  }
+
+  const register = (
+    phase: Phase,
+    target: Subscribable<V> | Matcher<TypedSignal>,
+    handler: TypedHandler<TypedSignal>,
+  ): Dispose => {
+    const matcher = isMatcher(target);
+    const trigram = toTrigram(
+      matcher ? (target.filter as MatchFilter) : (target as SignalSpec),
+    );
+    const adapted = adapt(vocabulary, handler, matcher);
+    (
+      kernel[`add${phase}Handler` as const] as (
+        trigram: object,
+        handler: UntypedHandler,
+      ) => unknown
+    )(trigram, adapted);
+    return () => {
+      (
+        kernel[`remove${phase}Handler` as const] as (
+          trigram: object,
+          handler: UntypedHandler,
+        ) => unknown
+      )(trigram, adapted);
+    };
+  };
+
+  return {
+    kernel,
+    vocabulary,
+    set(signal) {
+      kernel.setCtx({ t: signal.t, a: signal.a, o: signal.o }, signal.data);
+    },
+    onIntercept(target: Subscribable<V>, handler: TypedHandler<TypedSignal>) {
+      return register('Intercept', target, handler);
+    },
+    onAsync(target: Subscribable<V>, handler: TypedHandler<TypedSignal>) {
+      return register('Async', target, handler);
+    },
+    onInline(target: Subscribable<V>, handler: TypedHandler<TypedSignal>) {
+      return register('Inline', target, handler);
+    },
+  } as TypedKernel<V>;
+}

--- a/packages/tao-typed/src/signal.ts
+++ b/packages/tao-typed/src/signal.ts
@@ -1,0 +1,83 @@
+/**
+ * The typed signal algebra (TYPED-SPEC.md §2).
+ *
+ * A SignalSpec is a declared protocol message: a literal trigram plus the
+ * datagram type captured with it. A TypedSignal is one concrete message —
+ * the `tao` and `data` parameters of the JS handler contract fused into a
+ * single typed value.
+ */
+
+/** One concrete protocol message: literal trigram + typed datagram. */
+export interface TypedSignal<
+  T extends string = string,
+  A extends string = string,
+  O extends string = string,
+  D = unknown,
+> {
+  readonly t: T;
+  readonly a: A;
+  readonly o: O;
+  readonly data: D;
+}
+
+/** A declared protocol message: the trigram with its datagram type. */
+export interface SignalSpec<
+  T extends string = string,
+  A extends string = string,
+  O extends string = string,
+  D = unknown,
+> {
+  readonly t: T;
+  readonly a: A;
+  readonly o: O;
+  /** phantom carrier for the datagram type — never a runtime value */
+  readonly __data?: D;
+}
+
+/** Builder step between `signal(t, a, o)` and `.data<D>()`. */
+export interface SignalBuilder<
+  T extends string,
+  A extends string,
+  O extends string,
+> {
+  /** Capture the datagram type for this trigram. */
+  data<D>(): SignalSpec<T, A, O, D>;
+}
+
+/**
+ * Declare one protocol message: `signal('User', 'Find', 'Portal')
+ * .data<{ User: { id: string } }>()`. Runtime cost: one frozen object.
+ */
+export function signal<
+  T extends string,
+  A extends string,
+  O extends string,
+>(t: T, a: A, o: O): SignalBuilder<T, A, O> {
+  return {
+    data<D>(): SignalSpec<T, A, O, D> {
+      return Object.freeze({ t, a, o }) as SignalSpec<T, A, O, D>;
+    },
+  };
+}
+
+/** The `${t}|${a}|${o}` key of a trigram — matches AppCtxRoot.getKey. */
+export function keyOf(sig: { t: string; a: string; o: string }): string {
+  return `${sig.t}|${sig.a}|${sig.o}`;
+}
+
+/**
+ * Runtime check that a handler-returned value is a typed signal (vs a
+ * boolean intercept verdict, undefined, or app junk).
+ */
+export function isTypedSignal(value: unknown): value is TypedSignal {
+  if (value == null || typeof value !== 'object') {
+    return false;
+  }
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.t === 'string' &&
+    typeof v.a === 'string' &&
+    typeof v.o === 'string' &&
+    'data' in v
+  );
+}

--- a/packages/tao-typed/src/vocabulary.ts
+++ b/packages/tao-typed/src/vocabulary.ts
@@ -1,0 +1,151 @@
+/**
+ * Vocabularies (TYPED-SPEC.md §2–§3): the app's protocol as a plain,
+ * importable value. `defineVocabulary` turns declared SignalSpecs into
+ * typed signal constructors; `match`/`any` project the vocabulary into
+ * discriminated unions for wildcard subscription. No kernel is touched —
+ * a vocabulary is TAO.md as code.
+ */
+import {
+  SignalSpec,
+  TypedSignal,
+  keyOf,
+} from './signal';
+
+/** Any map of declared protocol messages. */
+export type SpecMap = Record<string, SignalSpec<string, string, string, unknown>>;
+
+/** The TypedSignal produced by one SignalSpec. */
+export type SignalOf<S> = S extends SignalSpec<infer T, infer A, infer O, infer D>
+  ? TypedSignal<T, A, O, D>
+  : never;
+
+/** The union of every signal in a vocabulary — the protocol's message type. */
+export type VocabularySignals<V extends SpecMap> = {
+  [K in keyof V]: SignalOf<V[K]>;
+}[keyof V];
+
+/**
+ * A signal constructor: call it with the datagram to get the concrete
+ * typed signal; its trigram rides along as literal-typed properties.
+ */
+export type SignalCtor<S extends SignalSpec> = S extends SignalSpec<
+  infer T,
+  infer A,
+  infer O,
+  infer D
+>
+  ? ((data: D) => TypedSignal<T, A, O, D>) & SignalSpec<T, A, O, D>
+  : never;
+
+/** A trigram filter over a vocabulary (partial, literal-typed). */
+export interface MatchFilter {
+  readonly t?: string;
+  readonly a?: string;
+  readonly o?: string;
+}
+
+/**
+ * A typed wildcard subscription: carries the projected union as a phantom
+ * plus the runtime trigram filter to register underneath.
+ */
+export interface Matcher<S extends TypedSignal = TypedSignal> {
+  readonly __matcher: true;
+  readonly filter: MatchFilter;
+  /** phantom carrier of the projected signal union */
+  readonly __signals?: S;
+}
+
+/** Signals of V whose trigram satisfies filter F (type-level projection). */
+export type MatchedSignals<
+  V extends SpecMap,
+  F extends MatchFilter,
+> = Extract<
+  VocabularySignals<V>,
+  (F extends { t: infer T extends string } ? { t: T } : unknown) &
+    (F extends { a: infer A extends string } ? { a: A } : unknown) &
+    (F extends { o: infer O extends string } ? { o: O } : unknown)
+>;
+
+/** The vocabulary meta-surface added alongside the constructors. */
+export interface VocabularyMeta<V extends SpecMap> {
+  /**
+   * Typed wildcard projection: signals matching the partial trigram, as a
+   * discriminated union. Registered as the equivalent wildcard underneath.
+   */
+  match<const F extends MatchFilter>(filter: F): Matcher<MatchedSignals<V, F>>;
+  /** The whole vocabulary as one union (full-wildcard subscription). */
+  any(): Matcher<VocabularySignals<V>>;
+  /** Is this concrete trigram declared in the vocabulary? */
+  has(sig: { t: string; a: string; o: string }): boolean;
+  /**
+   * The declared protocol as data — trigram list for TAO.md generation and
+   * the protocol extractor (AGENTIC.md).
+   */
+  toProtocol(): Array<{ name: string; t: string; a: string; o: string }>;
+}
+
+/** What `defineVocabulary` returns: constructors + meta. */
+export type Vocabulary<V extends SpecMap> = {
+  [K in keyof V]: SignalCtor<V[K]>;
+} & VocabularyMeta<V>;
+
+const META_KEYS = ['match', 'any', 'has', 'toProtocol'] as const;
+
+/**
+ * Turn declared SignalSpecs into a vocabulary of typed signal
+ * constructors. Referencing an undeclared signal is a compile error — the
+ * silent-no-op failure mode of string-keyed dispatch is gone at authoring
+ * time.
+ */
+export function defineVocabulary<V extends SpecMap>(specs: V): Vocabulary<V> {
+  const keys = new Set<string>();
+  const protocol: Array<{ name: string; t: string; a: string; o: string }> =
+    [];
+  const vocab = {} as Record<string, unknown>;
+
+  for (const [name, spec] of Object.entries(specs)) {
+    if ((META_KEYS as readonly string[]).includes(name)) {
+      throw new Error(
+        `'${name}' is reserved by the vocabulary meta-surface - rename the signal`,
+      );
+    }
+    const key = keyOf(spec);
+    if (keys.has(key)) {
+      throw new Error(
+        `duplicate trigram {${spec.t}, ${spec.a}, ${spec.o}} in vocabulary - one declared signal per trigram`,
+      );
+    }
+    keys.add(key);
+    protocol.push({ name, t: spec.t, a: spec.a, o: spec.o });
+    const ctor = (data: unknown) =>
+      Object.freeze({ t: spec.t, a: spec.a, o: spec.o, data });
+    Object.assign(ctor, { t: spec.t, a: spec.a, o: spec.o });
+    vocab[name] = ctor;
+  }
+
+  const meta: VocabularyMeta<V> = {
+    match(filter) {
+      return Object.freeze({ __matcher: true as const, filter });
+    },
+    any() {
+      return Object.freeze({ __matcher: true as const, filter: {} });
+    },
+    has(sig) {
+      return keys.has(keyOf(sig));
+    },
+    toProtocol() {
+      return protocol.map((entry) => ({ ...entry }));
+    },
+  };
+
+  return Object.freeze(Object.assign(vocab, meta)) as Vocabulary<V>;
+}
+
+/** Runtime discriminator between a signal constructor and a matcher. */
+export function isMatcher(value: unknown): value is Matcher {
+  return (
+    value != null &&
+    typeof value === 'object' &&
+    (value as { __matcher?: unknown }).__matcher === true
+  );
+}

--- a/packages/tao-typed/test-d/types.test-d.ts
+++ b/packages/tao-typed/test-d/types.test-d.ts
@@ -1,0 +1,70 @@
+/**
+ * Compile-time assertions for the vocabulary algebra (checked by
+ * `npm run typecheck`; nothing here runs). The @ts-expect-error lines ARE
+ * the tests: if the type system stops rejecting them, typecheck fails.
+ */
+import { signal, defineVocabulary, typedKernel } from '../src';
+import type { UntypedKernel } from '../src';
+
+declare const kernel: UntypedKernel;
+
+const App = defineVocabulary({
+  UserFind: signal('User', 'Find', 'Portal').data<{ User: { id: string } }>(),
+  UserView: signal('User', 'View', 'Portal').data<{ User: { name: string } }>(),
+  SpaceEnter: signal('Space', 'Enter', 'Portal').data<{ Space: { id: string } }>(),
+});
+
+const tao = typedKernel(kernel, App);
+
+// trigram literals survive
+const s = App.UserFind({ User: { id: '1' } });
+const t: 'User' = s.t;
+const a: 'Find' = s.a;
+const id: string = s.data.User.id;
+void t; void a; void id;
+
+// @ts-expect-error — undeclared signal names do not exist
+App.UserDelete({ User: { id: '1' } });
+
+// @ts-expect-error — datagram shape is enforced per trigram
+App.UserFind({ User: { id: 42 } });
+
+// @ts-expect-error — cross-signal datagrams do not interchange
+App.UserFind({ User: { name: 'x' } });
+
+// handlers receive the exact datagram type
+tao.onInline(App.UserFind, (sig) => {
+  const ok: string = sig.data.User.id;
+  void ok;
+  // @ts-expect-error — UserFind's datagram has no name
+  sig.data.User.name;
+});
+
+// typed chaining accepts vocabulary signals
+tao.onInline(App.UserFind, () => App.UserView({ User: { name: 'n' } }));
+
+// match projects a discriminated union narrowed by the action
+tao.onInline(App.match({ t: 'User' }), (sig) => {
+  if (sig.a === 'Find') {
+    const ok: string = sig.data.User.id;
+    void ok;
+  }
+  if (sig.a === 'View') {
+    const ok: string = sig.data.User.name;
+    void ok;
+  }
+  // @ts-expect-error — Space signals are excluded from a t:'User' projection
+  const never: 'Space' = sig.t;
+  void never;
+});
+
+// any() is the whole protocol union
+tao.onInline(App.any(), (sig) => {
+  const tri: 'User' | 'Space' = sig.t;
+  void tri;
+});
+
+// set() only accepts vocabulary signals
+tao.set(App.SpaceEnter({ Space: { id: 's' } }));
+// @ts-expect-error — raw objects are not vocabulary signals
+tao.set({ t: 'User', a: 'Find', o: 'Portal', data: {} });

--- a/packages/tao-typed/test/typed.spec.ts
+++ b/packages/tao-typed/test/typed.spec.ts
@@ -1,0 +1,237 @@
+/**
+ * Runtime translation fidelity (TYPED-SPEC.md §4): typed signals are
+ * ordinary signals on the kernel — phases, chaining, wildcards, and traces
+ * behave identically to their untyped equivalents.
+ */
+import { Kernel, AppCtx } from '@tao.js/core';
+import { Tracer, InMemorySink } from '@tao.js/telemetry';
+import { signal, defineVocabulary, typedKernel, isTypedSignal, keyOf } from '../src';
+
+const makeVocab = () =>
+  defineVocabulary({
+    UserFind: signal('User', 'Find', 'Portal').data<{ User: { id: string } }>(),
+    UserView: signal('User', 'View', 'Portal').data<{ User: { id: string; name: string } }>(),
+    UserFail: signal('User', 'Fail', 'Portal').data<{ User: { reason: string } }>(),
+    SpaceEnter: signal('Space', 'Enter', 'Portal').data<{ Space: { id: string } }>(),
+  });
+
+const drain = () => new Promise((resolve) => setTimeout(resolve, 30));
+
+describe('signal + defineVocabulary', () => {
+  it('constructs typed signals fusing trigram and datagram', () => {
+    const App = makeVocab();
+    const s = App.UserFind({ User: { id: '42' } });
+    expect(s).toEqual({ t: 'User', a: 'Find', o: 'Portal', data: { User: { id: '42' } } });
+    expect(Object.isFrozen(s)).toBe(true);
+    expect(App.UserFind.t).toBe('User');
+    expect(App.UserFind.a).toBe('Find');
+    expect(App.UserFind.o).toBe('Portal');
+  });
+
+  it('exposes the declared protocol as data', () => {
+    const App = makeVocab();
+    expect(App.toProtocol()).toEqual([
+      { name: 'UserFind', t: 'User', a: 'Find', o: 'Portal' },
+      { name: 'UserView', t: 'User', a: 'View', o: 'Portal' },
+      { name: 'UserFail', t: 'User', a: 'Fail', o: 'Portal' },
+      { name: 'SpaceEnter', t: 'Space', a: 'Enter', o: 'Portal' },
+    ]);
+    expect(App.has({ t: 'User', a: 'Find', o: 'Portal' })).toBe(true);
+    expect(App.has({ t: 'User', a: 'Delete', o: 'Portal' })).toBe(false);
+  });
+
+  it('rejects duplicate trigrams and reserved names', () => {
+    expect(() =>
+      defineVocabulary({
+        A: signal('X', 'Y', 'Z').data<object>(),
+        B: signal('X', 'Y', 'Z').data<object>(),
+      }),
+    ).toThrow(/duplicate trigram \{X, Y, Z\}/);
+    expect(() =>
+      defineVocabulary({ match: signal('X', 'Y', 'Z').data<object>() }),
+    ).toThrow(/'match' is reserved/);
+  });
+
+  it('keyOf matches the core key format', () => {
+    expect(keyOf({ t: 'User', a: 'Find', o: 'Portal' })).toBe('User|Find|Portal');
+    expect(new AppCtx('User', 'Find', 'Portal').key).toBe('User|Find|Portal');
+  });
+
+  it('isTypedSignal discriminates signals from junk', () => {
+    const App = makeVocab();
+    expect(isTypedSignal(App.UserFind({ User: { id: '1' } }))).toBe(true);
+    expect(isTypedSignal(undefined)).toBe(false);
+    expect(isTypedSignal(true)).toBe(false);
+    expect(isTypedSignal({ t: 'x', a: 'y' })).toBe(false);
+  });
+});
+
+describe('typedKernel translation', () => {
+  it('guards its inputs', () => {
+    const App = makeVocab();
+    expect(() => typedKernel({} as never, App)).toThrow(
+      /requires a @tao\.js\/core Kernel/,
+    );
+    expect(() => typedKernel(new Kernel(), {} as never)).toThrow(
+      /requires a vocabulary/,
+    );
+  });
+
+  it('set() dispatches to untyped handlers and typed handlers receive the fused signal', async () => {
+    const App = makeVocab();
+    const kernel = new Kernel();
+    const tao = typedKernel(kernel, App);
+    const typedSeen: unknown[] = [];
+    const untypedSeen: unknown[] = [];
+    tao.onInline(App.UserFind, (s) => {
+      typedSeen.push(s);
+    });
+    kernel.addInlineHandler({ t: 'User', a: 'Find', o: 'Portal' }, (t: { t: string }, data: unknown) => {
+      untypedSeen.push(data);
+    });
+    tao.set(App.UserFind({ User: { id: '7' } }));
+    await drain();
+    expect(typedSeen).toEqual([
+      { t: 'User', a: 'Find', o: 'Portal', data: { User: { id: '7' } } },
+    ]);
+    expect(untypedSeen).toEqual([{ User: { id: '7' } }]);
+  });
+
+  it('typed chaining: returned signals chain exactly like returned AppCtx', async () => {
+    const App = makeVocab();
+    const kernel = new Kernel();
+    const tao = typedKernel(kernel, App);
+    const order: string[] = [];
+    tao.onInline(App.UserFind, (s) => {
+      order.push(`find:${s.data.User.id}`);
+      return App.UserView({ User: { id: s.data.User.id, name: 'N' } });
+    });
+    tao.onInline(App.UserView, (s) => {
+      order.push(`view:${s.data.User.name}`);
+    });
+    tao.set(App.UserFind({ User: { id: '9' } }));
+    await drain();
+    expect(order).toEqual(['find:9', 'view:N']);
+  });
+
+  it('async typed handlers resolve to chains', async () => {
+    const App = makeVocab();
+    const kernel = new Kernel();
+    const tao = typedKernel(kernel, App);
+    const seen: string[] = [];
+    tao.onAsync(App.UserFind, async (s) => {
+      return App.UserView({ User: { id: s.data.User.id, name: 'async' } });
+    });
+    tao.onInline(App.UserView, (s) => {
+      seen.push(s.data.User.name);
+    });
+    tao.set(App.UserFind({ User: { id: '3' } }));
+    await drain();
+    expect(seen).toEqual(['async']);
+  });
+
+  it('intercept verdicts pass through: truthy halts, signal diverts', async () => {
+    const App = makeVocab();
+    const kernel = new Kernel();
+    const tao = typedKernel(kernel, App);
+    const reached: string[] = [];
+    tao.onIntercept(App.UserFind, (s) =>
+      s.data.User.id === 'blocked'
+        ? true
+        : s.data.User.id === 'divert'
+          ? App.UserFail({ User: { reason: 'diverted' } })
+          : undefined,
+    );
+    tao.onInline(App.UserFind, () => {
+      reached.push('inline');
+    });
+    tao.onInline(App.UserFail, (s) => {
+      reached.push(`fail:${s.data.User.reason}`);
+    });
+    tao.set(App.UserFind({ User: { id: 'blocked' } }));
+    await drain();
+    expect(reached).toEqual([]);
+    tao.set(App.UserFind({ User: { id: 'divert' } }));
+    await drain();
+    expect(reached).toEqual(['fail:diverted']);
+    tao.set(App.UserFind({ User: { id: 'ok' } }));
+    await drain();
+    expect(reached).toEqual(['fail:diverted', 'inline']);
+  });
+
+  it('matchers receive the projected union and skip out-of-vocabulary signals', async () => {
+    const App = makeVocab();
+    const kernel = new Kernel();
+    const tao = typedKernel(kernel, App);
+    const seen: string[] = [];
+    tao.onInline(App.match({ t: 'User' }), (s) => {
+      seen.push(`${s.a}`);
+    });
+    tao.set(App.UserFind({ User: { id: '1' } }));
+    tao.set(App.SpaceEnter({ Space: { id: 's' } }));
+    kernel.setCtx({ t: 'User', a: 'Undeclared', o: 'Portal' }, { x: 1 });
+    await drain();
+    expect(seen).toEqual(['Find']);
+  });
+
+  it('any() sees every vocabulary signal but nothing undeclared', async () => {
+    const App = makeVocab();
+    const kernel = new Kernel();
+    const tao = typedKernel(kernel, App);
+    const seen: string[] = [];
+    tao.onInline(App.any(), (s) => {
+      seen.push(s.t);
+    });
+    tao.set(App.UserFind({ User: { id: '1' } }));
+    tao.set(App.SpaceEnter({ Space: { id: 's' } }));
+    kernel.setCtx({ t: 'Rogue', a: 'Run', o: 'App' }, {});
+    await drain();
+    expect(seen.sort()).toEqual(['Space', 'User']);
+  });
+
+  it('dispose unregisters exactly the adapted handler', async () => {
+    const App = makeVocab();
+    const kernel = new Kernel();
+    const tao = typedKernel(kernel, App);
+    const seen: string[] = [];
+    const dispose = tao.onInline(App.UserFind, () => {
+      seen.push('a');
+    });
+    tao.onInline(App.UserFind, () => {
+      seen.push('b');
+    });
+    dispose();
+    tao.set(App.UserFind({ User: { id: '1' } }));
+    await drain();
+    expect(seen).toEqual(['b']);
+  });
+
+  it('a typed cascade traces identically to its untyped equivalent', async () => {
+    const App = makeVocab();
+    const typedK = new Kernel();
+    const untypedK = new Kernel();
+    const typedSink = new InMemorySink();
+    const untypedSink = new InMemorySink();
+    new Tracer(typedK, { sinks: [typedSink] });
+    new Tracer(untypedK, { sinks: [untypedSink] });
+
+    const tao = typedKernel(typedK, App);
+    tao.onInline(App.UserFind, (s) =>
+      App.UserView({ User: { id: s.data.User.id, name: 'T' } }),
+    );
+    tao.set(App.UserFind({ User: { id: '5' } }));
+
+    untypedK.addInlineHandler(
+      { t: 'User', a: 'Find', o: 'Portal' },
+      (t: { t: string }, data: { User: { id: string } }) =>
+        new AppCtx('User', 'View', 'Portal', { User: { id: data.User.id, name: 'T' } }),
+    );
+    untypedK.setCtx({ t: 'User', a: 'Find', o: 'Portal' }, { User: { id: '5' } });
+    await drain();
+
+    const shape = (records: Array<{ key: string; via?: string; parentId: string | null }>) =>
+      records.map((r) => ({ key: r.key, via: r.via ?? null, isRoot: r.parentId === null }));
+    expect(shape(typedSink.records)).toEqual(shape(untypedSink.records));
+    expect(typedSink.format()).toBe(untypedSink.format());
+  });
+});

--- a/packages/tao-typed/tsconfig.cjs.json
+++ b/packages/tao-typed/tsconfig.cjs.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "lib",
+    "declaration": true,
+    "declarationMap": true
+  }
+}

--- a/packages/tao-typed/tsconfig.esm.json
+++ b/packages/tao-typed/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "outDir": "dist",
+    "moduleResolution": "Bundler"
+  }
+}

--- a/packages/tao-typed/tsconfig.json
+++ b/packages/tao-typed/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020"],
+    "strict": true,
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "module": "CommonJS"
+  },
+  "include": ["src"]
+}

--- a/packages/tao-typed/tsconfig.typecheck.json
+++ b/packages/tao-typed/tsconfig.typecheck.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src", "test-d"]
+}

--- a/packages/tao-utils/src/Channel.js
+++ b/packages/tao-utils/src/Channel.js
@@ -15,6 +15,29 @@ function channelControl(channelId) {
 }
 
 /**
+ * A trigram matcher in short (`t`/`a`/`o`) or long (`term`/`action`/`orient`)
+ * keys; omitted parts are wildcards.
+ *
+ * @typedef {Object} Trigram
+ * @property {string} [t] - term (short key)
+ * @property {string} [term] - term (long key)
+ * @property {string} [a] - action (short key)
+ * @property {string} [action] - action (long key)
+ * @property {string} [o] - orient (short key)
+ * @property {string} [orient] - orient (long key)
+ */
+
+/**
+ * A TAO signal handler: called with the concrete trigram handled and the
+ * signal's datagram(s); returning an `AppCtx` chains it (see `@tao.js/core`).
+ *
+ * @callback SignalHandler
+ * @param {Object} tao - the concrete `{ t, a, o }` trigram handled
+ * @param {*} data - the signal's datagram(s)
+ * @returns {(AppCtx|*)}
+ */
+
+/**
  * Filters handling of AppCons to the set of attached handlers of the Channel for only those
  * AppCons that had a preceding AppCon originate from this Channel.
  *
@@ -25,16 +48,30 @@ function channelControl(channelId) {
  * channel-attached handlers continue the cascade envelope through the main
  * network's hop engine (they do not re-enter with a fresh envelope).
  *
+ * Decoration: `onForward` on the shared network, self-filtered on
+ * `envelope.cascade.channelId`. The channel tag rides the cascade scope —
+ * one shared reference for the whole cascade — so every descendant hop of a
+ * channel entry is mirrored, wherever the chain goes.
+ *
  * @export
  * @class Channel
  */
 export default class Channel {
   /**
    *Creates an instance of Channel.
-   * @param {Kernel} kernel - an instance of a Kernel or other TAO Network on which to build a Channel by sharing the same underlying Network
-   * @param {(string|function)} [id] - pass either a desired Channel ID value as a `string` or a `function` that will be used to generate a Channel ID
+   *
+   * Surface resolution follows the utils convention
+   * (`typeof kernel.enter === 'function' ? kernel : kernel._network`): pass
+   * anything exposing the envelope gate directly (a `Network`), or a
+   * Kernel-shaped wrapper exposing `_network`. The resolved network must
+   * support `enter` and `decorate`.
+   *
+   * @param {(Kernel|Network)} kernel - an instance of a Kernel or other TAO Network on which to build a Channel by sharing the same underlying Network
+   * @param {(string|function(number): (string|number))} [id] - pass either a desired Channel ID value as a `string` or a `function` that will be used to generate a Channel ID
    *        the `function` will be called with a new Channel ID integer value to help ensure uniqueness
    * @param {boolean} [debug=false] - pass true to console.log internal activity
+   * @throws {Error} when the resolved network lacks envelope support
+   *         (`enter` + `decorate`) - upgrade `@tao.js/core`
    * @memberof Channel
    */
   constructor(kernel, id, debug = false) {
@@ -66,10 +103,15 @@ export default class Channel {
   /**
    * Clones a Channel
    *
-   * @param {(string|function)} [cloneId] - used as the cloned `Channel`'s ID,
+   * The clone shares the same underlying network, copies the private
+   * network's handler registrations, and registers its own decoration under
+   * its own Channel ID.
+   *
+   * @param {(string|function(number): (string|number))} [cloneId] - used as the cloned `Channel`'s ID,
    *          same as the `id` param to the `Channel` constructor, either an
-   *          explicit value as a `string` or a `function` used to generate the Channel ID
-   * @returns
+   *          explicit value as a `string` or a `function` used to generate the Channel ID;
+   *          falls back to the constructor's `id` generator when one was given
+   * @returns {Channel} the cloned Channel
    * @memberof Channel
    */
   clone(cloneId) {
@@ -85,6 +127,7 @@ export default class Channel {
    * Detach this Channel's decoration from the shared network. Channel
    * handlers stop receiving mirrored AppCons; entries still dispatch.
    *
+   * @returns {void}
    * @memberof Channel
    */
   dispose() {
@@ -99,6 +142,12 @@ export default class Channel {
    *
    * @param {AppCtx} ac
    * @param {Object} [opts] - `{ cascade, hop, chain }` as `Network.enter`
+   * @param {Object} [opts.cascade] - caller cascade keys; the channel tag
+   *        wins key conflicts
+   * @param {Object} [opts.hop] - entry-hop values (e.g. a transport's
+   *        `source` marker)
+   * @param {(Object|null)} [opts.chain] - prior chain state to continue
+   * @returns {void}
    * @memberof Channel
    */
   enter(ac, { cascade = {}, hop = {}, chain = null } = {}) {
@@ -109,10 +158,26 @@ export default class Channel {
     });
   }
 
+  /**
+   * Builds an AppCtx from a trigram + datagram (long-form keys win) and
+   * enters it with this Channel's cascade scoping.
+   *
+   * @param {Trigram} trigram
+   * @param {*} data - datagram(s) for the signal
+   * @returns {void}
+   * @memberof Channel
+   */
   setCtx({ t, term, a, action, o, orient }, data) {
     this.enter(new AppCtx(term || t, action || a, orient || o, data));
   }
 
+  /**
+   * Enters an existing AppCtx with this Channel's cascade scoping.
+   *
+   * @param {AppCtx} ac
+   * @returns {void}
+   * @memberof Channel
+   */
   setAppCtx(ac) {
     this.enter(ac);
   }
@@ -122,7 +187,9 @@ export default class Channel {
    * AppCons mirrored to this Channel (used by wrapping adapters like
    * Transponder). Same contract as `Network.decorate`.
    *
-   * @returns {function} dispose - removes the decoration
+   * @param {Object} spec - decoration spec as `Network.decorate` accepts
+   *        (`{ name, onDispatch, onForward, onReturn, onProceed, chain }`)
+   * @returns {function(): void} dispose - removes the decoration
    * @memberof Channel
    */
   decorate(spec) {
@@ -146,6 +213,15 @@ export default class Channel {
     }
   }
 
+  /**
+   * Attaches an InterceptHandler to this Channel's private network — runs
+   * for matching AppCons mirrored to this Channel.
+   *
+   * @param {Trigram} trigram
+   * @param {SignalHandler} handler
+   * @returns {Channel} this
+   * @memberof Channel
+   */
   addInterceptHandler({ t, term, a, action, o, orient }, handler) {
     this._channel.addInterceptHandler(
       { t, term, a, action, o, orient },
@@ -154,16 +230,42 @@ export default class Channel {
     return this;
   }
 
+  /**
+   * Attaches an AsyncHandler to this Channel's private network — runs for
+   * matching AppCons mirrored to this Channel.
+   *
+   * @param {Trigram} trigram
+   * @param {SignalHandler} handler
+   * @returns {Channel} this
+   * @memberof Channel
+   */
   addAsyncHandler({ t, term, a, action, o, orient }, handler) {
     this._channel.addAsyncHandler({ t, term, a, action, o, orient }, handler);
     return this;
   }
 
+  /**
+   * Attaches an InlineHandler to this Channel's private network — runs for
+   * matching AppCons mirrored to this Channel.
+   *
+   * @param {Trigram} trigram
+   * @param {SignalHandler} handler
+   * @returns {Channel} this
+   * @memberof Channel
+   */
   addInlineHandler({ t, term, a, action, o, orient }, handler) {
     this._channel.addInlineHandler({ t, term, a, action, o, orient }, handler);
     return this;
   }
 
+  /**
+   * Removes an InterceptHandler previously attached for the same trigram.
+   *
+   * @param {Trigram} trigram
+   * @param {SignalHandler} handler
+   * @returns {Channel} this
+   * @memberof Channel
+   */
   removeInterceptHandler({ t, term, a, action, o, orient }, handler) {
     this._channel.removeInterceptHandler(
       { t, term, a, action, o, orient },
@@ -172,6 +274,14 @@ export default class Channel {
     return this;
   }
 
+  /**
+   * Removes an AsyncHandler previously attached for the same trigram.
+   *
+   * @param {Trigram} trigram
+   * @param {SignalHandler} handler
+   * @returns {Channel} this
+   * @memberof Channel
+   */
   removeAsyncHandler({ t, term, a, action, o, orient }, handler) {
     this._channel.removeAsyncHandler(
       { t, term, a, action, o, orient },
@@ -180,6 +290,14 @@ export default class Channel {
     return this;
   }
 
+  /**
+   * Removes an InlineHandler previously attached for the same trigram.
+   *
+   * @param {Trigram} trigram
+   * @param {SignalHandler} handler
+   * @returns {Channel} this
+   * @memberof Channel
+   */
   removeInlineHandler({ t, term, a, action, o, orient }, handler) {
     this._channel.removeInlineHandler(
       { t, term, a, action, o, orient },
@@ -188,6 +306,18 @@ export default class Channel {
     return this;
   }
 
+  /**
+   * Bridges matching AppCons flowing on another Kernel's network into this
+   * Channel (via `seive`), excluding cascades that already originated from
+   * this Channel (no echo).
+   *
+   * @param {Kernel} TAO - Kernel-shaped wrapper (exposing `_network`) to bridge from
+   * @param {...*} trigrams - optional trigram filters as `trigramFilter`
+   *        accepts (optional leading `exact` boolean, then short-key
+   *        trigrams or a single array of trigrams); none bridges every AppCon
+   * @returns {function(): void} dispose - detaches the bridge
+   * @memberof Channel
+   */
   bridgeFrom(TAO, ...trigrams) {
     return seive(
       this._channelId,

--- a/packages/tao-utils/src/Relay.js
+++ b/packages/tao-utils/src/Relay.js
@@ -12,14 +12,52 @@ function sourceControl(source) {
 }
 
 /**
+ * A trigram in short (`t`/`a`/`o`) or long (`term`/`action`/`orient`) keys;
+ * long-form keys win.
+ *
+ * @typedef {Object} Trigram
+ * @property {string} [t] - term (short key)
+ * @property {string} [term] - term (long key)
+ * @property {string} [a] - action (short key)
+ * @property {string} [action] - action (long key)
+ * @property {string} [o] - orient (short key)
+ * @property {string} [orient] - orient (long key)
+ */
+
+/**
  * Like Source, but `fromSrc` is required. Implemented as a Network
  * decoration; the origin marker rides the envelope's hop scope.
- * Unexported / experimental.
+ * Decoration: `onDispatch` (phase-blind emission), self-filtered on
+ * `envelope.hop.source`. Unexported / experimental.
  *
  * @export
  * @class Relay
  */
 export default class Relay {
+  /**
+   * Creates an instance of Relay.
+   *
+   * Note the Relay resolves its network from `kernel._network` only (it
+   * does not apply the utils surface-resolution convention, so a bare
+   * `Network` is not accepted); the resolved network must support `enter`
+   * and `decorate`.
+   *
+   * @param {Kernel} kernel - Kernel-shaped wrapper (exposing `_network`) to attach the Relay to
+   * @param {function(Object, *): void} toSrc - outbound emitter called with
+   *        `(tao, data)` — the unwrapped `{ t, a, o }` trigram and the
+   *        datagram(s) — for every AppCon except those arriving from this Relay
+   * @param {(string|function)} [name] - the Relay's name, used as its
+   *        hop-scope origin marker (auto-generated `FROM<n>` when omitted);
+   *        passing a `function` here is the `fromSrc` overload
+   * @param {function(function(Trigram, *): void): void} fromSrc - binder for
+   *        the inbound side (required): called once with a setter
+   *        `(tao, data)` that enters received signals stamped with this
+   *        Relay's origin marker
+   * @throws {Error} when `kernel` (or its `_network`) is missing, when the
+   *         network lacks envelope support (`enter` + `decorate`) - upgrade
+   *         `@tao.js/core`, or when `toSrc` is missing
+   * @memberof Relay
+   */
   constructor(kernel, toSrc, name, fromSrc) {
     if (!kernel || !kernel._network) {
       throw new Error(
@@ -52,26 +90,67 @@ export default class Relay {
     });
   }
 
+  /**
+   * The Relay's name — the hop-scope origin marker it stamps on entries
+   * and filters emission on.
+   *
+   * @type {string}
+   * @memberof Relay
+   */
   get name() {
     return this._name;
   }
 
+  /**
+   * `onDispatch` decoration callback: emits every dispatched AppCon to the
+   * source except those whose arriving hop carries this Relay's origin
+   * marker. Suppression reads the hop scope only — hops after the entry
+   * reset to `{}` — so AppCons chained in response are emitted back out
+   * (the bidirectional reflex).
+   *
+   * @param {AppCtx} ac
+   * @param {Object} envelope - the dispatch envelope `{ cascade, hop, chain }`
+   * @returns {void}
+   * @memberof Relay
+   */
   handleAppCon(ac, envelope) {
     if (envelope.hop.source !== this.name) {
       this._toSrc(ac.unwrapCtx(), ac.data);
     }
   }
 
+  /**
+   * Enters a signal received from the source: builds an AppCtx (long-form
+   * trigram keys win) and enters it with this Relay's origin marker on the
+   * entry hop, suppressing the echo back to the source.
+   *
+   * @param {Trigram} trigram
+   * @param {*} data - datagram(s) for the signal
+   * @returns {void}
+   * @memberof Relay
+   */
   setCtx = ({ t, term, a, action, o, orient }, data) => {
     this._enter({ t, term, a, action, o, orient }, data);
   };
 
+  /**
+   * @param {Trigram} trigram
+   * @param {*} data
+   * @private
+   */
   _enter({ t, term, a, action, o, orient }, data) {
     this._network.enter(new AppCtx(term || t, action || a, orient || o, data), {
       hop: sourceControl(this.name),
     });
   }
 
+  /**
+   * Detach this Relay's decoration from the network: stops emitting to the
+   * source. Inbound entries via `setCtx`/`fromSrc` still dispatch.
+   *
+   * @returns {void}
+   * @memberof Relay
+   */
   dispose() {
     this._undecorate();
   }

--- a/packages/tao-utils/src/Source.js
+++ b/packages/tao-utils/src/Source.js
@@ -12,6 +12,19 @@ function sourceControl(source) {
 }
 
 /**
+ * A trigram in short (`t`/`a`/`o`) or long (`term`/`action`/`orient`) keys;
+ * long-form keys win.
+ *
+ * @typedef {Object} Trigram
+ * @property {string} [t] - term (short key)
+ * @property {string} [term] - term (long key)
+ * @property {string} [a] - action (short key)
+ * @property {string} [action] - action (long key)
+ * @property {string} [o] - orient (short key)
+ * @property {string} [orient] - orient (long key)
+ */
+
+/**
  * Bridges a Network to an external source of AppCons (e.g. a socket): emits
  * every AppCon on the network to the source, except those that arrived FROM
  * the source — suppression applies to the arriving hop only, so AppCons
@@ -19,11 +32,37 @@ function sourceControl(source) {
  *
  * Implemented as a Network decoration; the origin marker rides the
  * envelope's hop scope (entry hop only) — see ENVELOPE-SPEC.md.
+ * Decoration: `onDispatch` (phase-blind emission), self-filtered on
+ * `envelope.hop.source`.
  *
  * @export
  * @class Source
  */
 export default class Source {
+  /**
+   * Creates an instance of Source.
+   *
+   * Note the Source resolves its network from `kernel._network` only (it
+   * does not apply the utils surface-resolution convention, so a bare
+   * `Network` is not accepted); the resolved network must support `enter`
+   * and `decorate`.
+   *
+   * @param {Kernel} kernel - Kernel-shaped wrapper (exposing `_network`) to attach the Source to
+   * @param {function(Object, *): void} toSrc - outbound emitter called with
+   *        `(tao, data)` — the unwrapped `{ t, a, o }` trigram and the
+   *        datagram(s) — for every AppCon except those arriving from this Source
+   * @param {(string|function)} [name] - the Source's name, used as its
+   *        hop-scope origin marker (auto-generated `FROM<n>` when omitted);
+   *        passing a `function` here is the `fromSrc` overload
+   * @param {function(function(Trigram, *): void): void} [fromSrc] - binder for
+   *        the inbound side: called once with a setter `(tao, data)` that
+   *        enters received signals stamped with this Source's origin marker
+   * @throws {Error} when `kernel` (or its `_network`) is missing, when the
+   *         network lacks envelope support (`enter` + `decorate`) - upgrade
+   *         `@tao.js/core`, when `toSrc` is missing, or when `fromSrc` is
+   *         given but not a function
+   * @memberof Source
+   */
   constructor(kernel, toSrc, name, fromSrc) {
     if (!kernel || !kernel._network) {
       throw new Error(
@@ -63,26 +102,67 @@ export default class Source {
     });
   }
 
+  /**
+   * The Source's name — the hop-scope origin marker it stamps on entries
+   * and filters emission on.
+   *
+   * @type {string}
+   * @memberof Source
+   */
   get name() {
     return this._name;
   }
 
+  /**
+   * `onDispatch` decoration callback: emits every dispatched AppCon to the
+   * source except those whose arriving hop carries this Source's origin
+   * marker. Suppression reads the hop scope only — hops after the entry
+   * reset to `{}` — so AppCons chained in response are emitted back out
+   * (the bidirectional reflex).
+   *
+   * @param {AppCtx} ac
+   * @param {Object} envelope - the dispatch envelope `{ cascade, hop, chain }`
+   * @returns {void}
+   * @memberof Source
+   */
   handleAppCon = (ac, envelope) => {
     if (envelope.hop.source !== this.name) {
       this._toSrc(ac.unwrapCtx(), ac.data);
     }
   };
 
+  /**
+   * Enters a signal received from the source: builds an AppCtx (long-form
+   * trigram keys win) and enters it with this Source's origin marker on the
+   * entry hop, suppressing the echo back to the source.
+   *
+   * @param {Trigram} trigram
+   * @param {*} data - datagram(s) for the signal
+   * @returns {void}
+   * @memberof Source
+   */
   setCtx = ({ t, term, a, action, o, orient }, data) => {
     this._enter({ t, term, a, action, o, orient }, data);
   };
 
+  /**
+   * @param {Trigram} trigram
+   * @param {*} data
+   * @private
+   */
   _enter({ t, term, a, action, o, orient }, data) {
     this._network.enter(new AppCtx(term || t, action || a, orient || o, data), {
       hop: sourceControl(this.name),
     });
   }
 
+  /**
+   * Detach this Source's decoration from the network: stops emitting to the
+   * source. Inbound entries via `setCtx`/`fromSrc` still dispatch.
+   *
+   * @returns {void}
+   * @memberof Source
+   */
   dispose() {
     this._undecorate();
   }

--- a/packages/tao-utils/src/Transceiver.js
+++ b/packages/tao-utils/src/Transceiver.js
@@ -21,6 +21,29 @@ function transceiverControl(transceiverId, resolve, reject) {
 }
 
 /**
+ * A trigram matcher in short (`t`/`a`/`o`) or long (`term`/`action`/`orient`)
+ * keys; omitted parts are wildcards.
+ *
+ * @typedef {Object} Trigram
+ * @property {string} [t] - term (short key)
+ * @property {string} [term] - term (long key)
+ * @property {string} [a] - action (short key)
+ * @property {string} [action] - action (long key)
+ * @property {string} [o] - orient (short key)
+ * @property {string} [orient] - orient (long key)
+ */
+
+/**
+ * A TAO signal handler: called with the concrete trigram handled and the
+ * signal's datagram(s); returning an `AppCtx` chains it (see `@tao.js/core`).
+ *
+ * @callback SignalHandler
+ * @param {Object} tao - the concrete `{ t, a, o }` trigram handled
+ * @param {*} data - the signal's datagram(s)
+ * @returns {(AppCtx|*)}
+ */
+
+/**
  * Like a Transponder, a Transceiver converts Signals on a Network to Promises.
  * Unlike a Transponder, a Transceiver allows the handlers attached to it to control
  * the behavior of the Promise.
@@ -49,6 +72,36 @@ function transceiverControl(transceiverId, resolve, reject) {
  * @class Transceiver
  */
 export default class Transceiver {
+  /**
+   * Creates an instance of Transceiver.
+   *
+   * Surface resolution follows the utils convention
+   * (`typeof network.enter === 'function' ? network : network._network`):
+   * pass anything exposing the envelope gate directly (a `Network`, or a
+   * `Channel` — entries then keep channel affinity), or a Kernel-shaped
+   * wrapper exposing `_network`. The resolved surface must support `enter`
+   * and `decorate`.
+   *
+   * Two decorations are registered: an `onForward` mirror on the underlying
+   * shared network (`surface._network || surface` — chained hops are
+   * observed there even when entries go through a Channel surface),
+   * self-filtered on `envelope.cascade.transceiverId`, mirroring matching
+   * chained AppCons onto the private signals network; and an `onReturn`
+   * settlement decoration on the signals network mapping signal-handler
+   * returns onto the Promise (see {@linkcode setAppCtx}).
+   *
+   * @param {(Kernel|Network|Channel)} network - the surface to wrap with a `Transceiver`
+   * @param {(string|function(number): (string|number))} [id] - pass either a desired Transceiver ID value as a `string` or a `function` that will be used to generate a Transceiver ID
+   *        the `function` will be called with a new Transceiver ID integer value to help ensure uniqueness
+   * @param {number} [timeoutMs=0] - a timeout to be used when awaiting `Promises`
+   *        - `0` - no timeout will be used
+   *        - `> 0` - timeout will be used to `reject` the `Promise` if it is not signaled in time
+   * @param {PromiseConstructor} [promise=Promise] - a `Promise` constructor to be used when creating promises
+   *        by a signalling method.
+   * @throws {Error} when the resolved surface lacks envelope support
+   *         (`enter` + `decorate`) - upgrade `@tao.js/core`
+   * @memberof Transceiver
+   */
   constructor(network, id, timeoutMs = 0, promise = Promise) {
     this._transceiverId =
       typeof id === 'function'
@@ -92,6 +145,17 @@ export default class Transceiver {
     this._cloneWithId = typeof id === 'function' ? id : undefined;
   }
 
+  /**
+   * Builds an AppCtx from a trigram + datagram (long-form keys win) and
+   * signals it via {@linkcode setAppCtx}.
+   *
+   * @param {Trigram} trigram
+   * @param {*} data - datagram(s) for the signal
+   * @param {Object} [opts] - as {@linkcode setAppCtx}
+   * @param {(Object|null)} [opts.chain] - prior chain state to continue
+   * @returns {Promise<*>} as {@linkcode setAppCtx}
+   * @memberof Transceiver
+   */
   setCtx = ({ t, term, a, action, o, orient }, data, opts) => {
     return this.setAppCtx(
       new AppCtx(term || t, action || a, orient || o, data),
@@ -100,11 +164,29 @@ export default class Transceiver {
   };
 
   /**
+   * Enters the AppCtx on the wrapped surface with this Transceiver's
+   * `{ transceiverId, signal }` cascade tag — the cascade (control) object
+   * is one shared reference for the whole cascade, so descendants of the
+   * entry are mirrored onto the signals network wherever the chain goes.
+   *
+   * Settlement semantics: signal handlers observe the mirrored descendants
+   * (never the entry hop itself) and their non-AppCtx returns settle the
+   * Promise through the signals network's `onReturn` hook — phase mapping:
+   * INTERCEPT (truthy return) and ERROR (thrown error / rejected async)
+   * reject; ASYNC and INLINE (non-null return) resolve. First settlement
+   * wins: it stamps `signalled` on the shared cascade and later returns are
+   * ignored. AppCtx returns chain like any handler's (continuing the
+   * cascade through the main network's hop engine) instead of settling.
+   * With no settling handler the Promise stays pending unless a `timeoutMs`
+   * was configured.
+   *
    * @param {AppCtx} ac
    * @param {Object} [opts]
-   * @param {Object} [opts.chain] - prior chain state to continue (e.g. a
+   * @param {(Object|null)} [opts.chain] - prior chain state to continue (e.g. a
    *        remote trace received over a transport — ENVELOPE-SPEC.md §9)
-   * @returns {Promise} settled by the attached signal handlers
+   * @returns {Promise<*>} settled by the attached signal handlers; rejects
+   *          with the string `reached timeout of: <ms>ms` when a
+   *          `timeoutMs` was configured and no settlement arrived in time
    * @memberof Transceiver
    */
   setAppCtx = (ac, { chain = null } = {}) => {
@@ -141,10 +223,31 @@ export default class Transceiver {
     }
   }
 
+  /**
+   * Attaches a signal handler — an InlineHandler on the private signals
+   * network, alias of {@linkcode addInlineHandler} — for matching AppCons
+   * mirrored to this Transceiver. Its return value settles the Promise as
+   * described on {@linkcode setAppCtx}; remove with
+   * {@linkcode removeInlineHandler}.
+   *
+   * @param {Trigram} trigram
+   * @param {SignalHandler} handler
+   * @returns {void}
+   * @memberof Transceiver
+   */
   addSignalHandler = ({ t, term, a, action, o, orient }, handler) => {
     this._signals.addInlineHandler({ t, term, a, action, o, orient }, handler);
   };
 
+  /**
+   * Attaches an InterceptHandler to the private signals network — a truthy
+   * non-AppCtx return rejects the Promise; a thrown error rejects it.
+   *
+   * @param {Trigram} trigram
+   * @param {SignalHandler} handler
+   * @returns {void}
+   * @memberof Transceiver
+   */
   addInterceptHandler({ t, term, a, action, o, orient }, handler) {
     this._signals.addInterceptHandler(
       { t, term, a, action, o, orient },
@@ -152,14 +255,41 @@ export default class Transceiver {
     );
   }
 
+  /**
+   * Attaches an AsyncHandler to the private signals network — a non-null
+   * non-AppCtx return resolves the Promise; a thrown error or rejection
+   * rejects it.
+   *
+   * @param {Trigram} trigram
+   * @param {SignalHandler} handler
+   * @returns {void}
+   * @memberof Transceiver
+   */
   addAsyncHandler({ t, term, a, action, o, orient }, handler) {
     this._signals.addAsyncHandler({ t, term, a, action, o, orient }, handler);
   }
 
+  /**
+   * Attaches an InlineHandler to the private signals network — a non-null
+   * non-AppCtx return resolves the Promise; a thrown error rejects it.
+   *
+   * @param {Trigram} trigram
+   * @param {SignalHandler} handler
+   * @returns {void}
+   * @memberof Transceiver
+   */
   addInlineHandler({ t, term, a, action, o, orient }, handler) {
     this._signals.addInlineHandler({ t, term, a, action, o, orient }, handler);
   }
 
+  /**
+   * Removes an InterceptHandler previously attached for the same trigram.
+   *
+   * @param {Trigram} trigram
+   * @param {SignalHandler} handler
+   * @returns {void}
+   * @memberof Transceiver
+   */
   removeInterceptHandler({ t, term, a, action, o, orient }, handler) {
     this._signals.removeInterceptHandler(
       { t, term, a, action, o, orient },
@@ -167,6 +297,14 @@ export default class Transceiver {
     );
   }
 
+  /**
+   * Removes an AsyncHandler previously attached for the same trigram.
+   *
+   * @param {Trigram} trigram
+   * @param {SignalHandler} handler
+   * @returns {void}
+   * @memberof Transceiver
+   */
   removeAsyncHandler({ t, term, a, action, o, orient }, handler) {
     this._signals.removeAsyncHandler(
       { t, term, a, action, o, orient },
@@ -174,6 +312,15 @@ export default class Transceiver {
     );
   }
 
+  /**
+   * Removes an InlineHandler previously attached for the same trigram
+   * (including handlers attached via {@linkcode addSignalHandler}).
+   *
+   * @param {Trigram} trigram
+   * @param {SignalHandler} handler
+   * @returns {void}
+   * @memberof Transceiver
+   */
   removeInlineHandler({ t, term, a, action, o, orient }, handler) {
     this._signals.removeInlineHandler(
       { t, term, a, action, o, orient },

--- a/packages/tao-utils/src/Transponder.js
+++ b/packages/tao-utils/src/Transponder.js
@@ -14,6 +14,19 @@ function transponderControl(transponderId, signal) {
 }
 
 /**
+ * A trigram in short (`t`/`a`/`o`) or long (`term`/`action`/`orient`) keys;
+ * long-form keys win.
+ *
+ * @typedef {Object} Trigram
+ * @property {string} [t] - term (short key)
+ * @property {string} [term] - term (long key)
+ * @property {string} [a] - action (short key)
+ * @property {string} [action] - action (long key)
+ * @property {string} [o] - orient (short key)
+ * @property {string} [orient] - orient (long key)
+ */
+
+/**
  * Allows use of Promises with a Network by returning a Promise from a signalling method
  * that will only resolve based on one of the handlers attached to the wrapped Network
  * being called.
@@ -26,8 +39,10 @@ function transponderControl(transponderId, signal) {
  *
  * Implemented as an `onDispatch` decoration on the wrapped surface (a raw
  * Network/Kernel network, or a Channel's private network via
- * `Channel.decorate`). The transponder tag rides the cascade scope of the
- * envelope, so it survives every hop of a chain (see ENVELOPE-SPEC.md).
+ * `Channel.decorate`), self-filtered on `envelope.cascade.transponderId`.
+ * The transponder tag rides the cascade scope of the envelope, so it
+ * survives every hop of a chain (see ENVELOPE-SPEC.md); resolve-once is
+ * enforced by stamping `signalled` on the shared cascade reference.
  *
  * @export
  * @class Transponder
@@ -35,16 +50,27 @@ function transponderControl(transponderId, signal) {
 export default class Transponder {
   /**
    *Creates an instance of Transponder.
-   * @param {Network} network - the `Network` to wrap with a `Transponder`
-   * @param {(string|function)} [id] - pass either a desired Channel ID value as a `string` or a `function` that will be used to generate a Channel ID
-   *        the `function` will be called with a new Channel ID integer value to help ensure uniqueness
+   *
+   * Surface resolution follows the utils convention
+   * (`typeof network.enter === 'function' ? network : network._network`):
+   * pass anything exposing the envelope gate directly (a `Network`, or a
+   * `Channel` — whose `enter`/`decorate` scope this Transponder to the
+   * channel), or a Kernel-shaped wrapper exposing `_network`. The resolved
+   * surface must support `enter` and `decorate`.
+   *
+   * @param {(Kernel|Network|Channel)} network - the surface to wrap with a `Transponder`
+   * @param {(string|function(number): (string|number))} [id] - pass either a desired Transponder ID value as a `string` or a `function` that will be used to generate a Transponder ID
+   *        the `function` will be called with a new Transponder ID integer value to help ensure uniqueness
    * @param {number} [timeoutMs=0] - a timeout to be used when awaiting `Promises`
    *        - `0` - no timeout will be used
    *        - `> 0` - timeout will be used to `reject` the `Promise` if it is not signaled in time
    *        - use this to prevent unexpected behaviors
-   * @param {Thenable} [promise=Promise] - a `Promise` constructor to be used when creating promises
+   *        - negative and non-numeric values clamp to `0`
+   * @param {PromiseConstructor} [promise=Promise] - a `Promise` constructor to be used when creating promises
    *        by a signalling method.
    * @param {boolean} [debug=false] - pass true to console.log internal activity
+   * @throws {Error} when the resolved surface lacks envelope support
+   *         (`enter` + `decorate`) - upgrade `@tao.js/core`
    * @memberof Transponder
    */
   constructor(network, id, timeoutMs = 0, promise = Promise, debug = false) {
@@ -78,6 +104,17 @@ export default class Transponder {
     this._cloneWithId = typeof id === 'function' ? id : undefined;
   }
 
+  /**
+   * Clones a Transponder on the same wrapped surface with the same timeout,
+   * Promise constructor and debug settings. The clone registers its own
+   * decoration under its own Transponder ID.
+   *
+   * @param {(string|function(number): (string|number))} [cloneId] - used as the cloned
+   *        `Transponder`'s ID, same as the `id` param to the constructor;
+   *        falls back to the constructor's `id` generator when one was given
+   * @returns {Transponder} the cloned Transponder
+   * @memberof Transponder
+   */
   clone(cloneId) {
     const clone = new Transponder(
       this._network,
@@ -101,7 +138,7 @@ export default class Transponder {
    *
    * @see {@link detach}
    *
-   * @returns this
+   * @returns {Transponder} this
    * @memberof Transponder
    */
   attach() {
@@ -120,7 +157,7 @@ export default class Transponder {
    *
    * @see {@link attach()}
    *
-   * @returns this
+   * @returns {Transponder} this
    * @memberof Transponder
    */
   detach() {
@@ -131,6 +168,17 @@ export default class Transponder {
     return this;
   }
 
+  /**
+   * Builds an AppCtx from a trigram + datagram (long-form keys win) and
+   * signals it via {@linkcode setAppCtx}.
+   *
+   * @param {Trigram} trigram
+   * @param {*} data - datagram(s) for the signal
+   * @param {Object} [opts] - as {@linkcode setAppCtx}
+   * @param {(Object|null)} [opts.chain] - prior chain state to continue
+   * @returns {Promise<AppCtx>} as {@linkcode setAppCtx}
+   * @memberof Transponder
+   */
   setCtx({ t, term, a, action, o, orient }, data, opts) {
     return this.setAppCtx(
       new AppCtx(term || t, action || a, orient || o, data),
@@ -139,11 +187,28 @@ export default class Transponder {
   }
 
   /**
+   * Enters the AppCtx on the wrapped surface with this Transponder's
+   * `{ transponderId, signal }` cascade tag — the cascade (control) object
+   * is one shared reference for the whole cascade, so the tag survives
+   * every hop of a chain.
+   *
+   * Resolution semantics: the Promise resolves with the first AppCon the
+   * Transponder's decoration observes dispatching for this cascade — the
+   * first handled AppCon of the cascade. Attached to a bare Network/Kernel
+   * that is the entered AppCtx itself; attached to a Channel (the
+   * decoration observes the channel's private network) it is the first
+   * descendant mirrored onto the channel — the entry hop itself is not
+   * mirrored. Resolve-once: the first signal stamps `signalled` on the
+   * shared cascade, so later dispatches of the same cascade never signal
+   * again and the Promise settles at most once.
+   *
    * @param {AppCtx} ac
    * @param {Object} [opts]
-   * @param {Object} [opts.chain] - prior chain state to continue (e.g. a
+   * @param {(Object|null)} [opts.chain] - prior chain state to continue (e.g. a
    *        remote trace received over a transport — ENVELOPE-SPEC.md §9)
-   * @returns {Promise} resolves with the first handled AppCon of the cascade
+   * @returns {Promise<AppCtx>} resolves with the first handled AppCon of the
+   *          cascade; rejects with the string `reached timeout of: <ms>ms`
+   *          when a `timeoutMs` was configured and no signal arrived in time
    * @memberof Transponder
    */
   setAppCtx(ac, { chain = null } = {}) {
@@ -164,6 +229,18 @@ export default class Transponder {
     });
   }
 
+  /**
+   * `onDispatch` decoration callback: signals the awaiting Promise with the
+   * first dispatched AppCon of a matching cascade. Self-filtered on
+   * `control.transponderId`; resolve-once is enforced by stamping
+   * `signalled` on the shared cascade control.
+   *
+   * @param {AppCtx} ac
+   * @param {Object} control - the envelope's cascade scope
+   *        (`{ transponderId, signal, signalled }`)
+   * @returns {void}
+   * @memberof Transponder
+   */
   handleSignalAppCon = (ac, control) => {
     // Stryker disable all: optional debug logging
     this._debug &&

--- a/packages/tao-utils/src/bridge.js
+++ b/packages/tao-utils/src/bridge.js
@@ -51,14 +51,63 @@ function bridge(type, source, destination, filters) {
     filters.forEach((trigrams) => source[detachment](trigrams, handler));
 }
 
+/**
+ * Bridges signals handled on the `source` Kernel into the `destination`
+ * Kernel via an `InterceptHandler` — the forwarded signal re-enters the
+ * destination through `setCtx` (or `setAppCtx` for AppCtx values). The
+ * bridging handler returns nothing, so an intercept bridge observes without
+ * halting the source cascade.
+ *
+ * @export
+ * @param {Kernel} source - the Kernel to bridge signals from
+ * @param {Kernel} destination - the Kernel to bridge signals into
+ * @param {...*} filters - optional leading filter function
+ *        `(tao, data) => boolean` gating which signals forward, then
+ *        trigrams (or a single array of trigrams) to bridge; with no
+ *        trigrams the bridge attaches to the wildcard `{}`
+ * @returns {function(): void} detaches the bridge from `source` (a no-op
+ *          when `source`/`destination` are not Kernel instances)
+ */
 export function interceptBridge(source, destination, ...filters) {
   return bridge(INTERCEPT, source, destination, filters);
 }
 
+/**
+ * Bridges signals handled on the `source` Kernel into the `destination`
+ * Kernel via an `AsyncHandler` — the forwarded signal re-enters the
+ * destination through `setCtx` (or `setAppCtx` for AppCtx values) on the
+ * async fork of the source cascade.
+ *
+ * @export
+ * @param {Kernel} source - the Kernel to bridge signals from
+ * @param {Kernel} destination - the Kernel to bridge signals into
+ * @param {...*} filters - optional leading filter function
+ *        `(tao, data) => boolean` gating which signals forward, then
+ *        trigrams (or a single array of trigrams) to bridge; with no
+ *        trigrams the bridge attaches to the wildcard `{}`
+ * @returns {function(): void} detaches the bridge from `source` (a no-op
+ *          when `source`/`destination` are not Kernel instances)
+ */
 export function asyncBridge(source, destination, ...filters) {
   return bridge(ASYNC, source, destination, filters);
 }
 
+/**
+ * Bridges signals handled on the `source` Kernel into the `destination`
+ * Kernel via an `InlineHandler` — the forwarded signal re-enters the
+ * destination through `setCtx` (or `setAppCtx` for AppCtx values) in the
+ * source cascade's inline spool.
+ *
+ * @export
+ * @param {Kernel} source - the Kernel to bridge signals from
+ * @param {Kernel} destination - the Kernel to bridge signals into
+ * @param {...*} filters - optional leading filter function
+ *        `(tao, data) => boolean` gating which signals forward, then
+ *        trigrams (or a single array of trigrams) to bridge; with no
+ *        trigrams the bridge attaches to the wildcard `{}`
+ * @returns {function(): void} detaches the bridge from `source` (a no-op
+ *          when `source`/`destination` are not Kernel instances)
+ */
 export function inlineBridge(source, destination, ...filters) {
   return bridge(INLINE, source, destination, filters);
 }

--- a/packages/tao-utils/src/forward-chain.js
+++ b/packages/tao-utils/src/forward-chain.js
@@ -20,15 +20,14 @@ function forward(kernel, from, to, type, opts) {
  * automatically remove it from the kernel that was passed in
  *
  * @export
- * @param  {any} kernel a TAO Kernel (TAO) that can attach handlers and receive TAO signals
- * @param  {any} from trigram representing the Application Context to chain from
- * @param  {any} to trigram representing the Application Context to chain to
- * @param {{
- *   transformTerm: function,
- *   transformAction: function,
- *   transformOrient: function,
- * }} opts optional functions to transform the datagrams in the new AppCtx
- * @return {function} the handler so that it can be removed from the kernel if needed
+ * @param {Kernel} kernel a TAO Kernel (TAO) that can attach handlers and receive TAO signals
+ * @param {Object} from trigram representing the Application Context to chain from
+ * @param {Object} to trigram representing the Application Context to chain to
+ * @param {Object} [opts] optional functions to transform the datagrams in the new AppCtx
+ * @param {function(*): *} [opts.transformTerm] transforms the term datagram
+ * @param {function(*): *} [opts.transformAction] transforms the action datagram
+ * @param {function(*): *} [opts.transformOrient] transforms the orient datagram
+ * @return {function(Object, Object): AppCtx} the handler (also exposing `.remove()`) so that it can be removed from the kernel if needed
  */
 export function forwardInline(kernel, from, to, opts) {
   return forward(kernel, from, to, INLINE, opts);
@@ -45,15 +44,14 @@ export function forwardInline(kernel, from, to, opts) {
  * automatically remove it from the kernel that was passed in
  *
  * @export
- * @param  {any} kernel a TAO Kernel (TAO) that can attach handlers and receive TAO signals
- * @param  {any} from trigram representing the Application Context to chain from
- * @param  {any} to trigram representing the Application Context to chain to
- * @param {{
- *   transformTerm: function,
- *   transformAction: function,
- *   transformOrient: function,
- * }} opts optional functions to transform the datagrams in the new AppCtx
- * @return {function} the handler so that it can be removed from the kernel if needed
+ * @param {Kernel} kernel a TAO Kernel (TAO) that can attach handlers and receive TAO signals
+ * @param {Object} from trigram representing the Application Context to chain from
+ * @param {Object} to trigram representing the Application Context to chain to
+ * @param {Object} [opts] optional functions to transform the datagrams in the new AppCtx
+ * @param {function(*): *} [opts.transformTerm] transforms the term datagram
+ * @param {function(*): *} [opts.transformAction] transforms the action datagram
+ * @param {function(*): *} [opts.transformOrient] transforms the orient datagram
+ * @return {function(Object, Object): AppCtx} the handler (also exposing `.remove()`) so that it can be removed from the kernel if needed
  */
 export function forwardAsync(kernel, from, to, opts) {
   return forward(kernel, from, to, ASYNC, opts);
@@ -70,15 +68,14 @@ export function forwardAsync(kernel, from, to, opts) {
  * automatically remove it from the kernel that was passed in
  *
  * @export
- * @param  {any} kernel a TAO Kernel (TAO) that can attach handlers and receive TAO signals
- * @param  {any} from trigram representing the Application Context to chain from
- * @param  {any} to trigram representing the Application Context to chain to
- * @param {{
- *   transformTerm: function,
- *   transformAction: function,
- *   transformOrient: function,
- * }} opts optional functions to transform the datagrams in the new AppCtx
- * @return {function} the handler so that it can be removed from the kernel if needed
+ * @param {Kernel} kernel a TAO Kernel (TAO) that can attach handlers and receive TAO signals
+ * @param {Object} from trigram representing the Application Context to chain from
+ * @param {Object} to trigram representing the Application Context to chain to
+ * @param {Object} [opts] optional functions to transform the datagrams in the new AppCtx
+ * @param {function(*): *} [opts.transformTerm] transforms the term datagram
+ * @param {function(*): *} [opts.transformAction] transforms the action datagram
+ * @param {function(*): *} [opts.transformOrient] transforms the orient datagram
+ * @return {function(Object, Object): AppCtx} the handler (also exposing `.remove()`) so that it can be removed from the kernel if needed
  */
 export function forwardIntercept(kernel, from, to, opts) {
   return forward(kernel, from, to, INTERCEPT, opts);

--- a/packages/tao-utils/src/seive.js
+++ b/packages/tao-utils/src/seive.js
@@ -15,6 +15,24 @@ function addControl(name, control) {
  * `destination` Channel's private network. Implemented as an `onDispatch`
  * decoration on the source network; chains from destination-channel
  * handlers continue the source cascade through the core hop engine.
+ *
+ * Clone-and-redirect: the destination entry carries a copy of the observed
+ * cascade with a `{ seive: name }` tag added (the source cascade object is
+ * never mutated), and passes the observed hop's `forward` continuation so
+ * chained AppCons re-join the source cascade.
+ *
+ * @param {(string|number)} name - seive tag stamped on redirected cascades
+ *        (`cascade.seive`) and used in the decoration's diagnostic name
+ * @param {Kernel} source - Kernel-shaped wrapper whose `_network` is a
+ *        `Network` to observe
+ * @param {Channel} destination - Channel whose private network (`_channel`)
+ *        receives the matching AppCons
+ * @param {...*} filters - optional leading filter function
+ *        `(ac: AppCtx, cascade: Object) => boolean`, then trigram filters as
+ *        `trigramFilter` accepts (optional `exact` boolean, then short-key
+ *        trigrams or a single array of trigrams)
+ * @returns {function(): void} dispose - detaches the decoration (a no-op
+ *          when `source`/`destination` are not the required shapes)
  */
 export default function seive(name, source, destination, ...filters) {
   if (

--- a/packages/tao-utils/src/transfer.js
+++ b/packages/tao-utils/src/transfer.js
@@ -1,19 +1,18 @@
 import { AppCtx } from '@tao.js/core';
 
-const IDENTITY = val => val;
+const IDENTITY = (val) => val;
 
 /**
  * Transfer the trigram and datagrams into a new Signal as an AppCtx
  *
- * @param {*} tao signal trigram that you want to transfer from
- * @param {*} data signal datagram that you want to transfer from
- * @param {*} to signal trigram that you want to transfer to - any missing trigram (t, a, or o) will use the value from the `tao` argument
- * @param {{
- *   transformTerm: function,
- *   transformAction: function,
- *   transformOrient: function,
- * }} options optional functions to transform the datagrams in the new AppCtx
- * @returns AppCtx with the trigram of the `to` argument and the data from the `data` argument
+ * @param {Object} tao signal trigram that you want to transfer from (short `t`/`a`/`o` keys)
+ * @param {Object} data signal datagram that you want to transfer from
+ * @param {Object} to signal trigram that you want to transfer to - any missing trigram (t, a, or o) will use the value from the `tao` argument
+ * @param {Object} [options] optional functions to transform the datagrams in the new AppCtx
+ * @param {function(*): *} [options.transformTerm] transforms the term datagram
+ * @param {function(*): *} [options.transformAction] transforms the action datagram
+ * @param {function(*): *} [options.transformOrient] transforms the orient datagram
+ * @returns {AppCtx} AppCtx with the trigram of the `to` argument and the data from the `data` argument
  */
 export function transferToAppCtx(
   tao,
@@ -22,8 +21,8 @@ export function transferToAppCtx(
   {
     transformTerm = IDENTITY,
     transformAction = IDENTITY,
-    transformOrient = IDENTITY
-  } = {}
+    transformOrient = IDENTITY,
+  } = {},
 ) {
   const { t, term, a, action, o, orient } = to;
   return new AppCtx(
@@ -32,7 +31,7 @@ export function transferToAppCtx(
     o || orient || tao.o,
     transformTerm(data[tao.t]),
     transformAction(data[tao.a]),
-    transformOrient(data[tao.o])
+    transformOrient(data[tao.o]),
   );
 }
 
@@ -40,7 +39,7 @@ function buildErrorDatagram(tao, data, error) {
   const fail = {
     reason: typeof error === 'string' ? error : error.message,
     a: tao.a,
-    [tao.a]: data[tao.a]
+    [tao.a]: data[tao.a],
   };
   if (typeof error !== 'string') {
     fail.error = error;
@@ -55,16 +54,15 @@ function buildErrorDatagram(tao, data, error) {
  * Transfer the trigram, datagrams and an error into a new AppCtx that
  * signals the Error
  *
- * @param {*} tao signal trigram that you want to transfer from
- * @param {*} data signal datagram that you want to transfer from
- * @param {error | string} error error that is either an Error or a String message
- * @param {{
- *   action: string,
- *   transformTerm: function,
- *   transformAction: function,
- *   transformOrient: function,
- * }} options optional functions to transform the datagrams in the new AppCtx
- * @returns AppCtx with the trigram of the { `tao.t`, `action` [`'fail'`], `tao.o` }
+ * @param {Object} tao signal trigram that you want to transfer from (short `t`/`a`/`o` keys)
+ * @param {Object} data signal datagram that you want to transfer from
+ * @param {(Error|string)} error error that is either an Error or a String message
+ * @param {Object} [options] optional functions to transform the datagrams in the new AppCtx
+ * @param {string} [options.action='fail'] action used in the new trigram
+ * @param {function(*): *} [options.transformTerm] transforms the term datagram
+ * @param {function(*): *} [options.transformAction] transforms the error datagram built for the action
+ * @param {function(*): *} [options.transformOrient] transforms the orient datagram
+ * @returns {AppCtx} AppCtx with the trigram of the { `tao.t`, `action` [`'fail'`], `tao.o` }
  * argument and the datagrams from the `data` argument with the error
  */
 export function transferError(
@@ -75,8 +73,8 @@ export function transferError(
     action = 'fail',
     transformTerm = IDENTITY,
     transformAction = IDENTITY,
-    transformOrient = IDENTITY
-  } = {}
+    transformOrient = IDENTITY,
+  } = {},
 ) {
   return transferToAppCtx(
     tao,
@@ -88,7 +86,7 @@ export function transferError(
         const fail = buildErrorDatagram(tao, data, error);
         return transformAction(fail);
       },
-      transformOrient
-    }
+      transformOrient,
+    },
   );
 }

--- a/packages/tao-utils/src/trigram-filter.js
+++ b/packages/tao-utils/src/trigram-filter.js
@@ -1,8 +1,19 @@
 import { AppCtx } from '@tao.js/core';
 
+/**
+ * Builds a predicate that tests whether a value is an `AppCtx` matching any
+ * of the given trigrams (wildcard-aware via `AppCtx.isMatch`, which reads
+ * short `t`/`a`/`o` keys only).
+ *
+ * @param {...*} trigrams - optional leading `exact` boolean (require exact
+ *        key equality — wildcards only match wildcards), then trigram
+ *        objects or a single array of trigrams; with none (or a leading
+ *        `null`) the predicate matches any `AppCtx`
+ * @returns {function(*): boolean} predicate over candidate AppCons
+ */
 export default function trigramFilter(...trigrams) {
   if (!trigrams.length || trigrams[0] == null) {
-    return ac => ac instanceof AppCtx;
+    return (ac) => ac instanceof AppCtx;
   }
   let exact = false;
   if (typeof trigrams[0] === 'boolean') {
@@ -11,10 +22,10 @@ export default function trigramFilter(...trigrams) {
   if (Array.isArray(trigrams[0])) {
     trigrams = trigrams[0];
   }
-  return ac => {
+  return (ac) => {
     if (!(ac instanceof AppCtx)) {
       return false;
     }
-    return trigrams.some(trigram => ac.isMatch(trigram, exact));
+    return trigrams.some((trigram) => ac.isMatch(trigram, exact));
   };
 }

--- a/packages/tao-utils/src/wire.js
+++ b/packages/tao-utils/src/wire.js
@@ -10,8 +10,20 @@ function transportName(name) {
 /**
  * Wire-envelope version. Receivers ignore wire envelopes with an unknown
  * version (treated as absent) rather than fail — see ENVELOPE-SPEC.md §9.
+ *
+ * @type {number}
  */
 export const WIRE_VERSION = 1;
+
+/**
+ * The portable part of a dispatch envelope — what a transport serializes
+ * alongside a signal's trigram + data (ENVELOPE-SPEC.md §9).
+ *
+ * @typedef {Object} WireEnvelope
+ * @property {number} v - wire-envelope version (`WIRE_VERSION`)
+ * @property {(Object|null)} chain - the sending hop's `envelope.chain`,
+ *           verbatim (JSON-clean by construction), or `null`
+ */
 
 /**
  * The portable part of a dispatch envelope, for serializing alongside a
@@ -19,8 +31,9 @@ export const WIRE_VERSION = 1;
  * `cascade` holds live references and process-local affinity, and `hop` is
  * boundary-local (ENVELOPE-SPEC.md §9).
  *
- * @param {Object} envelope - a dispatch envelope (`{ cascade, hop, chain }`)
- * @returns {{ v: number, chain: Object|null }}
+ * @param {Object} [envelope] - a dispatch envelope (`{ cascade, hop, chain }`)
+ * @returns {WireEnvelope} `{ v: WIRE_VERSION, chain }` — `chain` is `null`
+ *          when the envelope is absent or carries none
  */
 export function wireEnvelope(envelope) {
   return {
@@ -32,10 +45,11 @@ export function wireEnvelope(envelope) {
 /**
  * Extract the continuable chain from a received wire envelope. Absent,
  * unversioned, or unknown-version envelopes yield `null` (fresh chain) —
- * one-sided backward compatibility with pre-wire senders.
+ * one-sided backward compatibility with pre-wire senders. A `chain` that is
+ * not a plain object (arrays included) also yields `null`.
  *
- * @param {Object} [wire] - a received `{ v, chain }` wire envelope
- * @returns {Object|null}
+ * @param {WireEnvelope} [wire] - a received `{ v, chain }` wire envelope
+ * @returns {(Object|null)} the received chain to continue, or `null`
  */
 export function chainFromWire(wire) {
   if (
@@ -55,12 +69,17 @@ export function chainFromWire(wire) {
  * hop-scope origin marker (echo suppression) and continues the received
  * chain through the local reducers.
  *
- * @param {Kernel|Network|Channel} network - any surface exposing `enter`
+ * Surface resolution follows the utils convention
+ * (`typeof network.enter === 'function' ? network : network._network`).
+ *
+ * @param {(Kernel|Network|Channel)} network - any surface exposing `enter`
  *        (or a Kernel exposing `_network`)
- * @param {Object} tao - trigram (short or long keys)
- * @param {Object} data - datagram
- * @param {Object} [wire] - the received `{ v, chain }` wire envelope
+ * @param {Object} tao - trigram (short or long keys; long-form keys win)
+ * @param {*} data - datagram(s)
+ * @param {(WireEnvelope|undefined)} wire - the received `{ v, chain }` wire
+ *        envelope; pass `undefined` when the sender included none
  * @param {string} sourceName - this transport's origin marker
+ * @returns {void}
  */
 export function enterFromWire(network, tao, data, wire, sourceName) {
   const net = typeof network.enter === 'function' ? network : network._network;
@@ -94,13 +113,20 @@ export function enterFromWire(network, tao, data, wire, sourceName) {
  * semantics. For a veto-respecting emitter (e.g. a per-client reply path),
  * decorate with `onProceed` directly — see `@tao.js/socket.io`.
  *
- * @param {Kernel|Network} kernel - the network to bridge. Not a Channel:
+ * @param {(Kernel|Network)} kernel - the network to bridge. Not a Channel:
  *        a duplex transport spans the whole kernel; channel-scoped reply
  *        paths belong to phase-gated emitters (see `@tao.js/socket.io`)
  * @param {Object} opts
  * @param {string} [opts.name] - origin-marker name (auto-generated if omitted)
- * @param {function} opts.send - `(tao, data, wire) => void` outbound emitter
- * @returns {{ name: string, receive: function, dispose: function }}
+ * @param {function(Object, *, WireEnvelope): void} opts.send -
+ *        `(tao, data, wire) => void` outbound emitter
+ * @returns {{ name: string, receive: function(Object, *, WireEnvelope=): void, dispose: function(): void }}
+ *          the transport handle: `name` is the origin marker, `receive`
+ *          enters an inbound signal (as `enterFromWire`), `dispose`
+ *          detaches the emitting decoration
+ * @throws {Error} when `kernel` is missing, when the resolved network lacks
+ *         envelope support (`enter` + `decorate`) - upgrade `@tao.js/core`,
+ *         or when `send` is not a function
  */
 export function createTransport(kernel, { name, send } = {}) {
   if (!kernel || (typeof kernel.enter !== 'function' && !kernel._network)) {

--- a/packages/tao/src/AppCtx.js
+++ b/packages/tao/src/AppCtx.js
@@ -1,5 +1,18 @@
 import AppCtxRoot from './AppCtxRoot';
 
+/**
+ * Build the datum object from constructor data args: a single array spreads
+ * as positional `[term, action, orient]` data; a single non-array object is
+ * checked for tuple keys (`term`/`t`, `action`/`a`, `orient`/`o`, or the
+ * actual part names) and extracted per part when found, otherwise keyed
+ * whole under the term name; multiple args are positional per part.
+ *
+ * @param {string} term - the trigram's term (datum key for term data)
+ * @param {string} action - the trigram's action (datum key for action data)
+ * @param {string} orient - the trigram's orient (datum key for orient data)
+ * @param {...*} data - the raw data args
+ * @returns {Object} datum keyed by the trigram's part names (may be empty)
+ */
 function _cleanDatum(term, action, orient, ...data) {
   const datum = {};
   // Stryker disable next-line all: empty data still yields {} via the positional path below
@@ -104,7 +117,21 @@ function _cleanDatum(term, action, orient, ...data) {
 //   }
 // }
 
+/**
+ * A concrete Application Context (AppCon): a trigram plus the data it
+ * carries. Setting an AppCtx on a Kernel/Network runs matching handlers,
+ * which receive `(tao, data)` built from this instance; handlers chain by
+ * returning another AppCtx.
+ */
 export default class AppCtx extends AppCtxRoot {
+  /**
+   * @param {string} [term] - the thing (missing = WILDCARD)
+   * @param {string} [action] - the operation (missing = WILDCARD)
+   * @param {string} [orient] - the perspective (missing = WILDCARD)
+   * @param {...*} data - context data; see `_cleanDatum` for the inference
+   *        rules (single object → tuple-key extraction or keyed under the
+   *        term name; array or multiple args → positional per part)
+   */
   constructor(term, action, orient, ...data) {
     super(term, action, orient);
     // TODO: figure out how to deal with associated AppCon data <-- what did I mean by this?
@@ -112,10 +139,17 @@ export default class AppCtx extends AppCtxRoot {
     this.datum = _cleanDatum(term, action, orient, ...data);
   }
 
+  /** The context's data — always an object, possibly empty. @returns {Object} */
   get data() {
     return this.datum;
   }
 
+  /**
+   * The trigram as a plain object.
+   * @param {boolean} [verbose=false] - long keys (`{term, action, orient}`)
+   *        instead of short (`{t, a, o}`)
+   * @returns {{t: string, a: string, o: string}|{term: string, action: string, orient: string}}
+   */
   unwrapCtx(verbose = false) {
     return !verbose
       ? { t: this.t, a: this.a, o: this.o }

--- a/packages/tao/src/AppCtxHandlers.js
+++ b/packages/tao/src/AppCtxHandlers.js
@@ -3,12 +3,45 @@ import AppCtx from './AppCtx';
 import { INTERCEPT, ASYNC, INLINE, ERROR } from './constants';
 import { isIterable } from './utils';
 
+/** @typedef {import('./Network').Forward} Forward */
+
+/**
+ * A TAO handler: receives the concrete trigram (short keys) and the
+ * signal's data (always an object, possibly empty). Returning — or
+ * resolving to — an AppCtx chains that context onto the cascade. Other
+ * returns are phase-dependent: a truthy intercept return halts the signal;
+ * non-null async/inline returns go to settlement (`onReturn`) when hooks
+ * are attached, and are otherwise discarded.
+ *
+ * @callback Handler
+ * @param {{t: string, a: string, o: string}} tao - the trigram being handled
+ * @param {Object} data - the context data (never null/undefined)
+ * @returns {AppCtx|Promise<AppCtx>|*}
+ */
+
+/**
+ * Local no-op console standing in for the loop's debug logging.
+ * @type {{error: (...args: any[]) => void, log: (...args: any[]) => void}}
+ */
 const console = {
   error: () => 1,
   log: () => 1,
 };
 
+/**
+ * The handler group for one trigram key: holds the intercept/async/inline
+ * handler sets and runs the three-phase dispatch for matching AppCons.
+ * Wildcard groups track their concrete "leaf" groups and propagate handler
+ * add/remove to them, so dispatch only ever executes a concrete group.
+ */
 export default class AppCtxHandlers extends AppCtxRoot {
+  /**
+   * @param {string} [term] - the term (missing = WILDCARD)
+   * @param {string} [action] - the action (missing = WILDCARD)
+   * @param {string} [orient] - the orient (missing = WILDCARD)
+   * @param {Iterable<AppCtxHandlers>} [leafAppConHandlers] - initial concrete
+   *        leaf groups this (wildcard) group propagates its handlers to
+   */
   constructor(term, action, orient, leafAppConHandlers) {
     super(term, action, orient);
 
@@ -18,6 +51,13 @@ export default class AppCtxHandlers extends AppCtxRoot {
     this._inline = new Set();
   }
 
+  /**
+   * Track a concrete leaf group under this wildcard group (no-op unless this
+   * group is wild, the leaf is concrete, and the leaf matches this trigram)
+   * and copy this group's current handlers onto it.
+   * @param {AppCtxHandlers} leafAch
+   * @throws {Error} when `leafAch` is not an AppCtxHandlers
+   */
   addLeafHandler(leafAch) {
     if (!(leafAch instanceof AppCtxHandlers)) {
       throw new Error("'leafAch' is not an instance of AppCtxHandlers");
@@ -39,6 +79,10 @@ export default class AppCtxHandlers extends AppCtxRoot {
     }
   }
 
+  /**
+   * Add one leaf group or an iterable of them via {@link AppCtxHandlers#addLeafHandler}.
+   * @param {AppCtxHandlers|Iterable<AppCtxHandlers>} leafAches
+   */
   addLeafHandlers(leafAches) {
     if (!isIterable(leafAches)) {
       this.addLeafHandler(leafAches);
@@ -49,6 +93,11 @@ export default class AppCtxHandlers extends AppCtxRoot {
     }
   }
 
+  /**
+   * Register an intercept-phase handler (propagates to leaf groups).
+   * @param {Handler} handler
+   * @throws {Error} when `handler` is not a function
+   */
   addInterceptHandler(handler) {
     if (typeof handler !== 'function') {
       throw new Error('An InterceptHandler can only be a function');
@@ -59,6 +108,10 @@ export default class AppCtxHandlers extends AppCtxRoot {
     );
   }
 
+  /**
+   * Unregister an intercept-phase handler (propagates to leaf groups).
+   * @param {Handler} handler
+   */
   removeInterceptHandler(handler) {
     this._intercept.delete(handler);
     this._leafAppConHandlers.forEach((leafAch) =>
@@ -66,6 +119,11 @@ export default class AppCtxHandlers extends AppCtxRoot {
     );
   }
 
+  /**
+   * Register an async-phase handler (propagates to leaf groups).
+   * @param {Handler} handler
+   * @throws {Error} when `handler` is not a function
+   */
   addAsyncHandler(handler) {
     if (typeof handler !== 'function') {
       throw new Error('An AsyncHandler can only be a function');
@@ -76,6 +134,10 @@ export default class AppCtxHandlers extends AppCtxRoot {
     );
   }
 
+  /**
+   * Unregister an async-phase handler (propagates to leaf groups).
+   * @param {Handler} handler
+   */
   removeAsyncHandler(handler) {
     this._async.delete(handler);
     this._leafAppConHandlers.forEach((leafAch) =>
@@ -83,6 +145,11 @@ export default class AppCtxHandlers extends AppCtxRoot {
     );
   }
 
+  /**
+   * Register an inline-phase handler (propagates to leaf groups).
+   * @param {Handler} handler
+   * @throws {Error} when `handler` is not a function
+   */
   addInlineHandler(handler) {
     if (typeof handler !== 'function') {
       throw new Error('An InlineHandler can only be a function');
@@ -93,6 +160,10 @@ export default class AppCtxHandlers extends AppCtxRoot {
     );
   }
 
+  /**
+   * Unregister an inline-phase handler (propagates to leaf groups).
+   * @param {Handler} handler
+   */
   removeInlineHandler(handler) {
     this._inline.delete(handler);
     this._leafAppConHandlers.forEach((leafAch) =>
@@ -103,14 +174,17 @@ export default class AppCtxHandlers extends AppCtxRoot {
   // Might need but removing to have accurate code coverage metric
   // populateHandlersFromWildcards() {}
 
+  /** The registered intercept handlers. @returns {IterableIterator<Handler>} */
   get interceptHandlers() {
     return this._intercept.values();
   }
 
+  /** The registered async handlers. @returns {IterableIterator<Handler>} */
   get asyncHandlers() {
     return this._async.values();
   }
 
+  /** The registered inline handlers. @returns {IterableIterator<Handler>} */
   get inlineHandlers() {
     return this._inline.values();
   }
@@ -129,6 +203,18 @@ export default class AppCtxHandlers extends AppCtxRoot {
    *
    * `setAppCtx` receives the producing phase as a third argument so the
    * hop engine can stamp `hop.via` on chained hops (§4).
+   *
+   * @param {AppCtx} ac - the Application Context to handle
+   * @param {Forward} setAppCtx - continuation for handler-chained AppCtxs
+   *        (the hop engine's forward, or an adapter override); called as
+   *        `setAppCtx(nextAc, control, phase)`
+   * @param {Object} control - the cascade scope (`envelope.cascade`), passed
+   *        through to `setAppCtx`
+   * @param {{onReturn?: (phase: string, value: any, ac: AppCtx) => void, onProceed?: () => void}} [hooks]
+   *        settlement hooks built by the Network from decorations
+   * @returns {Promise<void>} settles after the intercept and inline phases
+   *        complete (async handlers are forked, not awaited); rejects on a
+   *        dispatch error only when no `onReturn` hook is present
    */
   async handleAppCon(ac, setAppCtx, control, hooks) {
     const { t, a, o, data } = ac;
@@ -157,6 +243,21 @@ export default class AppCtxHandlers extends AppCtxRoot {
     }
   }
 
+  /**
+   * Run the three phases in order: await intercepts (halt/divert
+   * short-circuits), fork async handlers, await inline handlers, settle
+   * inline returns, then set the spooled chained AppCtxs.
+   *
+   * @param {AppCtx} ac - the Application Context being handled
+   * @param {Forward} setAppCtx - continuation for chained AppCtxs
+   * @param {Object} control - the cascade scope, threaded to `setAppCtx`
+   * @param {((phase: string, value: any, ac: AppCtx) => void)|null} onReturn - settlement sink
+   * @param {(() => void)|null} onProceed - intercept-phase-passed hook
+   * @param {string} t - the term (from `ac`)
+   * @param {string} a - the action (from `ac`)
+   * @param {string} o - the orient (from `ac`)
+   * @param {Object} data - the context data (from `ac`)
+   */
   async _handlePhases(
     ac,
     setAppCtx,

--- a/packages/tao/src/AppCtxRoot.js
+++ b/packages/tao/src/AppCtxRoot.js
@@ -1,36 +1,83 @@
 import { WILDCARD } from './constants';
 
+/**
+ * A trigram names an Application Context: the thing (term), the operation on
+ * it (action), and the perspective of the interaction (orient). Short
+ * (`t`/`a`/`o`) and long (`term`/`action`/`orient`) keys are interchangeable
+ * — supply one style per part. A missing, empty, or `'*'` part is a wildcard.
+ *
+ * @typedef {Object} Trigram
+ * @property {string} [t] - the term (short key)
+ * @property {string} [term] - the term: the domain thing
+ * @property {string} [a] - the action (short key)
+ * @property {string} [action] - the action: the operation on the term
+ * @property {string} [o] - the orient (short key)
+ * @property {string} [orient] - the orient: perspective / role / surface
+ */
+
+/**
+ * Whether a single trigram part is wild (missing, empty, or the WILDCARD).
+ * @param {string} [val] - the trigram part
+ * @returns {boolean}
+ */
 function isPartWild(val) {
   return !val || WILDCARD === val;
 }
 
+/**
+ * Base of the trigram-keyed classes: holds the three parts (missing parts
+ * become WILDCARD) and answers wildcard / matching questions. Key format:
+ * `` `${term}|${action}|${orient}` ``.
+ */
 export default class AppCtxRoot {
+  /**
+   * @param {string} [term] - the term (missing = WILDCARD)
+   * @param {string} [action] - the action (missing = WILDCARD)
+   * @param {string} [orient] - the orient (missing = WILDCARD)
+   */
   constructor(term, action, orient) {
     this._term = term || WILDCARD;
     this._action = action || WILDCARD;
     this._orient = orient || WILDCARD;
   }
 
+  /** The `term|action|orient` key for this trigram. @returns {string} */
   get key() {
     return AppCtxRoot.getKey(this._term, this._action, this._orient);
   }
 
+  /** The term. @returns {string} */
   get t() {
     return this._term;
   }
 
+  /** The action. @returns {string} */
   get a() {
     return this._action;
   }
 
+  /** The orient. @returns {string} */
   get o() {
     return this._orient;
   }
 
+  /**
+   * Build the `term|action|orient` key; missing parts become WILDCARD.
+   * @param {string} [term]
+   * @param {string} [action]
+   * @param {string} [orient]
+   * @returns {string}
+   */
   static getKey(term, action, orient) {
     return `${term || WILDCARD}|${action || WILDCARD}|${orient || WILDCARD}`;
   }
 
+  /**
+   * Whether any part of a trigram is wild (missing, empty, or WILDCARD).
+   * Both key styles are accepted; short keys win when both are present.
+   * @param {Trigram} [ac]
+   * @returns {boolean}
+   */
   // static isWildcard({ term = WILDCARD, action = WILDCARD, orient = WILDCARD } = {}) {
   static isWildcard(ac = {}) {
     const { t, term, a, action, o, orient } = ac;
@@ -50,10 +97,26 @@ export default class AppCtxRoot {
     );
   }
 
+  /**
+   * Whether every part of a trigram is concrete (no wildcards).
+   * @param {Trigram} [ac]
+   * @returns {boolean}
+   */
   static isConcrete(ac = {}) {
     return !AppCtxRoot.isWildcard(ac);
   }
 
+  /**
+   * Whether an AppCtx(-like) matches a trigram, honoring wildcards on both
+   * sides unless `exact`. NOTE: `trigram` is read with short keys
+   * (`t`/`a`/`o`) only — long keys are not consulted here, so a
+   * long-key-only trigram is treated as all-wild.
+   *
+   * @param {AppCtxRoot|Trigram} ac - the context being tested (both key styles accepted)
+   * @param {{t: (string|undefined), a: (string|undefined), o: (string|undefined)}} trigram - the trigram to match against (short keys only)
+   * @param {boolean} [exact=false] - require exact key equality (wildcards only match wildcards)
+   * @returns {boolean}
+   */
   // TODO: write TESTS for this
   static isMatch(ac, trigram, exact = false) {
     // Stryker disable next-line ConditionalExpression: re-wrapping an AppCtxRoot is observationally identical
@@ -79,26 +142,37 @@ export default class AppCtxRoot {
     return matchTerm && matchAction && matchOrient;
   }
 
+  /** Whether the term is wild. @returns {boolean} */
   get isTermWild() {
     return isPartWild(this._term);
   }
 
+  /** Whether the action is wild. @returns {boolean} */
   get isActionWild() {
     return isPartWild(this._action);
   }
 
+  /** Whether the orient is wild. @returns {boolean} */
   get isOrientWild() {
     return isPartWild(this._orient);
   }
 
+  /** Whether any part is wild. @returns {boolean} */
   get isWildcard() {
     return this.isTermWild || this.isActionWild || this.isOrientWild;
   }
 
+  /** Whether every part is concrete. @returns {boolean} */
   get isConcrete() {
     return !this.isWildcard;
   }
 
+  /**
+   * Instance form of {@link AppCtxRoot.isMatch} with this as the context.
+   * @param {{t: (string|undefined), a: (string|undefined), o: (string|undefined)}} trigram - the trigram to match against (short keys only)
+   * @param {boolean} [exact=false]
+   * @returns {boolean}
+   */
   isMatch(trigram, exact = false) {
     return AppCtxRoot.isMatch(this, trigram, exact);
   }

--- a/packages/tao/src/Kernel.js
+++ b/packages/tao/src/Kernel.js
@@ -3,16 +3,38 @@ import AppCtxRoot from './AppCtxRoot';
 import AppCtx from './AppCtx';
 import { _cleanAC } from './utils';
 
+/** @typedef {import('./AppCtxRoot').Trigram} Trigram */
+/** @typedef {import('./AppCtxHandlers').Handler} Handler */
+
+/**
+ * The app-facing veneer over a Network: signal Application Contexts
+ * (`setCtx` / `setAppCtx`) and register handlers in the three phases
+ * (intercept / async / inline). The default export of @tao.js/core is a
+ * shared Kernel instance (`TAO`); create your own for isolation.
+ */
 export default class Kernel {
+  /**
+   * @param {boolean} [canSetWildcard=false] - allow wildcard AppCtxs to be
+   *        set on (and chained within) this kernel; otherwise they are
+   *        silently ignored
+   */
   constructor(canSetWildcard = false) {
     this._network = new Network(canSetWildcard);
     this._canSetWildcard = canSetWildcard;
   }
 
+  /** Whether wildcard AppCtxs may be set on this kernel. @returns {boolean} */
   get canSetWildcard() {
     return this._canSetWildcard;
   }
 
+  /**
+   * An independent Kernel whose Network has every handler registration
+   * copied; decorations on the underlying Network are not copied.
+   * @param {boolean} [canSetWildcard] - override for the clone; defaults to
+   *        this kernel's setting
+   * @returns {Kernel}
+   */
   clone(canSetWildcard) {
     const cloned = new Kernel(
       typeof canSetWildcard !== 'undefined'
@@ -23,6 +45,15 @@ export default class Kernel {
     return cloned;
   }
 
+  /**
+   * Signal an Application Context from trigram parts plus data. Wildcard
+   * trigrams are silently ignored unless the kernel `canSetWildcard`.
+   * @param {Trigram} trigram - both key styles accepted; long keys win
+   * @param {*} [data] - context data; a single object is keyed per the
+   *        AppCtx datum inference rules, an array is positional
+   *        `[term, action, orient]` data
+   * @returns {void}
+   */
   setCtx({ t, term, a, action, o, orient }, data) {
     // get the hash for the ac
     const acIn = _cleanAC({ t, term, a, action, o, orient });
@@ -34,6 +65,13 @@ export default class Kernel {
     this._network.enter(new AppCtx(acIn.term, acIn.action, acIn.orient, data));
   }
 
+  /**
+   * Signal an already-constructed AppCtx. Wildcard AppCtxs are silently
+   * ignored unless the kernel `canSetWildcard`.
+   * @param {AppCtx} appCtx
+   * @returns {void}
+   * @throws {Error} when `appCtx` is not an AppCtx instance
+   */
   setAppCtx(appCtx) {
     // Stryker disable next-line all: Network.enter throws the same error
     if (!(appCtx instanceof AppCtx)) {
@@ -47,6 +85,15 @@ export default class Kernel {
     this._network.enter(appCtx);
   }
 
+  /**
+   * Register an intercept-phase handler: runs first; a truthy return halts
+   * the signal, an AppCtx return diverts it. Omitted trigram parts are
+   * wildcards.
+   * @param {Trigram} trigram
+   * @param {Handler} handler
+   * @returns {Kernel} this
+   * @throws {Error} when `handler` is missing or not a function
+   */
   addInterceptHandler({ t, term, a, action, o, orient }, handler) {
     this._network.addInterceptHandler(
       { t, term, a, action, o, orient },
@@ -55,16 +102,41 @@ export default class Kernel {
     return this;
   }
 
+  /**
+   * Register an async-phase handler: forked outside the caller's
+   * synchronous flow after intercepts pass; may return an AppCtx to chain.
+   * Omitted trigram parts are wildcards.
+   * @param {Trigram} trigram
+   * @param {Handler} handler
+   * @returns {Kernel} this
+   * @throws {Error} when `handler` is missing or not a function
+   */
   addAsyncHandler({ t, term, a, action, o, orient }, handler) {
     this._network.addAsyncHandler({ t, term, a, action, o, orient }, handler);
     return this;
   }
 
+  /**
+   * Register an inline-phase handler: runs in the caller's execution
+   * context after async handlers are forked; returned AppCtxs are spooled,
+   * then set. Omitted trigram parts are wildcards.
+   * @param {Trigram} trigram
+   * @param {Handler} handler
+   * @returns {Kernel} this
+   * @throws {Error} when `handler` is missing or not a function
+   */
   addInlineHandler({ t, term, a, action, o, orient }, handler) {
     this._network.addInlineHandler({ t, term, a, action, o, orient }, handler);
     return this;
   }
 
+  /**
+   * Unregister an intercept-phase handler for a trigram.
+   * @param {Trigram} trigram
+   * @param {Handler} handler
+   * @returns {Kernel} this
+   * @throws {Error} when `handler` is missing or not a function
+   */
   removeInterceptHandler({ t, term, a, action, o, orient }, handler) {
     this._network.removeInterceptHandler(
       { t, term, a, action, o, orient },
@@ -73,6 +145,13 @@ export default class Kernel {
     return this;
   }
 
+  /**
+   * Unregister an async-phase handler for a trigram.
+   * @param {Trigram} trigram
+   * @param {Handler} handler
+   * @returns {Kernel} this
+   * @throws {Error} when `handler` is missing or not a function
+   */
   removeAsyncHandler({ t, term, a, action, o, orient }, handler) {
     this._network.removeAsyncHandler(
       { t, term, a, action, o, orient },
@@ -81,6 +160,13 @@ export default class Kernel {
     return this;
   }
 
+  /**
+   * Unregister an inline-phase handler for a trigram.
+   * @param {Trigram} trigram
+   * @param {Handler} handler
+   * @returns {Kernel} this
+   * @throws {Error} when `handler` is missing or not a function
+   */
   removeInlineHandler({ t, term, a, action, o, orient }, handler) {
     this._network.removeInlineHandler(
       { t, term, a, action, o, orient },

--- a/packages/tao/src/Network.js
+++ b/packages/tao/src/Network.js
@@ -4,7 +4,83 @@ import AppCtx from './AppCtx';
 import AppCtxHandlers from './AppCtxHandlers';
 import { _cleanAC, _validateHandler } from './utils';
 
+/** @typedef {import('./AppCtxRoot').Trigram} Trigram */
+/** @typedef {import('./AppCtxHandlers').Handler} Handler */
+
+/**
+ * The per-dispatch envelope (ENVELOPE-SPEC.md §4): three scopes with
+ * explicit lifetimes. Handlers never see it — only decorations and
+ * adapters do.
+ *
+ * @typedef {Object} Envelope
+ * @property {Object} cascade - cascade lifetime: one shared mutable
+ *           reference for the whole cascade (the `control` object).
+ *           Adapter affinity keys (`channelId`, transponder
+ *           `signal`/`signalled`, …) live here as top-level properties.
+ *           Never crosses a process boundary
+ * @property {Object} hop - single-hop lifetime, replaced on every hop:
+ *           entry hops carry caller-supplied values (e.g. `Source`'s
+ *           `source` echo-suppression marker) and never `via`; chained
+ *           hops carry `{ via }` — the phase constant that produced them.
+ *           Boundary-local
+ * @property {Object} chain - derived parent→child on each hop by the
+ *           registered reducers, keyed by reducer namespace.
+ *           JSON-serializable by design — the only scope that crosses a
+ *           process boundary (§9)
+ */
+
+/**
+ * Continuation that chains an AppCtx onto the current cascade — the hop
+ * engine's own forward, or the `enter()`/`mirror()` override. Handler
+ * returns are handed to it by `AppCtxHandlers.handleAppCon`; non-AppCtx
+ * values are ignored, and wildcard AppCtxs are dropped unless the network
+ * allows wildcards (parity with `Kernel.setAppCtx`).
+ *
+ * @callback Forward
+ * @param {AppCtx} chainedAc - the AppCtx to dispatch as the next hop
+ * @param {Object} [control] - legacy call-shape parity; ignored by the core
+ *        forward (the cascade is already threaded via the envelope)
+ * @param {string} [via] - the producing phase constant, stamped as
+ *        `hop.via` on the chained hop
+ * @returns {void}
+ */
+
+/**
+ * An additive, non-competitive Network decoration (ENVELOPE-SPEC.md §5).
+ * All capabilities are optional but at least one is required; a throwing
+ * decoration callback never breaks dispatch.
+ *
+ * @typedef {Object} DecorationSpec
+ * @property {string} [name] - diagnostic label
+ * @property {(ac: AppCtx, envelope: Envelope, handler: AppCtxHandlers, forward: Forward) => void} [onDispatch]
+ *           observe every dispatch; `forward(chainedAc)` continues this
+ *           hop's cascade through the core hop engine
+ * @property {(nextAc: AppCtx, envelope: Envelope, meta: {from: Envelope, forward: Forward}) => void} [onForward]
+ *           mirror/route a chained AppCon before core dispatches it;
+ *           `meta.from` is the producing hop's envelope and
+ *           `meta.forward(chainedAc)` continues the cascade from the
+ *           chained hop; must never re-enter the main dispatch
+ * @property {(phase: string, value: any, ac: AppCtx, envelope: Envelope) => void} [onReturn]
+ *           settle non-AppCtx handler returns and errors (phase is one of
+ *           the INTERCEPT/ASYNC/INLINE/ERROR constants)
+ * @property {(ac: AppCtx, envelope: Envelope) => void} [onProceed]
+ *           fires when the intercept phase passes without halting or
+ *           diverting, before async/inline run (veto-respecting emitters)
+ * @property {{key: string, next: (prev: any, ac: AppCtx, prevEnvelope: Envelope | null) => any}} [chain]
+ *           per-hop reducer for `envelope.chain[key]`; `next(prev, ac,
+ *           prevEnvelope)` receives the parent hop's value for `key` and
+ *           the parent hop's envelope (both empty/null at entry). Keys are
+ *           exclusive per network
+ */
+
 // Stryker disable all: multi-axis leaf/wildcard indexing is redundant; single-axis mutants are equivalent
+/**
+ * Collect leaf groups from one axis index into `leavesTo` — the groups
+ * under `taoism`, or every group when the part is wild.
+ * @param {Map<string, Set<AppCtxHandlers>>} leavesFrom - one axis of the leaf index
+ * @param {Set<AppCtxHandlers>} leavesTo - accumulator
+ * @param {string} [taoism] - the trigram part value (falsy = wild)
+ */
 function _appendLeaves(leavesFrom, leavesTo, taoism) {
   if (taoism) {
     if (leavesFrom.has(taoism) && leavesFrom.get(taoism).size) {
@@ -17,6 +93,13 @@ function _appendLeaves(leavesFrom, leavesTo, taoism) {
   }
 }
 
+/**
+ * Collect wildcard groups from one axis index into `wildcardsTo` — the
+ * groups under `taoism` plus the groups indexed under WILDCARD itself.
+ * @param {Map<string, Set<AppCtxHandlers>>} wildcardsFrom - one axis of the wildcard index
+ * @param {Set<AppCtxHandlers>} wildcardsTo - accumulator
+ * @param {string} taoism - the trigram part value
+ */
 function _appendWildcards(wildcardsFrom, wildcardsTo, taoism) {
   if (wildcardsFrom.has(taoism)) {
     wildcardsFrom.get(taoism).forEach((wc) => wildcardsTo.add(wc));
@@ -26,6 +109,12 @@ function _appendWildcards(wildcardsFrom, wildcardsTo, taoism) {
   }
 }
 
+/**
+ * Index a concrete group under one axis value of the leaf index.
+ * @param {Map<string, Set<AppCtxHandlers>>} leaves - one axis of the leaf index
+ * @param {string} taoism - the trigram part value
+ * @param {AppCtxHandlers} ach - the concrete group
+ */
 function _addLeaf(leaves, taoism, ach) {
   if (!leaves.has(taoism)) {
     leaves.set(taoism, new Set());
@@ -34,6 +123,12 @@ function _addLeaf(leaves, taoism, ach) {
 }
 // Stryker restore all
 
+/**
+ * Index a wildcard group under one axis value of the wildcard index.
+ * @param {Map<string, Set<AppCtxHandlers>>} wildcards - one axis of the wildcard index
+ * @param {string} taoism - the trigram part value (WILDCARD for a wild part)
+ * @param {AppCtxHandlers} ach - the wildcard group
+ */
 function _addWildcard(wildcards, taoism, ach) {
   if (!wildcards.has(taoism)) {
     wildcards.set(taoism, new Set());
@@ -41,6 +136,17 @@ function _addWildcard(wildcards, taoism, ach) {
   wildcards.get(taoism).add(ach);
 }
 
+/**
+ * Get or create the AppCtxHandlers group for a trigram, wiring the
+ * wildcard↔leaf cross-links on creation (a new wildcard group adopts all
+ * matching leaves; a new concrete group is adopted by matching wildcards).
+ * @param {Network} tao - the owning network (unused; kept for call-shape)
+ * @param {Map<string, AppCtxHandlers>} taoHandlers - groups by trigram key
+ * @param {{t: Map, a: Map, o: Map}} taoLeaves - per-axis leaf index
+ * @param {{t: Map, a: Map, o: Map}} taoWildcards - per-axis wildcard index
+ * @param {{term: (string|undefined), action: (string|undefined), orient: (string|undefined)}} trigram - long-key trigram (from `_cleanAC`)
+ * @returns {AppCtxHandlers}
+ */
 function _addACHandler(
   tao,
   taoHandlers,
@@ -86,6 +192,14 @@ function _addACHandler(
   return ach;
 }
 
+/**
+ * Remove a handler of the given phase from the group for a trigram, if
+ * that group exists.
+ * @param {Map<string, AppCtxHandlers>} taoHandlers - groups by trigram key
+ * @param {{term: (string|undefined), action: (string|undefined), orient: (string|undefined)}} trigram - long-key trigram (from `_cleanAC`)
+ * @param {Handler} handler
+ * @param {string} type - INTERCEPT, ASYNC, or INLINE constant
+ */
 function _removeHandler(taoHandlers, { term, action, orient }, handler, type) {
   _validateHandler(handler);
   // guard is currently impossible to hit so removing to get 100% test coverage
@@ -113,7 +227,19 @@ function _removeHandler(taoHandlers, { term, action, orient }, handler, type) {
 //   );
 // }
 
+/**
+ * The wiring surface of the TAO: a trigram-indexed handler registry plus
+ * the envelope hop engine. `enter()` is the only dispatch gate and
+ * `decorate()` the only extension surface (ENVELOPE-SPEC.md). Application
+ * code should use a Kernel; adapters (utils, bridges) compose against the
+ * Network.
+ */
 export default class Network {
+  /**
+   * @param {boolean} [canSetWildcard=false] - allow wildcard AppCtxs
+   *        chained by handlers to dispatch (parity with the owning
+   *        Kernel's setting); coerced to boolean
+   */
   constructor(canSetWildcard = false) {
     this._handlers = new Map();
     this._leaves = {
@@ -152,7 +278,10 @@ export default class Network {
    *
    * A throwing decorator callback never breaks dispatch.
    *
-   * @returns {function} dispose - removes the decoration
+   * @param {DecorationSpec} spec
+   * @returns {() => void} dispose - removes the decoration
+   * @throws {Error} on a malformed spec, a spec with no capability, or a
+   *         `chain.key` already reduced on this network
    * @memberof Network
    */
   decorate(spec) {
@@ -218,14 +347,17 @@ export default class Network {
    * @param {Object} [opts]
    * @param {Object} [opts.cascade] - shared for the whole cascade (the
    *        `control` object; same reference every hop)
-   * @param {Object} [opts.hop] - entry-hop values; hops after the entry get {}
-   * @param {Object} [opts.chain] - prior chain state to continue (e.g. from a
-   *        remote process); reducers derive the entry's chain from it
-   * @param {function} [opts.forward] - network-composition plumbing: routes
+   * @param {Object} [opts.hop] - entry-hop values; hops after the entry get
+   *        a fresh hop carrying only `via` (the producing phase)
+   * @param {?Object} [opts.chain] - prior chain state to continue (e.g.
+   *        from a remote process); reducers derive the entry's chain from it
+   * @param {Forward} [opts.forward] - network-composition plumbing: routes
    *        handler-returned AppCons to the given continuation instead of this
    *        network's own hop engine. Used by adapters that mirror a cascade
    *        onto a private network while its chains continue on the main one
    *        (Channel, Transceiver); not an application-level surface
+   * @returns {void}
+   * @throws {Error} when `appCtx` is not an AppCtx instance
    * @memberof Network
    */
   enter(appCtx, { cascade = {}, hop = {}, chain = null, forward } = {}) {
@@ -252,8 +384,10 @@ export default class Network {
    * should follow (normally the mirroring hop's `meta.forward`).
    *
    * @param {AppCtx} appCtx
-   * @param {Object} envelope - the observed `{ cascade, hop, chain }`
-   * @param {function} [forward]
+   * @param {Envelope} envelope - the observed `{ cascade, hop, chain }`
+   * @param {Forward} [forward]
+   * @returns {void}
+   * @throws {Error} when `appCtx` is not an AppCtx or `envelope` is missing
    * @memberof Network
    */
   mirror(appCtx, envelope, forward) {
@@ -270,6 +404,14 @@ export default class Network {
     );
   }
 
+  /**
+   * Run one hop: resolve (or lazily create) the handler group for the
+   * AppCtx's key, notify `onDispatch` decorations, then execute the phases.
+   * @param {AppCtx} appCtx
+   * @param {Envelope} envelope - this hop's envelope
+   * @param {Forward} [forward] - continuation override for chained AppCtxs;
+   *        defaults to this network's hop engine
+   */
   _dispatch(appCtx, envelope, forward) {
     const isWild = appCtx.isWildcard;
     if (!this._handlers.has(appCtx.key) && !isWild) {
@@ -293,6 +435,14 @@ export default class Network {
     handler.handleAppCon(appCtx, coreForward, envelope.cascade, hooks);
   }
 
+  /**
+   * The hop engine: derive the chained hop's envelope (shared cascade,
+   * `{ via }` hop, reduced chain), notify `onForward` decorations, then
+   * dispatch the chained AppCtx exactly once.
+   * @param {AppCtx} nextAc - the chained AppCtx (non-AppCtx values ignored)
+   * @param {Envelope} prevEnvelope - the producing hop's envelope
+   * @param {string} [via] - the phase constant that produced the chain
+   */
   _forwardNext(nextAc, prevEnvelope, via) {
     // guard parity with the legacy NOOP forward: handlers may hand the core
     // forward non-AppCtx values
@@ -327,6 +477,15 @@ export default class Network {
     this._dispatch(nextAc, nextEnvelope);
   }
 
+  /**
+   * Derive a hop's chain scope by running every registered reducer against
+   * the parent's value under its own key; a throwing reducer contributes
+   * nothing.
+   * @param {?Object} prevChain - the parent hop's chain (null at entry)
+   * @param {AppCtx} ac - the AppCtx being dispatched
+   * @param {?Envelope} prevEnvelope - the parent hop's envelope (null at entry)
+   * @returns {Object} the new chain, keyed by reducer namespace
+   */
   _reduceChain(prevChain, ac, prevEnvelope) {
     const next = {};
     for (const [key, reduceNext] of this._chainReducers) {
@@ -343,6 +502,15 @@ export default class Network {
     return next;
   }
 
+  /**
+   * Bridge `onReturn`/`onProceed` decorations into the settlement hooks
+   * `AppCtxHandlers.handleAppCon` accepts; undefined when no decoration
+   * needs them. Each decoration call is guarded — a throw never breaks
+   * dispatch.
+   * @param {AppCtx} appCtx - the AppCtx being dispatched
+   * @param {Envelope} envelope - this hop's envelope (appended to each call)
+   * @returns {{onReturn?: (phase: string, value: any, ac: AppCtx) => void, onProceed?: () => void}|undefined}
+   */
   _buildHooks(appCtx, envelope) {
     let settlers = null;
     let proceeders = null;
@@ -393,6 +561,14 @@ export default class Network {
     return hooks;
   }
 
+  /**
+   * Invoke every decoration's `onDispatch` in registration order, guarding
+   * against throws.
+   * @param {AppCtx} appCtx
+   * @param {Envelope} envelope
+   * @param {AppCtxHandlers} handler - the group about to execute
+   * @param {Forward} forward - the continuation for this hop's chains
+   */
   _notifyDispatch(appCtx, envelope, handler, forward) {
     for (const decorator of this._decorators) {
       // Stryker disable next-line ConditionalExpression: equivalent - calling a missing onDispatch throws inside the guarded try, so observable behavior is identical
@@ -406,6 +582,11 @@ export default class Network {
     }
   }
 
+  /**
+   * An independent Network with every handler registration copied across
+   * all three phases. Decorations and chain reducers are not copied.
+   * @returns {Network}
+   */
   clone() {
     const cloned = new Network(this._canSetWildcard);
     for (let trigram of this._handlers.values()) {
@@ -422,6 +603,14 @@ export default class Network {
     return cloned;
   }
 
+  /**
+   * Register an intercept-phase handler for a trigram (omitted parts are
+   * wildcards).
+   * @param {Trigram} trigram
+   * @param {Handler} handler
+   * @returns {Network} this
+   * @throws {Error} when `handler` is missing or not a function
+   */
   addInterceptHandler({ t, term, a, action, o, orient }, handler) {
     _validateHandler(handler);
     const ach = _addACHandler(
@@ -435,6 +624,14 @@ export default class Network {
     return this;
   }
 
+  /**
+   * Register an async-phase handler for a trigram (omitted parts are
+   * wildcards).
+   * @param {Trigram} trigram
+   * @param {Handler} handler
+   * @returns {Network} this
+   * @throws {Error} when `handler` is missing or not a function
+   */
   addAsyncHandler({ t, term, a, action, o, orient }, handler) {
     _validateHandler(handler);
     const ach = _addACHandler(
@@ -448,6 +645,14 @@ export default class Network {
     return this;
   }
 
+  /**
+   * Register an inline-phase handler for a trigram (omitted parts are
+   * wildcards).
+   * @param {Trigram} trigram
+   * @param {Handler} handler
+   * @returns {Network} this
+   * @throws {Error} when `handler` is missing or not a function
+   */
   addInlineHandler({ t, term, a, action, o, orient }, handler) {
     _validateHandler(handler);
     const ach = _addACHandler(
@@ -461,6 +666,15 @@ export default class Network {
     return this;
   }
 
+  /**
+   * Unregister a handler for a trigram from one phase, or from all three
+   * when `type` is omitted.
+   * @param {Trigram} trigram
+   * @param {Handler} handler
+   * @param {string} [type] - INTERCEPT, ASYNC, or INLINE constant
+   * @returns {Network} this
+   * @throws {Error} when `handler` is missing or not a function
+   */
   removeHandler({ t, term, a, action, o, orient }, handler, type) {
     const ac = _cleanAC({ t, term, a, action, o, orient });
     if (type) {
@@ -473,6 +687,13 @@ export default class Network {
     return this;
   }
 
+  /**
+   * Unregister an intercept-phase handler for a trigram.
+   * @param {Trigram} trigram
+   * @param {Handler} handler
+   * @returns {Network} this
+   * @throws {Error} when `handler` is missing or not a function
+   */
   removeInterceptHandler({ t, term, a, action, o, orient }, handler) {
     _removeHandler(
       this._handlers,
@@ -483,6 +704,13 @@ export default class Network {
     return this;
   }
 
+  /**
+   * Unregister an async-phase handler for a trigram.
+   * @param {Trigram} trigram
+   * @param {Handler} handler
+   * @returns {Network} this
+   * @throws {Error} when `handler` is missing or not a function
+   */
   removeAsyncHandler({ t, term, a, action, o, orient }, handler) {
     _removeHandler(
       this._handlers,
@@ -493,6 +721,13 @@ export default class Network {
     return this;
   }
 
+  /**
+   * Unregister an inline-phase handler for a trigram.
+   * @param {Trigram} trigram
+   * @param {Handler} handler
+   * @returns {Network} this
+   * @throws {Error} when `handler` is missing or not a function
+   */
   removeInlineHandler({ t, term, a, action, o, orient }, handler) {
     _removeHandler(
       this._handlers,

--- a/packages/tao/src/constants.js
+++ b/packages/tao/src/constants.js
@@ -1,5 +1,10 @@
+/** Trigram part that matches any value; a missing or empty part means the same. */
 export const WILDCARD = '*';
+/** Handler phase: runs first; a truthy return halts the signal, an AppCtx return diverts it. */
 export const INTERCEPT = 'Intercept';
+/** Handler phase: forked outside the caller's synchronous flow after intercepts pass. */
 export const ASYNC = 'Async';
+/** Handler phase: runs in the caller's execution context; returned AppCtxs spool, then set. */
 export const INLINE = 'Inline';
+/** Settlement phase reported to `onReturn` for thrown handler errors (not a handler phase). */
 export const ERROR = 'Error';

--- a/packages/tao/src/index.js
+++ b/packages/tao/src/index.js
@@ -1,8 +1,21 @@
+/**
+ * @tao.js/core — the TAO signal network.
+ *
+ * Applications are built as handlers attached to trigram-named Application
+ * Contexts (Term / Action / Orient). Setting an {@link AppCtx} on a
+ * {@link Kernel} (or the shared default `TAO`) runs matching handlers in
+ * three phases — `INTERCEPT`, `ASYNC`, `INLINE` — and handlers chain by
+ * returning another AppCtx. {@link Network} is the lower-level wiring
+ * surface (`enter()` + `decorate()`) for adapters; see ENVELOPE-SPEC.md.
+ *
+ * @module @tao.js/core
+ */
 import AppCtx from './AppCtx';
 import Network from './Network';
 import Kernel from './Kernel';
 export { INTERCEPT, ASYNC, INLINE, ERROR } from './constants';
 
+/** The shared default Kernel instance. */
 const TAO = new Kernel();
 export default TAO;
 export { AppCtx, Network, Kernel };

--- a/packages/tao/src/utils.js
+++ b/packages/tao/src/utils.js
@@ -1,4 +1,13 @@
+/** @typedef {import('./AppCtxRoot').Trigram} Trigram */
+/** @typedef {import('./AppCtxHandlers').Handler} Handler */
+
 // taken from http://stackoverflow.com/questions/18884249/checking-whether-something-is-iterable
+/**
+ * Whether a value is iterable — strings excluded on purpose (a string arg
+ * is a trigram part, never a collection).
+ * @param {*} obj
+ * @returns {obj is Iterable<any>}
+ */
 export function isIterable(obj) {
   // checks for null and undefined
   if (obj == null) {
@@ -10,6 +19,12 @@ export function isIterable(obj) {
   return typeof obj[Symbol.iterator] === 'function';
 }
 
+/**
+ * Normalize a trigram to long keys only; long keys win when both styles
+ * are present. Missing parts stay undefined (wild).
+ * @param {Trigram} ac
+ * @returns {{term: (string|undefined), action: (string|undefined), orient: (string|undefined)}}
+ */
 export function _cleanAC({ t, term, a, action, o, orient }) {
   return {
     term: term || t,
@@ -18,6 +33,11 @@ export function _cleanAC({ t, term, a, action, o, orient }) {
   };
 }
 
+/**
+ * Throw unless the handler is a function.
+ * @param {Handler} handler
+ * @throws {Error} when `handler` is missing or not a function
+ */
 export function _validateHandler(handler) {
   if (!handler) {
     throw new Error('cannot do anything with missing handler');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,7 +64,7 @@ importers:
         version: file:examples/patois.api(@tao.js/telemetry@file:packages/tao-telemetry(@tao.js/core@file:packages/tao))
       patois.web:
         specifier: file:examples/patois.web
-        version: link:examples/patois.web
+        version: file:examples/patois.web(@tao.js/telemetry@file:packages/tao-telemetry(@tao.js/core@file:packages/tao))(eslint@9.32.0(jiti@2.5.1))(prop-types@15.8.1)(typescript@5.9.3)
     devDependencies:
       '@babel/cli':
         specifier: 7.1.5
@@ -96,6 +96,9 @@ importers:
       '@babel/preset-react':
         specifier: 7.27.1
         version: 7.27.1(@babel/core@7.28.0)
+      '@babel/preset-typescript':
+        specifier: ^8.0.1
+        version: 8.0.1(@babel/core@7.28.0)
       '@eslint/eslintrc':
         specifier: ^3.3.1
         version: 3.3.1
@@ -107,16 +110,16 @@ importers:
         version: 30.4.1
       '@nx/eslint':
         specifier: 23.1.0
-        version: 23.1.0(@babel/traverse@7.29.7)(@nx/jest@23.1.0(@babel/traverse@7.29.7)(@types/node@24.1.0)(babel-plugin-macros@3.1.0)(jest@30.4.2(@types/node@24.1.0)(babel-plugin-macros@3.1.0))(nx@23.1.0)(typescript@6.0.3))(@zkochan/js-yaml@0.0.7)(eslint@9.32.0(jiti@2.5.1))(nx@23.1.0)
+        version: 23.1.0(@babel/traverse@7.29.7)(@nx/jest@23.1.0(@babel/traverse@7.29.7)(@types/node@24.1.0)(babel-plugin-macros@3.1.0)(jest@30.4.2(@types/node@24.1.0)(babel-plugin-macros@3.1.0))(nx@23.1.0)(ts-jest@29.4.12(@babel/core@7.28.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.3.0(@babel/core@7.28.0))(jest-util@30.4.1)(jest@30.4.2(@types/node@24.1.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(typescript@5.9.3))(@zkochan/js-yaml@0.0.7)(eslint@9.32.0(jiti@2.5.1))(nx@23.1.0)
       '@nx/jest':
         specifier: 23.1.0
-        version: 23.1.0(@babel/traverse@7.29.7)(@types/node@24.1.0)(babel-plugin-macros@3.1.0)(jest@30.4.2(@types/node@24.1.0)(babel-plugin-macros@3.1.0))(nx@23.1.0)(typescript@6.0.3)
+        version: 23.1.0(@babel/traverse@7.29.7)(@types/node@24.1.0)(babel-plugin-macros@3.1.0)(jest@30.4.2(@types/node@24.1.0)(babel-plugin-macros@3.1.0))(nx@23.1.0)(ts-jest@29.4.12(@babel/core@7.28.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.3.0(@babel/core@7.28.0))(jest-util@30.4.1)(jest@30.4.2(@types/node@24.1.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(typescript@5.9.3)
       '@nx/js':
         specifier: 23.1.0
         version: 23.1.0(@babel/traverse@7.29.7)(nx@23.1.0)
       '@nx/rollup':
         specifier: 23.1.0
-        version: 23.1.0(@babel/core@7.28.0)(@babel/traverse@7.29.7)(@types/babel__core@7.20.5)(nx@23.1.0)(rollup@4.62.2)(typescript@6.0.3)
+        version: 23.1.0(@babel/core@7.28.0)(@babel/traverse@7.29.7)(@types/babel__core@7.20.5)(nx@23.1.0)(rollup@4.62.2)(typescript@5.9.3)
       '@rollup/plugin-babel':
         specifier: ^6.0.4
         version: 6.0.4(@babel/core@7.28.0)(@types/babel__core@7.20.5)(rollup@4.62.2)
@@ -237,6 +240,12 @@ importers:
       rollup-plugin-peer-deps-external:
         specifier: ^2.2.4
         version: 2.2.4(rollup@4.62.2)
+      ts-jest:
+        specifier: ^29.4.12
+        version: 29.4.12(@babel/core@7.28.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.3.0(@babel/core@7.28.0))(jest-util@30.4.1)(jest@30.4.2(@types/node@24.1.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
 
   examples/patois.api:
     dependencies:
@@ -321,7 +330,7 @@ importers:
         version: 16.14.0(react@16.14.0)
       react-scripts:
         specifier: 2.0.5
-        version: 2.0.5(eslint@9.32.0(jiti@2.5.1))(react@16.14.0)(typescript@6.0.3)
+        version: 2.0.5(eslint@9.32.0(jiti@2.5.1))(react@16.14.0)(typescript@7.0.2)
     devDependencies:
       '@tao.js/telemetry':
         specifier: file:../../packages/tao-telemetry
@@ -557,6 +566,15 @@ importers:
         specifier: file:../tao-utils
         version: link:../tao-utils
 
+  packages/tao-typed:
+    devDependencies:
+      '@tao.js/core':
+        specifier: file:../tao
+        version: link:../tao
+      '@tao.js/telemetry':
+        specifier: file:../tao-telemetry
+        version: link:../tao-telemetry
+
   packages/tao-utils:
     devDependencies:
       '@tao.js/core':
@@ -595,6 +613,10 @@ packages:
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/code-frame@8.0.0':
+    resolution: {integrity: sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/compat-data@7.28.0':
     resolution: {integrity: sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==}
     engines: {node: '>=6.9.0'}
@@ -630,6 +652,10 @@ packages:
     resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/generator@8.0.0':
+    resolution: {integrity: sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/helper-annotate-as-pure@7.27.3':
     resolution: {integrity: sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==}
     engines: {node: '>=6.9.0'}
@@ -637,6 +663,10 @@ packages:
   '@babel/helper-annotate-as-pure@7.29.7':
     resolution: {integrity: sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/helper-annotate-as-pure@8.0.0':
+    resolution: {integrity: sha512-NSpMkMsvvZqzThJ0p1B02cbtA2ObEyfBvq950bmNkyxsxvcxwhvvCB036rKhlEnuBBo30bOrk13u3FzlKSoRrw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/helper-compilation-targets@7.27.2':
     resolution: {integrity: sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==}
@@ -657,6 +687,12 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
+
+  '@babel/helper-create-class-features-plugin@8.0.1':
+    resolution: {integrity: sha512-++t3ZktzlLmASAxIlxeXQK9Z2YwUafYGYcvGBFevqOqt16HozVHStUoQvWD09fzAZOb/uJGpUTBuGK41AJAuOA==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
 
   '@babel/helper-create-regexp-features-plugin@7.27.1':
     resolution: {integrity: sha512-uVDC72XVf8UbrH5qQTc18Agb8emwjTiZrQE11Nv3CuBEZmVvTwwE9CBUEvHku06gQCAyYf8Nv6ja1IN+6LMbxQ==}
@@ -689,6 +725,10 @@ packages:
     resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-globals@8.0.0':
+    resolution: {integrity: sha512-lLozHOM6sWWlxNo8CYqHy4MBZeTvHXNgVPBfPOGsjPKUzHC2Az9QwB6gxdQmpwHl6GlQtbGgS+lj5887guDiLw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/helper-member-expression-to-functions@7.27.1':
     resolution: {integrity: sha512-E5chM8eWjTp/aNoVpcbfM7mLxu9XGLWYise2eBKGQomAk/Mb4XoxyqXTZbuTohbsl8EKqdlMhnDI2CCLfcs9wA==}
     engines: {node: '>=6.9.0'}
@@ -697,6 +737,10 @@ packages:
     resolution: {integrity: sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-member-expression-to-functions@8.0.0':
+    resolution: {integrity: sha512-xkXrMbtk87Gk7+oKBVmBc6EORg/Qwx++AHESldmHkpvG8wgccdhJJFwrzqlF382Fk8wfXhJHWE/g/43QvEGNPQ==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/helper-module-imports@7.27.1':
     resolution: {integrity: sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==}
     engines: {node: '>=6.9.0'}
@@ -704,6 +748,10 @@ packages:
   '@babel/helper-module-imports@7.29.7':
     resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@8.0.0':
+    resolution: {integrity: sha512-NZ7mSS93o4ndX4KrbD7W8Sf3QT8Qe24PrnFyUcuOPDzK6faqDFKjY9RG7he7+I7FdiQ4llpnosFqzrXa+Vy3Ew==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/helper-module-transforms@7.27.3':
     resolution: {integrity: sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==}
@@ -717,6 +765,12 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
+  '@babel/helper-module-transforms@8.0.1':
+    resolution: {integrity: sha512-UgAhl1kqiW5ciE0yCXqqvnb4H2n3IELJ7lIIQRezwDPilPEZX5i+Rvbja9MFTkwUn2biEiSMeV31aUzR4Lwakw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
+
   '@babel/helper-optimise-call-expression@7.27.1':
     resolution: {integrity: sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==}
     engines: {node: '>=6.9.0'}
@@ -725,6 +779,10 @@ packages:
     resolution: {integrity: sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-optimise-call-expression@8.0.0':
+    resolution: {integrity: sha512-3W6satvtPuCUkUx63S2jMoW9EQNYkADgs1HTfufmL7gCmAulHMKupA/12WNz4A0GMMFn/YnWWwqOT9IZrJHQjg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/helper-plugin-utils@7.27.1':
     resolution: {integrity: sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==}
     engines: {node: '>=6.9.0'}
@@ -732,6 +790,12 @@ packages:
   '@babel/helper-plugin-utils@7.29.7':
     resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/helper-plugin-utils@8.0.1':
+    resolution: {integrity: sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
 
   '@babel/helper-remap-async-to-generator@7.27.1':
     resolution: {integrity: sha512-7fiA521aVw8lSPeI4ZOD3vRFkoqkJcS+z4hFo82bFSH/2tNd6eJ5qCVMS5OzDmZh/kaHQeBaeyxK6wljcPtveA==}
@@ -751,6 +815,12 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
+  '@babel/helper-replace-supers@8.0.1':
+    resolution: {integrity: sha512-B1SZADIcy3tmH8CmWvj4SHi/oAPom4UL3uknTc2QRNsPVLFk/sPnZvQL/8kj7Y5omvjMqie0vklvs6XM4OLW5Q==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
+
   '@babel/helper-simple-access@7.27.1':
     resolution: {integrity: sha512-OU4zVQrJgFBNXMjrHs1yFSdlTgufO4tefcUZoqNhukVfw0p8x1Asht/gcGZ3bpHbi8gu/76m4JhrlKPqkrs/WQ==}
     engines: {node: '>=6.9.0'}
@@ -762,6 +832,10 @@ packages:
   '@babel/helper-skip-transparent-expression-wrappers@7.29.7':
     resolution: {integrity: sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/helper-skip-transparent-expression-wrappers@8.0.0':
+    resolution: {integrity: sha512-xmCA9kP3IhySsqhzwIdWGlDN/1A4cCKNBO/uwZx/3YzmDoMePwno2Q5/Bq0q+tYaKbeF940YiKV/kaW8Mzvpjw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/helper-split-export-declaration@7.24.7':
     resolution: {integrity: sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==}
@@ -775,6 +849,10 @@ packages:
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@8.0.0':
+    resolution: {integrity: sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/helper-validator-identifier@7.27.1':
     resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
     engines: {node: '>=6.9.0'}
@@ -783,6 +861,10 @@ packages:
     resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-identifier@8.0.4':
+    resolution: {integrity: sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/helper-validator-option@7.27.1':
     resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
     engines: {node: '>=6.9.0'}
@@ -790,6 +872,10 @@ packages:
   '@babel/helper-validator-option@7.29.7':
     resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@8.0.0':
+    resolution: {integrity: sha512-U4Dybxh4WESWHt5XhBeExi4DrY0/DNK1aHpQbsrQXCUbFHuMweT0TpLEWKvaraV2Y6fS+ZXunsZ8zIuZIgvF2Q==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/helper-wrap-function@7.27.1':
     resolution: {integrity: sha512-NFJK2sHUvrjo8wAU/nQTWU890/zB2jj0qBcCbZbbf+005cAsv6tMjXz31fBign6M5ov1o0Bllu+9nbqkfsjjJQ==}
@@ -821,6 +907,11 @@ packages:
   '@babel/parser@7.29.7':
     resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@8.0.4':
+    resolution: {integrity: sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==}
+    engines: {node: ^22.18.0 || >=24.11.0}
     hasBin: true
 
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.27.1':
@@ -1042,6 +1133,12 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-syntax-typescript@8.0.3':
+    resolution: {integrity: sha512-jmTPwps7oSQSZaV1SxkQ3C12UWyufGysGc5OzDpZzvPAIX4mO7dJT3hoqkWVrSImvkcMiknir1iLN1SNV/CZzg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
+
   '@babel/plugin-syntax-unicode-sets-regex@7.18.6':
     resolution: {integrity: sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==}
     engines: {node: '>=6.9.0'}
@@ -1217,6 +1314,12 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-modules-commonjs@8.0.1':
+    resolution: {integrity: sha512-PMuzulWrrzFNmY3lXSk/tV9NRb7y0eZZLJY4UEo2TKszroxvUZHAPPi+T9FDyrQhod+TQA+t+8/QYaaMpiEuhA==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
 
   '@babel/plugin-transform-modules-systemjs@7.27.1':
     resolution: {integrity: sha512-w5N1XzsRbc0PQStASMksmUeqECuzKuTJer7kFagK8AXgpCMkeDMO5S+aaFb7A51ZYDF7XI34qsTX+fkHiIm5yA==}
@@ -1413,17 +1516,17 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-typescript@7.28.0':
-    resolution: {integrity: sha512-4AEiDEBPIZvLQaWlc9liCavE0xRM0dNca41WtBeM3jgFptfUOSG9z0uteLhq6+3rq+WB6jIvUwKDTpXEHPJ2Vg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-transform-typescript@7.29.7':
     resolution: {integrity: sha512-jK52h8LaLc7JarhQV2ofeFMts4H7vnOXnqZNA6fYglBTZewRBE51KWt3BUltW1P+KoPsYkHoJeXePuz4zo2LMw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-typescript@8.0.1':
+    resolution: {integrity: sha512-0Svqp3413Eg0GElldykF/T7SNsxQO5YVGD70fZyAdZTnX8WRgcopmbiU7GTa5xY5ZnJcEpNbfns8/GjX+/1yeA==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
 
   '@babel/plugin-transform-unicode-escapes@7.27.1':
     resolution: {integrity: sha512-Ysg4v6AmF26k9vpfFuTZg8HRfVWzsh1kVfowA23y9j/Gu6dOuahdUVhkLqpObp3JIv27MLSii6noRnuKN8H0Mg==}
@@ -1480,17 +1583,17 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/preset-typescript@7.27.1':
-    resolution: {integrity: sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/preset-typescript@7.28.5':
     resolution: {integrity: sha512-+bQy5WOI2V6LJZpPVxY+yp66XdZ2yifu0Mc1aP5CQKgjn4QM5IN2i5fAZ4xKop47pr8rpVhiAeu+nDQa12C8+g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/preset-typescript@8.0.1':
+    resolution: {integrity: sha512-qrPhQIN1NLrPmzgazF9XKQqXrOcp/WJly+K+6ReFonn24FZqRJO7clxOJo6Ni75L+2vAqI3cHVU2OJLBxoPp5A==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+    peerDependencies:
+      '@babel/core': ^8.0.0
 
   '@babel/register@7.27.1':
     resolution: {integrity: sha512-K13lQpoV54LATKkzBpBAEu1GGSIRzxR9f4IN4V8DCDgiUMo2UDGagEZr3lPeVNJPLkWUi5JE4hCHKneVTwQlYQ==}
@@ -1517,6 +1620,10 @@ packages:
     resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/template@8.0.0':
+    resolution: {integrity: sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/traverse@7.28.0':
     resolution: {integrity: sha512-mGe7UK5wWyh0bKRfupsUchrQGqvDbZDbKJw+kcRGSmdHVYrv+ltd0pnpDTVpiTqnaBru9iEvA8pz8W46v0Amwg==}
     engines: {node: '>=6.9.0'}
@@ -1525,6 +1632,10 @@ packages:
     resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/traverse@8.0.4':
+    resolution: {integrity: sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
   '@babel/types@7.28.2':
     resolution: {integrity: sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==}
     engines: {node: '>=6.9.0'}
@@ -1532,6 +1643,10 @@ packages:
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/types@8.0.4':
+    resolution: {integrity: sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
@@ -2854,6 +2969,11 @@ packages:
       react: ^18.2.0 || ^19.0.0
       react-dom: ^18.2.0 || ^19.0.0
 
+  '@tao.js/router@file:packages/tao-router':
+    resolution: {directory: packages/tao-router, type: directory}
+    peerDependencies:
+      '@tao.js/core': '*'
+
   '@tao.js/socket.io@file:packages/tao-socket-io':
     resolution: {directory: packages/tao-socket-io, type: directory}
     peerDependencies:
@@ -2948,6 +3068,9 @@ packages:
   '@types/jsdom@21.1.7':
     resolution: {integrity: sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==}
 
+  '@types/jsesc@2.5.1':
+    resolution: {integrity: sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -2999,6 +3122,126 @@ packages:
 
   '@types/yargs@17.0.33':
     resolution: {integrity: sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==}
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
@@ -3878,6 +4121,10 @@ packages:
     resolution: {integrity: sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  bs-logger@0.2.6:
+    resolution: {integrity: sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==}
+    engines: {node: '>= 6'}
 
   bser@2.1.1:
     resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
@@ -5947,6 +6194,11 @@ packages:
     engines: {node: '>=0.4.7'}
     hasBin: true
 
+  handlebars@4.7.9:
+    resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
+    engines: {node: '>=0.4.7'}
+    hasBin: true
+
   har-schema@2.0.0:
     resolution: {integrity: sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==}
     engines: {node: '>=4'}
@@ -7101,6 +7353,9 @@ packages:
   js-md4@0.3.2:
     resolution: {integrity: sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA==}
 
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+
   js-tokens@3.0.2:
     resolution: {integrity: sha512-RjTcuD4xjtthQkaWH7dFlH85L+QaVtSoOyGdZ3g6HFhS9dFNDfLyqgm2NFe2X6cQpeFmt0452FJjFG5UameExg==}
 
@@ -7559,6 +7814,9 @@ packages:
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
+
+  make-error@1.3.6:
+    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
 
   make-iterator@1.0.1:
     resolution: {integrity: sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==}
@@ -8203,6 +8461,10 @@ packages:
   obuf@1.1.2:
     resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
 
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
+
   octal@1.0.0:
     resolution: {integrity: sha512-nnda7W8d+A3vEIY+UrDQzzboPf1vhs4JYVhff5CDkq9QNoZY7Xrxeo/htox37j9dZf7yNHevZzqtejWgy1vCqQ==}
 
@@ -8514,6 +8776,9 @@ packages:
 
   patois.api@file:examples/patois.api:
     resolution: {directory: examples/patois.api, type: directory}
+
+  patois.web@file:examples/patois.web:
+    resolution: {directory: examples/patois.web, type: directory}
 
   pbkdf2@3.1.3:
     resolution: {integrity: sha512-wfRLBZ0feWRhCIkoMB6ete7czJcnNnqRpcoWQBLqatqXXmelSRqfdDK4F3u9T2s2cXas/hQJcryI/4lAL+XTlA==}
@@ -9628,6 +9893,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   send@0.19.0:
     resolution: {integrity: sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==}
     engines: {node: '>= 0.8.0'}
@@ -10328,6 +10598,33 @@ packages:
   tryer@1.0.1:
     resolution: {integrity: sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==}
 
+  ts-jest@29.4.12:
+    resolution: {integrity: sha512-Ov6ClY53Fflh6BGAnY2DlTq1hYDrTycz2PVTXBWFW2CU+9zrEqAp9fWdGXl42EXO5RLSFAcAZ2JFKbP+zBTFfw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@babel/core': '>=7.0.0-beta.0 <8'
+      '@jest/transform': ^29.0.0 || ^30.0.0
+      '@jest/types': ^29.0.0 || ^30.0.0
+      babel-jest: ^29.0.0 || ^30.0.0
+      esbuild: '*'
+      jest: ^29.0.0 || ^30.0.0
+      jest-util: ^29.0.0 || ^30.0.0
+      typescript: '>=4.3 <7'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@jest/transform':
+        optional: true
+      '@jest/types':
+        optional: true
+      babel-jest:
+        optional: true
+      esbuild:
+        optional: true
+      jest-util:
+        optional: true
+
   tsconfig-paths@4.2.0:
     resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
     engines: {node: '>=6'}
@@ -10383,6 +10680,10 @@ packages:
     resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
     engines: {node: '>=8'}
 
+  type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
+    engines: {node: '>=16'}
+
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
@@ -10417,9 +10718,19 @@ packages:
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
+    hasBin: true
+
+  typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+    engines: {node: '>=16.20.0'}
     hasBin: true
 
   uglify-es@3.3.9:
@@ -11153,6 +11464,11 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/code-frame@8.0.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 8.0.4
+      js-tokens: 10.0.0
+
   '@babel/compat-data@7.28.0': {}
 
   '@babel/compat-data@7.29.7': {}
@@ -11240,6 +11556,15 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.29
       jsesc: 3.1.0
 
+  '@babel/generator@8.0.0':
+    dependencies:
+      '@babel/parser': 8.0.4
+      '@babel/types': 8.0.4
+      '@jridgewell/gen-mapping': 0.3.12
+      '@jridgewell/trace-mapping': 0.3.29
+      '@types/jsesc': 2.5.1
+      jsesc: 3.1.0
+
   '@babel/helper-annotate-as-pure@7.27.3':
     dependencies:
       '@babel/types': 7.28.2
@@ -11247,6 +11572,10 @@ snapshots:
   '@babel/helper-annotate-as-pure@7.29.7':
     dependencies:
       '@babel/types': 7.29.7
+
+  '@babel/helper-annotate-as-pure@8.0.0':
+    dependencies:
+      '@babel/types': 8.0.4
 
   '@babel/helper-compilation-targets@7.27.2':
     dependencies:
@@ -11277,6 +11606,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.28.0)':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/helper-annotate-as-pure': 7.29.7
+      '@babel/helper-member-expression-to-functions': 7.29.7
+      '@babel/helper-optimise-call-expression': 7.29.7
+      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.28.0)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
+      '@babel/traverse': 7.29.7
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
@@ -11289,6 +11631,17 @@ snapshots:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
+
+  '@babel/helper-create-class-features-plugin@8.0.1(@babel/core@7.28.0)':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/helper-annotate-as-pure': 8.0.0
+      '@babel/helper-member-expression-to-functions': 8.0.0
+      '@babel/helper-optimise-call-expression': 8.0.0
+      '@babel/helper-replace-supers': 8.0.1(@babel/core@7.28.0)
+      '@babel/helper-skip-transparent-expression-wrappers': 8.0.0
+      '@babel/traverse': 8.0.4
+      semver: 7.8.4
 
   '@babel/helper-create-regexp-features-plugin@7.27.1(@babel/core@7.1.0)':
     dependencies:
@@ -11307,13 +11660,13 @@ snapshots:
   '@babel/helper-define-map@7.18.6':
     dependencies:
       '@babel/helper-function-name': 7.24.7
-      '@babel/types': 7.28.2
+      '@babel/types': 7.29.7
 
   '@babel/helper-define-polyfill-provider@0.6.5(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       debug: 4.4.1
       lodash.debounce: 4.0.8
       resolve: 1.22.10
@@ -11322,16 +11675,18 @@ snapshots:
 
   '@babel/helper-environment-visitor@7.24.7':
     dependencies:
-      '@babel/types': 7.28.2
+      '@babel/types': 7.29.7
 
   '@babel/helper-function-name@7.24.7':
     dependencies:
       '@babel/template': 7.27.2
-      '@babel/types': 7.28.2
+      '@babel/types': 7.29.7
 
   '@babel/helper-globals@7.28.0': {}
 
   '@babel/helper-globals@7.29.7': {}
+
+  '@babel/helper-globals@8.0.0': {}
 
   '@babel/helper-member-expression-to-functions@7.27.1':
     dependencies:
@@ -11347,6 +11702,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-member-expression-to-functions@8.0.0':
+    dependencies:
+      '@babel/traverse': 8.0.4
+      '@babel/types': 8.0.4
+
   '@babel/helper-module-imports@7.27.1':
     dependencies:
       '@babel/traverse': 7.28.0
@@ -11360,6 +11720,11 @@ snapshots:
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
+
+  '@babel/helper-module-imports@8.0.0':
+    dependencies:
+      '@babel/traverse': 8.0.4
+      '@babel/types': 8.0.4
 
   '@babel/helper-module-transforms@7.27.3(@babel/core@7.1.0)':
     dependencies:
@@ -11397,6 +11762,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-module-transforms@8.0.1(@babel/core@7.28.0)':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/helper-module-imports': 8.0.0
+      '@babel/helper-validator-identifier': 8.0.4
+      '@babel/traverse': 8.0.4
+
   '@babel/helper-optimise-call-expression@7.27.1':
     dependencies:
       '@babel/types': 7.28.2
@@ -11405,9 +11777,17 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
+  '@babel/helper-optimise-call-expression@8.0.0':
+    dependencies:
+      '@babel/types': 8.0.4
+
   '@babel/helper-plugin-utils@7.27.1': {}
 
   '@babel/helper-plugin-utils@7.29.7': {}
+
+  '@babel/helper-plugin-utils@8.0.1(@babel/core@7.28.0)':
+    dependencies:
+      '@babel/core': 7.28.0
 
   '@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.1.0)':
     dependencies:
@@ -11445,6 +11825,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-replace-supers@7.29.7(@babel/core@7.28.0)':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/helper-member-expression-to-functions': 7.29.7
+      '@babel/helper-optimise-call-expression': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-replace-supers@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
@@ -11453,6 +11842,13 @@ snapshots:
       '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
+
+  '@babel/helper-replace-supers@8.0.1(@babel/core@7.28.0)':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/helper-member-expression-to-functions': 8.0.0
+      '@babel/helper-optimise-call-expression': 8.0.0
+      '@babel/traverse': 8.0.4
 
   '@babel/helper-simple-access@7.27.1':
     dependencies:
@@ -11475,21 +11871,32 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-skip-transparent-expression-wrappers@8.0.0':
+    dependencies:
+      '@babel/traverse': 8.0.4
+      '@babel/types': 8.0.4
+
   '@babel/helper-split-export-declaration@7.24.7':
     dependencies:
-      '@babel/types': 7.28.2
+      '@babel/types': 7.29.7
 
   '@babel/helper-string-parser@7.27.1': {}
 
   '@babel/helper-string-parser@7.29.7': {}
 
+  '@babel/helper-string-parser@8.0.0': {}
+
   '@babel/helper-validator-identifier@7.27.1': {}
 
   '@babel/helper-validator-identifier@7.29.7': {}
 
+  '@babel/helper-validator-identifier@8.0.4': {}
+
   '@babel/helper-validator-option@7.27.1': {}
 
   '@babel/helper-validator-option@7.29.7': {}
+
+  '@babel/helper-validator-option@8.0.0': {}
 
   '@babel/helper-wrap-function@7.27.1':
     dependencies:
@@ -11511,7 +11918,7 @@ snapshots:
 
   '@babel/highlight@7.25.9':
     dependencies:
-      '@babel/helper-validator-identifier': 7.27.1
+      '@babel/helper-validator-identifier': 7.29.7
       chalk: 2.4.2
       js-tokens: 4.0.0
       picocolors: 1.1.1
@@ -11533,10 +11940,14 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
+  '@babel/parser@8.0.4':
+    dependencies:
+      '@babel/types': 8.0.4
+
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.27.1(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/traverse': 7.28.0
     transitivePeerDependencies:
       - supports-color
@@ -11544,17 +11955,17 @@ snapshots:
   '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
       '@babel/plugin-transform-optional-chaining': 7.27.1(@babel/core@7.28.0)
     transitivePeerDependencies:
@@ -11563,7 +11974,7 @@ snapshots:
   '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.27.1(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/traverse': 7.28.0
     transitivePeerDependencies:
       - supports-color
@@ -11572,7 +11983,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.1.0
       '@babel/helper-environment-visitor': 7.24.7
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.1.0)
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.1.0)
     transitivePeerDependencies:
@@ -11584,7 +11995,7 @@ snapshots:
       '@babel/helper-function-name': 7.24.7
       '@babel/helper-member-expression-to-functions': 7.27.1
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-replace-supers': 7.27.1(@babel/core@7.1.0)
       '@babel/plugin-syntax-class-properties': 7.0.0(@babel/core@7.1.0)
     transitivePeerDependencies:
@@ -11594,7 +12005,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.0
       '@babel/helper-create-class-features-plugin': 7.27.1(@babel/core@7.28.0)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/plugin-syntax-decorators': 7.27.1(@babel/core@7.28.0)
     transitivePeerDependencies:
       - supports-color
@@ -11611,19 +12022,19 @@ snapshots:
   '@babel/plugin-proposal-json-strings@7.18.6(@babel/core@7.1.0)':
     dependencies:
       '@babel/core': 7.1.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.1.0)
 
   '@babel/plugin-proposal-object-rest-spread@7.0.0(@babel/core@7.1.0)':
     dependencies:
       '@babel/core': 7.1.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.1.0)
 
   '@babel/plugin-proposal-optional-catch-binding@7.18.6(@babel/core@7.1.0)':
     dependencies:
       '@babel/core': 7.1.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.1.0)
 
   '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.28.0)':
@@ -11634,22 +12045,22 @@ snapshots:
     dependencies:
       '@babel/core': 7.1.0
       '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.1.0)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.1.0)':
     dependencies:
       '@babel/core': 7.1.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-class-properties@7.0.0(@babel/core@7.1.0)':
     dependencies:
@@ -11664,17 +12075,17 @@ snapshots:
   '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-decorators@7.27.1(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-decorators@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -11684,133 +12095,143 @@ snapshots:
   '@babel/plugin-syntax-dynamic-import@7.0.0(@babel/core@7.1.0)':
     dependencies:
       '@babel/core': 7.1.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-flow@7.27.1(@babel/core@7.1.0)':
     dependencies:
       '@babel/core': 7.1.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-import-assertions@7.27.1(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-import-attributes@7.27.1(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.1.0)':
     dependencies:
       '@babel/core': 7.1.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.1.0)':
     dependencies:
       '@babel/core': 7.1.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.1.0)':
     dependencies:
       '@babel/core': 7.1.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.1.0)':
     dependencies:
       '@babel/core': 7.1.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-typescript@7.27.1(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.28.0)':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
+  '@babel/plugin-syntax-typescript@8.0.3(@babel/core@7.28.0)':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.28.0)
+
   '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.28.0)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.1.0)':
     dependencies:
       '@babel/core': 7.1.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-async-generator-functions@7.28.0(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.28.0)
       '@babel/traverse': 7.28.0
     transitivePeerDependencies:
@@ -11820,7 +12241,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.1.0
       '@babel/helper-module-imports': 7.27.1
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.1.0)
     transitivePeerDependencies:
       - supports-color
@@ -11829,7 +12250,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.0
       '@babel/helper-module-imports': 7.27.1
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.28.0)
     transitivePeerDependencies:
       - supports-color
@@ -11837,22 +12258,22 @@ snapshots:
   '@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.1.0)':
     dependencies:
       '@babel/core': 7.1.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-block-scoping@7.28.0(@babel/core@7.1.0)':
     dependencies:
       '@babel/core': 7.1.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-block-scoping@7.28.0(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-class-properties@7.27.1(@babel/core@7.28.0)':
     dependencies:
@@ -11866,18 +12287,18 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.0
       '@babel/helper-create-class-features-plugin': 7.27.1(@babel/core@7.28.0)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-transform-classes@7.1.0(@babel/core@7.1.0)':
     dependencies:
       '@babel/core': 7.1.0
-      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-annotate-as-pure': 7.29.7
       '@babel/helper-define-map': 7.18.6
       '@babel/helper-function-name': 7.24.7
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-replace-supers': 7.27.1(@babel/core@7.1.0)
       '@babel/helper-split-export-declaration': 7.24.7
       globals: 11.12.0
@@ -11890,7 +12311,7 @@ snapshots:
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-globals': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-replace-supers': 7.27.1(@babel/core@7.1.0)
       '@babel/traverse': 7.28.0
     transitivePeerDependencies:
@@ -11902,7 +12323,7 @@ snapshots:
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-globals': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.0)
       '@babel/traverse': 7.28.0
     transitivePeerDependencies:
@@ -11911,19 +12332,19 @@ snapshots:
   '@babel/plugin-transform-computed-properties@7.27.1(@babel/core@7.1.0)':
     dependencies:
       '@babel/core': 7.1.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/template': 7.27.2
 
   '@babel/plugin-transform-computed-properties@7.27.1(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/template': 7.27.2
 
   '@babel/plugin-transform-destructuring@7.0.0(@babel/core@7.1.0)':
     dependencies:
       '@babel/core': 7.1.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-destructuring@7.28.0(@babel/core@7.1.0)':
     dependencies:
@@ -11953,39 +12374,39 @@ snapshots:
     dependencies:
       '@babel/core': 7.1.0
       '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.1.0)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-dotall-regex@7.27.1(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.28.0)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.1.0)':
     dependencies:
       '@babel/core': 7.1.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.27.1(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.28.0)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-explicit-resource-management@7.28.0(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/plugin-transform-destructuring': 7.28.0(@babel/core@7.28.0)
     transitivePeerDependencies:
       - supports-color
@@ -11993,7 +12414,7 @@ snapshots:
   '@babel/plugin-transform-explicit-resource-management@7.28.0(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/plugin-transform-destructuring': 7.28.0(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
@@ -12001,28 +12422,28 @@ snapshots:
   '@babel/plugin-transform-exponentiation-operator@7.27.1(@babel/core@7.1.0)':
     dependencies:
       '@babel/core': 7.1.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-exponentiation-operator@7.27.1(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-flow-strip-types@7.0.0(@babel/core@7.1.0)':
     dependencies:
       '@babel/core': 7.1.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/plugin-syntax-flow': 7.27.1(@babel/core@7.1.0)
 
   '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.1.0)':
     dependencies:
       '@babel/core': 7.1.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
@@ -12030,7 +12451,7 @@ snapshots:
   '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
@@ -12039,7 +12460,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.1.0
       '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/traverse': 7.28.0
     transitivePeerDependencies:
       - supports-color
@@ -12048,7 +12469,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.0
       '@babel/helper-compilation-targets': 7.27.2
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/traverse': 7.28.0
     transitivePeerDependencies:
       - supports-color
@@ -12056,33 +12477,33 @@ snapshots:
   '@babel/plugin-transform-json-strings@7.27.1(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-literals@7.27.1(@babel/core@7.1.0)':
     dependencies:
       '@babel/core': 7.1.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-literals@7.27.1(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-logical-assignment-operators@7.27.1(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.1.0)':
     dependencies:
       '@babel/core': 7.1.0
       '@babel/helper-module-transforms': 7.27.3(@babel/core@7.1.0)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -12090,7 +12511,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.0
       '@babel/helper-module-transforms': 7.27.3(@babel/core@7.28.0)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -12116,7 +12537,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.0
       '@babel/helper-module-transforms': 7.27.3(@babel/core@7.28.0)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -12124,15 +12545,21 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-module-transforms': 7.27.3(@babel/core@7.29.7)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
+
+  '@babel/plugin-transform-modules-commonjs@8.0.1(@babel/core@7.28.0)':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/helper-module-transforms': 8.0.1(@babel/core@7.28.0)
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.28.0)
 
   '@babel/plugin-transform-modules-systemjs@7.27.1(@babel/core@7.1.0)':
     dependencies:
       '@babel/core': 7.1.0
       '@babel/helper-module-transforms': 7.27.3(@babel/core@7.1.0)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-validator-identifier': 7.27.1
       '@babel/traverse': 7.28.0
     transitivePeerDependencies:
@@ -12142,7 +12569,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.0
       '@babel/helper-module-transforms': 7.27.3(@babel/core@7.28.0)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-validator-identifier': 7.27.1
       '@babel/traverse': 7.28.0
     transitivePeerDependencies:
@@ -12152,7 +12579,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.1.0
       '@babel/helper-module-transforms': 7.27.3(@babel/core@7.1.0)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -12160,7 +12587,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.0
       '@babel/helper-module-transforms': 7.27.3(@babel/core@7.28.0)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -12168,27 +12595,27 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.0
       '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.28.0)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-new-target@7.27.1(@babel/core@7.1.0)':
     dependencies:
       '@babel/core': 7.1.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-new-target@7.27.1(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-nullish-coalescing-operator@7.27.1(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-numeric-separator@7.27.1(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-object-rest-spread@7.28.0(@babel/core@7.28.0)':
     dependencies:
@@ -12204,7 +12631,7 @@ snapshots:
   '@babel/plugin-transform-object-super@7.27.1(@babel/core@7.1.0)':
     dependencies:
       '@babel/core': 7.1.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-replace-supers': 7.27.1(@babel/core@7.1.0)
     transitivePeerDependencies:
       - supports-color
@@ -12212,7 +12639,7 @@ snapshots:
   '@babel/plugin-transform-object-super@7.27.1(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-replace-supers': 7.27.1(@babel/core@7.28.0)
     transitivePeerDependencies:
       - supports-color
@@ -12220,12 +12647,12 @@ snapshots:
   '@babel/plugin-transform-optional-catch-binding@7.27.1(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-optional-chaining@7.27.1(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
@@ -12244,7 +12671,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.0
       '@babel/helper-create-class-features-plugin': 7.27.1(@babel/core@7.28.0)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -12253,40 +12680,40 @@ snapshots:
       '@babel/core': 7.28.0
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-create-class-features-plugin': 7.27.1(@babel/core@7.28.0)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-react-constant-elements@7.0.0(@babel/core@7.1.0)':
     dependencies:
       '@babel/core': 7.1.0
-      '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-annotate-as-pure': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-react-constant-elements@7.27.1(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-react-display-name@7.0.0(@babel/core@7.1.0)':
     dependencies:
       '@babel/core': 7.1.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-react-display-name@7.28.0(@babel/core@7.1.0)':
     dependencies:
       '@babel/core': 7.1.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-react-display-name@7.28.0(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-react-jsx-development@7.27.1(@babel/core@7.28.0)':
     dependencies:
@@ -12298,29 +12725,29 @@ snapshots:
   '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.1.0)':
     dependencies:
       '@babel/core': 7.1.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.1.0)':
     dependencies:
       '@babel/core': 7.1.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-react-jsx@7.27.1(@babel/core@7.1.0)':
     dependencies:
       '@babel/core': 7.1.0
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-module-imports': 7.27.1
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.1.0)
       '@babel/types': 7.28.2
     transitivePeerDependencies:
@@ -12331,7 +12758,7 @@ snapshots:
       '@babel/core': 7.28.0
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-module-imports': 7.27.1
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.0)
       '@babel/types': 7.28.2
     transitivePeerDependencies:
@@ -12341,34 +12768,34 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.0
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-regenerator@7.28.1(@babel/core@7.1.0)':
     dependencies:
       '@babel/core': 7.1.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-regenerator@7.28.1(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-regexp-modifiers@7.27.1(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.28.0)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-runtime@7.1.0(@babel/core@7.1.0)':
     dependencies:
       '@babel/core': 7.1.0
       '@babel/helper-module-imports': 7.27.1
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       resolve: 1.22.10
       semver: 5.7.2
     transitivePeerDependencies:
@@ -12378,7 +12805,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.0
       '@babel/helper-module-imports': 7.27.1
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       babel-plugin-polyfill-corejs2: 0.4.14(@babel/core@7.28.0)
       babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.28.0)
       babel-plugin-polyfill-regenerator: 0.6.5(@babel/core@7.28.0)
@@ -12389,17 +12816,17 @@ snapshots:
   '@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.1.0)':
     dependencies:
       '@babel/core': 7.1.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-spread@7.27.1(@babel/core@7.1.0)':
     dependencies:
       '@babel/core': 7.1.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
@@ -12407,7 +12834,7 @@ snapshots:
   '@babel/plugin-transform-spread@7.27.1(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
@@ -12415,41 +12842,41 @@ snapshots:
   '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.1.0)':
     dependencies:
       '@babel/core': 7.1.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-template-literals@7.27.1(@babel/core@7.1.0)':
     dependencies:
       '@babel/core': 7.1.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-template-literals@7.27.1(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.1.0)':
     dependencies:
       '@babel/core': 7.1.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-typescript@7.28.0(@babel/core@7.28.0)':
+  '@babel/plugin-transform-typescript@7.29.7(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-create-class-features-plugin': 7.27.1(@babel/core@7.28.0)
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.0)
+      '@babel/helper-annotate-as-pure': 7.29.7
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.28.0)
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
+      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.28.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -12464,34 +12891,43 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-typescript@8.0.1(@babel/core@7.28.0)':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/helper-annotate-as-pure': 8.0.0
+      '@babel/helper-create-class-features-plugin': 8.0.1(@babel/core@7.28.0)
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.28.0)
+      '@babel/helper-skip-transparent-expression-wrappers': 8.0.0
+      '@babel/plugin-syntax-typescript': 8.0.3(@babel/core@7.28.0)
+
   '@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-unicode-property-regex@7.27.1(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.28.0)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.1.0)':
     dependencies:
       '@babel/core': 7.1.0
       '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.1.0)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.28.0)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-unicode-sets-regex@7.27.1(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/helper-create-regexp-features-plugin': 7.27.1(@babel/core@7.28.0)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/polyfill@7.12.1':
     dependencies:
@@ -12502,7 +12938,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.1.0
       '@babel/helper-module-imports': 7.27.1
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/plugin-proposal-async-generator-functions': 7.20.7(@babel/core@7.1.0)
       '@babel/plugin-proposal-json-strings': 7.18.6(@babel/core@7.1.0)
       '@babel/plugin-proposal-object-rest-spread': 7.0.0(@babel/core@7.1.0)
@@ -12624,14 +13060,14 @@ snapshots:
   '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/types': 7.28.2
       esutils: 2.0.3
 
   '@babel/preset-react@7.0.0(@babel/core@7.1.0)':
     dependencies:
       '@babel/core': 7.1.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/plugin-transform-react-display-name': 7.28.0(@babel/core@7.1.0)
       '@babel/plugin-transform-react-jsx': 7.27.1(@babel/core@7.1.0)
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.1.0)
@@ -12651,27 +13087,35 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/preset-typescript@7.27.1(@babel/core@7.28.0)':
+  '@babel/preset-typescript@7.28.5(@babel/core@7.28.0)':
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-validator-option': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.0)
       '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-transform-typescript': 7.28.0(@babel/core@7.28.0)
+      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.28.0)
     transitivePeerDependencies:
       - supports-color
 
   '@babel/preset-typescript@7.28.5(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-validator-option': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.7)
       '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.29.7)
       '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
+
+  '@babel/preset-typescript@8.0.1(@babel/core@7.28.0)':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/helper-plugin-utils': 8.0.1(@babel/core@7.28.0)
+      '@babel/helper-validator-option': 8.0.0
+      '@babel/plugin-transform-modules-commonjs': 8.0.1(@babel/core@7.28.0)
+      '@babel/plugin-transform-typescript': 8.0.1(@babel/core@7.28.0)
 
   '@babel/register@7.27.1(@babel/core@7.28.0)':
     dependencies:
@@ -12704,6 +13148,12 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
 
+  '@babel/template@8.0.0':
+    dependencies:
+      '@babel/code-frame': 8.0.0
+      '@babel/parser': 8.0.4
+      '@babel/types': 8.0.4
+
   '@babel/traverse@7.28.0':
     dependencies:
       '@babel/code-frame': 7.27.1
@@ -12728,6 +13178,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/traverse@8.0.4':
+    dependencies:
+      '@babel/code-frame': 8.0.0
+      '@babel/generator': 8.0.0
+      '@babel/helper-globals': 8.0.0
+      '@babel/parser': 8.0.4
+      '@babel/template': 8.0.0
+      '@babel/types': 8.0.4
+      obug: 2.1.4
+
   '@babel/types@7.28.2':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
@@ -12737,6 +13197,11 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
+
+  '@babel/types@8.0.4':
+    dependencies:
+      '@babel/helper-string-parser': 8.0.0
+      '@babel/helper-validator-identifier': 8.0.4
 
   '@bcoe/v8-coverage@0.2.3': {}
 
@@ -13600,12 +14065,12 @@ snapshots:
       enquirer: 2.3.6
       minimatch: 10.2.5
       nx: 23.1.0
-      semver: 7.7.4
+      semver: 7.8.4
       tslib: 2.8.1
       yaml: 2.9.0
       yargs-parser: 21.1.1
 
-  '@nx/eslint@23.1.0(@babel/traverse@7.29.7)(@nx/jest@23.1.0(@babel/traverse@7.29.7)(@types/node@24.1.0)(babel-plugin-macros@3.1.0)(jest@30.4.2(@types/node@24.1.0)(babel-plugin-macros@3.1.0))(nx@23.1.0)(typescript@6.0.3))(@zkochan/js-yaml@0.0.7)(eslint@9.32.0(jiti@2.5.1))(nx@23.1.0)':
+  '@nx/eslint@23.1.0(@babel/traverse@7.29.7)(@nx/jest@23.1.0(@babel/traverse@7.29.7)(@types/node@24.1.0)(babel-plugin-macros@3.1.0)(jest@30.4.2(@types/node@24.1.0)(babel-plugin-macros@3.1.0))(nx@23.1.0)(ts-jest@29.4.12(@babel/core@7.28.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.3.0(@babel/core@7.28.0))(jest-util@30.4.1)(jest@30.4.2(@types/node@24.1.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(typescript@5.9.3))(@zkochan/js-yaml@0.0.7)(eslint@9.32.0(jiti@2.5.1))(nx@23.1.0)':
     dependencies:
       '@nx/devkit': 23.1.0(nx@23.1.0)
       '@nx/js': 23.1.0(@babel/traverse@7.29.7)(nx@23.1.0)
@@ -13614,7 +14079,7 @@ snapshots:
       tslib: 2.8.1
       typescript: 6.0.3
     optionalDependencies:
-      '@nx/jest': 23.1.0(@babel/traverse@7.29.7)(@types/node@24.1.0)(babel-plugin-macros@3.1.0)(jest@30.4.2(@types/node@24.1.0)(babel-plugin-macros@3.1.0))(nx@23.1.0)(typescript@6.0.3)
+      '@nx/jest': 23.1.0(@babel/traverse@7.29.7)(@types/node@24.1.0)(babel-plugin-macros@3.1.0)(jest@30.4.2(@types/node@24.1.0)(babel-plugin-macros@3.1.0))(nx@23.1.0)(ts-jest@29.4.12(@babel/core@7.28.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.3.0(@babel/core@7.28.0))(jest-util@30.4.1)(jest@30.4.2(@types/node@24.1.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(typescript@5.9.3)
       '@zkochan/js-yaml': 0.0.7
     transitivePeerDependencies:
       - '@babel/traverse'
@@ -13625,13 +14090,13 @@ snapshots:
       - supports-color
       - verdaccio
 
-  '@nx/jest@23.1.0(@babel/traverse@7.29.7)(@types/node@24.1.0)(babel-plugin-macros@3.1.0)(jest@30.4.2(@types/node@24.1.0)(babel-plugin-macros@3.1.0))(nx@23.1.0)(typescript@6.0.3)':
+  '@nx/jest@23.1.0(@babel/traverse@7.29.7)(@types/node@24.1.0)(babel-plugin-macros@3.1.0)(jest@30.4.2(@types/node@24.1.0)(babel-plugin-macros@3.1.0))(nx@23.1.0)(ts-jest@29.4.12(@babel/core@7.28.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.3.0(@babel/core@7.28.0))(jest-util@30.4.1)(jest@30.4.2(@types/node@24.1.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
       '@jest/reporters': 30.4.1
       '@jest/test-result': 30.4.1
       '@nx/devkit': 23.1.0(nx@23.1.0)
       '@nx/js': 23.1.0(@babel/traverse@7.29.7)(nx@23.1.0)
-      '@phenomnomnominal/tsquery': 6.2.0(typescript@6.0.3)
+      '@phenomnomnominal/tsquery': 6.2.0(typescript@5.9.3)
       identity-obj-proxy: 3.0.0
       jest-config: 30.4.2(@types/node@24.1.0)(babel-plugin-macros@3.1.0)
       jest-resolve: 30.4.1
@@ -13645,6 +14110,7 @@ snapshots:
       yargs-parser: 21.1.1
     optionalDependencies:
       jest: 30.4.2(@types/node@24.1.0)(babel-plugin-macros@3.1.0)
+      ts-jest: 29.4.12(@babel/core@7.28.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.3.0(@babel/core@7.28.0))(jest-util@30.4.1)(jest@30.4.2(@types/node@24.1.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -13667,7 +14133,7 @@ snapshots:
       '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.28.0)
       '@babel/plugin-transform-runtime': 7.28.0(@babel/core@7.28.0)
       '@babel/preset-env': 7.28.0(@babel/core@7.28.0)
-      '@babel/preset-typescript': 7.27.1(@babel/core@7.28.0)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.28.0)
       '@babel/runtime': 7.28.2
       '@nx/devkit': 23.1.0(nx@23.1.0)
       '@nx/workspace': 23.1.0
@@ -13725,17 +14191,17 @@ snapshots:
   '@nx/nx-win32-x64-msvc@23.1.0':
     optional: true
 
-  '@nx/rollup@23.1.0(@babel/core@7.28.0)(@babel/traverse@7.29.7)(@types/babel__core@7.20.5)(nx@23.1.0)(rollup@4.62.2)(typescript@6.0.3)':
+  '@nx/rollup@23.1.0(@babel/core@7.28.0)(@babel/traverse@7.29.7)(@types/babel__core@7.20.5)(nx@23.1.0)(rollup@4.62.2)(typescript@5.9.3)':
     dependencies:
       '@nx/devkit': 23.1.0(nx@23.1.0)
       '@nx/js': 23.1.0(@babel/traverse@7.29.7)(nx@23.1.0)
-      '@phenomnomnominal/tsquery': 6.2.0(typescript@6.0.3)
+      '@phenomnomnominal/tsquery': 6.2.0(typescript@5.9.3)
       '@rollup/plugin-babel': 6.0.4(@babel/core@7.28.0)(@types/babel__core@7.20.5)(rollup@4.62.2)
       '@rollup/plugin-commonjs': 25.0.8(rollup@4.62.2)
       '@rollup/plugin-image': 3.0.3(rollup@4.62.2)
       '@rollup/plugin-json': 6.1.0(rollup@4.62.2)
       '@rollup/plugin-node-resolve': 15.3.1(rollup@4.62.2)
-      '@rollup/plugin-typescript': 12.1.4(rollup@4.62.2)(tslib@2.8.1)(typescript@6.0.3)
+      '@rollup/plugin-typescript': 12.1.4(rollup@4.62.2)(tslib@2.8.1)(typescript@5.9.3)
       autoprefixer: 10.4.21(postcss@8.5.6)
       concat-with-sourcemaps: 1.1.0
       picocolors: 1.1.1
@@ -13765,7 +14231,7 @@ snapshots:
       enquirer: 2.3.6
       nx: 23.1.0
       picomatch: 4.0.4
-      semver: 7.7.4
+      semver: 7.8.4
       tslib: 2.8.1
       yargs-parser: 21.1.1
     transitivePeerDependencies:
@@ -13774,11 +14240,11 @@ snapshots:
 
   '@opentelemetry/api@1.9.1': {}
 
-  '@phenomnomnominal/tsquery@6.2.0(typescript@6.0.3)':
+  '@phenomnomnominal/tsquery@6.2.0(typescript@5.9.3)':
     dependencies:
       '@types/esquery': 1.5.4
       esquery: 1.7.0
-      typescript: 6.0.3
+      typescript: 5.9.3
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -13854,11 +14320,11 @@ snapshots:
     optionalDependencies:
       rollup: 4.62.2
 
-  '@rollup/plugin-typescript@12.1.4(rollup@4.62.2)(tslib@2.8.1)(typescript@6.0.3)':
+  '@rollup/plugin-typescript@12.1.4(rollup@4.62.2)(tslib@2.8.1)(typescript@5.9.3)':
     dependencies:
       '@rollup/pluginutils': 5.2.0(rollup@4.62.2)
       resolve: 1.22.10
-      typescript: 6.0.3
+      typescript: 5.9.3
     optionalDependencies:
       rollup: 4.62.2
       tslib: 2.8.1
@@ -14105,6 +14571,16 @@ snapshots:
       react: 16.14.0
       react-dom: 16.14.0(react@16.14.0)
 
+  '@tao.js/router@file:packages/tao-router(@tao.js/core@file:packages/tao)':
+    dependencies:
+      '@tao.js/core': file:packages/tao
+      get-value: 3.0.1
+      history: 4.10.1
+      path-to-regexp: 2.4.0
+      routington: 1.0.3
+      set-value: 3.0.3
+      url-pattern: 1.0.3
+
   '@tao.js/socket.io@file:packages/tao-socket-io(@tao.js/core@file:packages/tao)(@tao.js/utils@file:packages/tao-utils(@tao.js/core@file:packages/tao)(@tao.js/telemetry@file:packages/tao-telemetry(@tao.js/core@file:packages/tao)))':
     dependencies:
       '@tao.js/core': file:packages/tao
@@ -14218,6 +14694,8 @@ snapshots:
       '@types/tough-cookie': 4.0.5
       parse5: 7.3.0
 
+  '@types/jsesc@2.5.1': {}
+
   '@types/json-schema@7.0.15': {}
 
   '@types/keyv@3.1.4':
@@ -14267,6 +14745,66 @@ snapshots:
   '@types/yargs@17.0.33':
     dependencies:
       '@types/yargs-parser': 21.0.3
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    optional: true
 
   '@ungap/structured-clone@1.3.0': {}
 
@@ -14903,7 +15441,7 @@ snapshots:
   babel-plugin-const-enum@1.2.0(@babel/core@7.28.0):
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.0)
       '@babel/traverse': 7.28.0
     transitivePeerDependencies:
@@ -14933,7 +15471,7 @@ snapshots:
 
   babel-plugin-istanbul@7.0.1:
     dependencies:
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
       '@istanbuljs/load-nyc-config': 1.1.0
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-instrument: 6.0.3
@@ -15002,7 +15540,7 @@ snapshots:
   babel-plugin-transform-typescript-metadata@0.3.2(@babel/core@7.28.0)(@babel/traverse@7.29.7):
     dependencies:
       '@babel/core': 7.28.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
     optionalDependencies:
       '@babel/traverse': 7.29.7
 
@@ -15350,6 +15888,10 @@ snapshots:
       electron-to-chromium: 1.5.191
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.25.1)
+
+  bs-logger@0.2.6:
+    dependencies:
+      fast-json-stable-stringify: 2.1.0
 
   bser@2.1.1:
     dependencies:
@@ -16886,7 +17428,7 @@ snapshots:
     dependencies:
       eslint: 9.32.0(jiti@2.5.1)
 
-  eslint-config-react-app@3.0.8(babel-eslint@9.0.0)(eslint-plugin-flowtype@2.50.1(eslint@9.32.0(jiti@2.5.1)))(eslint-plugin-import@2.14.0(eslint@9.32.0(jiti@2.5.1)))(eslint-plugin-jsx-a11y@6.1.2(eslint@9.32.0(jiti@2.5.1)))(eslint-plugin-react@7.11.1(eslint@9.32.0(jiti@2.5.1)))(eslint@9.32.0(jiti@2.5.1))(typescript@6.0.3):
+  eslint-config-react-app@3.0.8(babel-eslint@9.0.0)(eslint-plugin-flowtype@2.50.1(eslint@9.32.0(jiti@2.5.1)))(eslint-plugin-import@2.14.0(eslint@9.32.0(jiti@2.5.1)))(eslint-plugin-jsx-a11y@6.1.2(eslint@9.32.0(jiti@2.5.1)))(eslint-plugin-react@7.11.1(eslint@9.32.0(jiti@2.5.1)))(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.3):
     dependencies:
       babel-eslint: 9.0.0
       confusing-browser-globals: 1.0.11
@@ -16896,7 +17438,19 @@ snapshots:
       eslint-plugin-jsx-a11y: 6.1.2(eslint@9.32.0(jiti@2.5.1))
       eslint-plugin-react: 7.11.1(eslint@9.32.0(jiti@2.5.1))
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: 5.9.3
+
+  eslint-config-react-app@3.0.8(babel-eslint@9.0.0)(eslint-plugin-flowtype@2.50.1(eslint@9.32.0(jiti@2.5.1)))(eslint-plugin-import@2.14.0(eslint@9.32.0(jiti@2.5.1)))(eslint-plugin-jsx-a11y@6.1.2(eslint@9.32.0(jiti@2.5.1)))(eslint-plugin-react@7.11.1(eslint@9.32.0(jiti@2.5.1)))(eslint@9.32.0(jiti@2.5.1))(typescript@7.0.2):
+    dependencies:
+      babel-eslint: 9.0.0
+      confusing-browser-globals: 1.0.11
+      eslint: 9.32.0(jiti@2.5.1)
+      eslint-plugin-flowtype: 2.50.1(eslint@9.32.0(jiti@2.5.1))
+      eslint-plugin-import: 2.14.0(eslint@9.32.0(jiti@2.5.1))
+      eslint-plugin-jsx-a11y: 6.1.2(eslint@9.32.0(jiti@2.5.1))
+      eslint-plugin-react: 7.11.1(eslint@9.32.0(jiti@2.5.1))
+    optionalDependencies:
+      typescript: 7.0.2
 
   eslint-import-resolver-node@0.3.9:
     dependencies:
@@ -17941,6 +18495,15 @@ snapshots:
   handle-thing@1.2.5: {}
 
   handlebars@4.7.8:
+    dependencies:
+      minimist: 1.2.8
+      neo-async: 2.6.2
+      source-map: 0.6.1
+      wordwrap: 1.0.0
+    optionalDependencies:
+      uglify-js: 3.19.3
+
+  handlebars@4.7.9:
     dependencies:
       minimist: 1.2.8
       neo-async: 2.6.2
@@ -19363,7 +19926,7 @@ snapshots:
       '@babel/core': 7.28.0
       '@babel/generator': 7.28.0
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.0)
-      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.0)
+      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.28.0)
       '@babel/types': 7.28.2
       '@jest/expect-utils': 30.4.1
       '@jest/get-type': 30.1.0
@@ -19500,6 +20063,8 @@ snapshots:
   js-levenshtein@1.1.6: {}
 
   js-md4@0.3.2: {}
+
+  js-tokens@10.0.0: {}
 
   js-tokens@3.0.2: {}
 
@@ -20074,6 +20639,8 @@ snapshots:
   make-dir@4.0.0:
     dependencies:
       semver: 7.8.4
+
+  make-error@1.3.6: {}
 
   make-iterator@1.0.1:
     dependencies:
@@ -20773,6 +21340,8 @@ snapshots:
 
   obuf@1.1.2: {}
 
+  obug@2.1.4: {}
+
   octal@1.0.0: {}
 
   on-finished@2.4.1:
@@ -21118,6 +21687,34 @@ snapshots:
       - snappy
       - supports-color
       - utf-8-validate
+
+  patois.web@file:examples/patois.web(@tao.js/telemetry@file:packages/tao-telemetry(@tao.js/core@file:packages/tao))(eslint@9.32.0(jiti@2.5.1))(prop-types@15.8.1)(typescript@5.9.3):
+    dependencies:
+      '@tao.js/core': file:packages/tao
+      '@tao.js/react': file:packages/react-tao(@tao.js/core@file:packages/tao)(prop-types@15.8.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
+      '@tao.js/router': file:packages/tao-router(@tao.js/core@file:packages/tao)
+      '@tao.js/socket.io': file:packages/tao-socket-io(@tao.js/core@file:packages/tao)(@tao.js/utils@file:packages/tao-utils(@tao.js/core@file:packages/tao)(@tao.js/telemetry@file:packages/tao-telemetry(@tao.js/core@file:packages/tao)))
+      '@tao.js/utils': file:packages/tao-utils(@tao.js/core@file:packages/tao)(@tao.js/telemetry@file:packages/tao-telemetry(@tao.js/core@file:packages/tao))
+      axios: 0.18.1
+      lodash.isempty: 4.4.0
+      lodash.merge: 4.6.2
+      react: 16.14.0
+      react-dom: 16.14.0(react@16.14.0)
+      react-scripts: 2.0.5(eslint@9.32.0(jiti@2.5.1))(react@16.14.0)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@tao.js/telemetry'
+      - '@typescript-eslint/parser'
+      - bufferutil
+      - canvas
+      - eslint
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - prop-types
+      - supports-color
+      - typescript
+      - utf-8-validate
+      - webpack-cli
+      - webpack-command
 
   pbkdf2@3.1.3:
     dependencies:
@@ -21847,7 +22444,7 @@ snapshots:
       raf: 3.4.0
       whatwg-fetch: 3.0.0
 
-  react-dev-utils@6.1.1(typescript@6.0.3)(webpack@4.19.1):
+  react-dev-utils@6.1.1(typescript@5.9.3)(webpack@4.19.1):
     dependencies:
       '@babel/code-frame': 7.0.0
       address: 1.0.3
@@ -21875,7 +22472,39 @@ snapshots:
       text-table: 0.2.0
       webpack: 4.19.1
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  react-dev-utils@6.1.1(typescript@7.0.2)(webpack@4.19.1):
+    dependencies:
+      '@babel/code-frame': 7.0.0
+      address: 1.0.3
+      browserslist: 4.1.1
+      chalk: 2.4.1
+      cross-spawn: 6.0.5
+      detect-port-alt: 1.1.6
+      escape-string-regexp: 1.0.5
+      filesize: 3.6.1
+      find-up: 3.0.0
+      global-modules: 1.0.0
+      globby: 8.0.1
+      gzip-size: 5.0.0
+      immer: 1.7.2
+      inquirer: 6.2.0
+      is-root: 2.0.0
+      loader-utils: 1.1.0
+      opn: 5.4.0
+      pkg-up: 2.0.0
+      react-error-overlay: 5.1.6
+      recursive-readdir: 2.2.2
+      shell-quote: 1.6.1
+      sockjs-client: 1.1.5(supports-color@5.5.0)
+      strip-ansi: 4.0.0
+      text-table: 0.2.0
+      webpack: 4.19.1
+    optionalDependencies:
+      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -21912,7 +22541,7 @@ snapshots:
     optionalDependencies:
       react-dom: 19.2.7(react@19.2.7)
 
-  react-scripts@2.0.5(eslint@9.32.0(jiti@2.5.1))(react@16.14.0)(typescript@6.0.3):
+  react-scripts@2.0.5(eslint@9.32.0(jiti@2.5.1))(react@16.14.0)(typescript@5.9.3):
     dependencies:
       '@babel/core': 7.1.0
       '@svgr/webpack': 2.4.1
@@ -21929,7 +22558,7 @@ snapshots:
       dotenv: 6.0.0
       dotenv-expand: 4.2.0
       eslint: 9.32.0(jiti@2.5.1)
-      eslint-config-react-app: 3.0.8(babel-eslint@9.0.0)(eslint-plugin-flowtype@2.50.1(eslint@9.32.0(jiti@2.5.1)))(eslint-plugin-import@2.14.0(eslint@9.32.0(jiti@2.5.1)))(eslint-plugin-jsx-a11y@6.1.2(eslint@9.32.0(jiti@2.5.1)))(eslint-plugin-react@7.11.1(eslint@9.32.0(jiti@2.5.1)))(eslint@9.32.0(jiti@2.5.1))(typescript@6.0.3)
+      eslint-config-react-app: 3.0.8(babel-eslint@9.0.0)(eslint-plugin-flowtype@2.50.1(eslint@9.32.0(jiti@2.5.1)))(eslint-plugin-import@2.14.0(eslint@9.32.0(jiti@2.5.1)))(eslint-plugin-jsx-a11y@6.1.2(eslint@9.32.0(jiti@2.5.1)))(eslint-plugin-react@7.11.1(eslint@9.32.0(jiti@2.5.1)))(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.3)
       eslint-loader: 2.1.1(eslint@9.32.0(jiti@2.5.1))(webpack@4.19.1)
       eslint-plugin-flowtype: 2.50.1(eslint@9.32.0(jiti@2.5.1))
       eslint-plugin-import: 2.14.0(eslint@9.32.0(jiti@2.5.1))
@@ -21951,7 +22580,70 @@ snapshots:
       postcss-safe-parser: 4.0.1
       react: 16.14.0
       react-app-polyfill: 0.1.3
-      react-dev-utils: 6.1.1(typescript@6.0.3)(webpack@4.19.1)
+      react-dev-utils: 6.1.1(typescript@5.9.3)(webpack@4.19.1)
+      resolve: 1.8.1
+      sass-loader: 7.1.0(webpack@4.19.1)
+      style-loader: 0.23.0
+      terser-webpack-plugin: 1.1.0(webpack@4.19.1)
+      url-loader: 1.1.1(webpack@4.19.1)
+      webpack: 4.19.1
+      webpack-dev-server: 3.1.9(webpack@4.19.1)
+      webpack-manifest-plugin: 2.0.4(webpack@4.19.1)
+      workbox-webpack-plugin: 3.6.2(webpack@4.19.1)
+    optionalDependencies:
+      fsevents: 1.2.4
+    transitivePeerDependencies:
+      - '@typescript-eslint/parser'
+      - bufferutil
+      - canvas
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+      - typescript
+      - utf-8-validate
+      - webpack-cli
+      - webpack-command
+
+  react-scripts@2.0.5(eslint@9.32.0(jiti@2.5.1))(react@16.14.0)(typescript@7.0.2):
+    dependencies:
+      '@babel/core': 7.1.0
+      '@svgr/webpack': 2.4.1
+      babel-core: 7.0.0-bridge.0(@babel/core@7.1.0)
+      babel-eslint: 9.0.0
+      babel-jest: 23.6.0(babel-core@7.0.0-bridge.0(@babel/core@7.1.0))
+      babel-loader: 8.0.4(@babel/core@7.1.0)(webpack@4.19.1)
+      babel-plugin-named-asset-import: 0.2.3(@babel/core@7.1.0)
+      babel-preset-react-app: 5.0.4(webpack@4.19.1)
+      bfj: 6.1.1
+      case-sensitive-paths-webpack-plugin: 2.1.2
+      chalk: 2.4.1
+      css-loader: 1.0.0(webpack@4.19.1)
+      dotenv: 6.0.0
+      dotenv-expand: 4.2.0
+      eslint: 9.32.0(jiti@2.5.1)
+      eslint-config-react-app: 3.0.8(babel-eslint@9.0.0)(eslint-plugin-flowtype@2.50.1(eslint@9.32.0(jiti@2.5.1)))(eslint-plugin-import@2.14.0(eslint@9.32.0(jiti@2.5.1)))(eslint-plugin-jsx-a11y@6.1.2(eslint@9.32.0(jiti@2.5.1)))(eslint-plugin-react@7.11.1(eslint@9.32.0(jiti@2.5.1)))(eslint@9.32.0(jiti@2.5.1))(typescript@7.0.2)
+      eslint-loader: 2.1.1(eslint@9.32.0(jiti@2.5.1))(webpack@4.19.1)
+      eslint-plugin-flowtype: 2.50.1(eslint@9.32.0(jiti@2.5.1))
+      eslint-plugin-import: 2.14.0(eslint@9.32.0(jiti@2.5.1))
+      eslint-plugin-jsx-a11y: 6.1.2(eslint@9.32.0(jiti@2.5.1))
+      eslint-plugin-react: 7.11.1(eslint@9.32.0(jiti@2.5.1))
+      file-loader: 2.0.0(webpack@4.19.1)
+      fs-extra: 7.0.0
+      html-webpack-plugin: 4.0.0-alpha.2(webpack@4.19.1)
+      identity-obj-proxy: 3.0.0
+      jest: 23.6.0
+      jest-pnp-resolver: 1.0.1(jest-resolve@23.6.0)
+      jest-resolve: 23.6.0
+      mini-css-extract-plugin: 0.4.3(webpack@4.19.1)
+      optimize-css-assets-webpack-plugin: 5.0.1(webpack@4.19.1)
+      pnp-webpack-plugin: 1.1.0
+      postcss-flexbugs-fixes: 4.1.0
+      postcss-loader: 3.0.0
+      postcss-preset-env: 6.0.6
+      postcss-safe-parser: 4.0.1
+      react: 16.14.0
+      react-app-polyfill: 0.1.3
+      react-dev-utils: 6.1.1(typescript@7.0.2)(webpack@4.19.1)
       resolve: 1.8.1
       sass-loader: 7.1.0(webpack@4.19.1)
       style-loader: 0.23.0
@@ -22508,6 +23200,8 @@ snapshots:
   semver@7.7.4: {}
 
   semver@7.8.4: {}
+
+  semver@7.8.5: {}
 
   send@0.19.0(supports-color@5.5.0):
     dependencies:
@@ -23379,6 +24073,26 @@ snapshots:
 
   tryer@1.0.1: {}
 
+  ts-jest@29.4.12(@babel/core@7.28.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.3.0(@babel/core@7.28.0))(jest-util@30.4.1)(jest@30.4.2(@types/node@24.1.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3):
+    dependencies:
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      handlebars: 4.7.9
+      jest: 30.4.2(@types/node@24.1.0)(babel-plugin-macros@3.1.0)
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.8.5
+      type-fest: 4.41.0
+      typescript: 5.9.3
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.28.0
+      '@jest/transform': 30.4.1
+      '@jest/types': 30.4.1
+      babel-jest: 30.3.0(@babel/core@7.28.0)
+      jest-util: 30.4.1
+
   tsconfig-paths@4.2.0:
     dependencies:
       json5: 2.2.3
@@ -23418,6 +24132,8 @@ snapshots:
   type-fest@0.6.0: {}
 
   type-fest@0.8.1: {}
+
+  type-fest@4.41.0: {}
 
   type-is@1.6.18:
     dependencies:
@@ -23471,7 +24187,33 @@ snapshots:
 
   typedarray@0.0.6: {}
 
+  typescript@5.9.3: {}
+
   typescript@6.0.3: {}
+
+  typescript@7.0.2:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
+    optional: true
 
   uglify-es@3.3.9:
     dependencies:


### PR DESCRIPTION
Per [`TYPED-SPEC.md`](https://github.com/zzyzxlab/tao.js/blob/feat/typescript-wrapper/TYPED-SPEC.md), committed spec-first.

> **Status / role of this PR:** the JSDoc typedef pass originally carried here was split out and landed via #64 (cherry-picked verbatim, then extended to every release-group package + d.ts emission wiring). What remains here is the **`@tao.js/typed` v1 prototype** — superseded by the v2 transparent-DX design recorded in TYPED-SPEC §7 on this branch. It stays open **unmerged** as the reference record for the §7 rewrite; the v1 surface does not ship, and only the v2 surface will ever publish under the typed name.

## `@tao.js/typed` — typed trigram vocabularies (v1 prototype)

```ts
const App = defineVocabulary({
  UserFind: signal('User', 'Find', 'Portal').data<{ User: { id: string } }>(),
  UserView: signal('User', 'View', 'Portal').data<{ User: UserRecord }>(),
});
const tao = typedKernel(kernel, App);
tao.onInline(App.UserFind, (s) => App.UserView({ User: load(s.data.User.id) }));
tao.onInline(App.match({ t: 'User' }), (s) => { /* discriminated union on s.a */ });
```

- Each protocol message fuses trigram + datagram into one typed value; undeclared signals and mis-shaped datagrams are **compile errors** — the silent-no-op failure mode is closed at authoring time (AGENTIC.md "typed trigram vocabularies").
- `defineVocabulary` is protocol-as-code: a plain importable value, `toProtocol()` feeds TAO.md generation and the protocol extractor.
- `typedKernel` is a deliberately dumb translation layer: typed chaining, intercept verdict passthrough, dispose fns — dispatch untouched. **Pinned by test: a typed cascade produces identical trace trees to its untyped equivalent.**
- Verification: 14 runtime tests at 100% coverage; a compile-time suite where `@ts-expect-error` assertions are the tests (`npm run typecheck`); CJS+ESM+d.ts builds; built lib smoke-tested on a real Kernel.
- Deliberately **not** in the nx release group — and per §7, staying out: v2 replaces this surface (part carriers / `Part<Self>` classes, open vs protocol mode, decorators with `.chain()`/`.chains()`, the type-arg transform, the TAO.md path DSL).

## Toolchain notes (carried forward into §7.8)

- Bare `typescript` now resolves to the native TS7 compiler (no JS API) — pinned `typescript@^5.9`; ts-jest for the package's self-contained jest config (the shared babel preset proved unreliable for `.ts`).

## Follow-ups surfaced by the typedef pass (now landed via #64; behavior not changed there)

- `AppCtxRoot.isMatch` honors short keys only (long-key filters match everything — also affects `trigramFilter`/`seive`)
- Relay's copy-pasted "Source" error string
- Transponder/Transceiver timeouts reject plain strings rather than Errors
- `Network.enter` doesn't gate `canSetWildcard` (only Kernel does)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
