### PR TITLE
feat(types): every 0.20 package ships d.ts emitted from JSDoc (0.21 train, 1/3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,7 +232,37 @@ Nx project names match package names (e.g. `@tao.js/core`). Package manager: **p
 
 - Library code: `packages/<dir>/src/`
 - Tests: `packages/<dir>/test/*.spec.js` (Jest via `@nx/jest`)
-- Built outputs: `dist` (ESM), `lib` (CJS), sometimes `bundles/` (UMD)
+- Built outputs: `dist` (ESM), `lib` (CJS + emitted `.d.ts`), sometimes `bundles/` (UMD)
+
+### TypeScript declarations (0.21+)
+
+Every release-group package publishes its own `.d.ts`, **emitted from the
+JSDoc** — never hand-written. Per package: `tsconfig.types.json` (extends
+`config/tsconfig.types.json`), a `build:types` script (`tsc -p
+tsconfig.types.json`, declaration-only into `lib/`), chained into `build`,
+and `"types": "lib/index.d.ts"`. `checkJs` stays ON as the JSDoc/behavior
+drift gate — fix type errors by correcting the JSDoc (or a comment-cast
+`/** @type {X} */ (expr)` at duck-typed spots), not by weakening public
+signatures to `any`. Rules learned wiring it:
+
+- `@param {Object}` emits as `any` — name a typedef (or a structural shape)
+  instead.
+- Modules reachable from an index `export *` must reference cross-package
+  types **inline** (`import('@tao.js/core').Kernel`) — top-level typedef
+  aliases are exported from the module's d.ts and collide across `export *`
+  sources (TS2308).
+- Duck-typed acceptance is typed as a structural shape at its origin:
+  `NetworkSurface` in utils (`typeof x.enter === 'function' ? x :
+x._network` convention), `TraceableSurface` in telemetry. Public params
+  reference those, prose keeps the Kernel/Network framing.
+- Shared shapes get typedefs at their origin module and are re-exported
+  from `src/index.js` via a comments-only typedef block (see
+  `packages/tao/src/index.js`).
+- Clean-room proof: `pnpm run test:types` (tools/types-consumer) packs all
+  13 tarballs, installs them with the host libs in a scratch project, and
+  compiles strict typical usage with `IsAny` guards so a declaration that
+  degrades to `any` fails. Run it (after `pnpm build`) before every
+  release.
 
 ### Commands (repo root)
 
@@ -240,6 +270,7 @@ Nx project names match package names (e.g. `@tao.js/core`). Package manager: **p
 pnpm test                          # nx run-many test (excludes patois.*)
 pnpm build                         # nx run-many build
 pnpm lint                          # nx run-many lint
+pnpm run test:types                # clean-room d.ts consumer check (after pnpm build)
 
 pnpm nx test @tao.js/core          # one project
 pnpm nx build @tao.js/core
@@ -247,6 +278,11 @@ pnpm nx run-many -t test -p @tao.js/core,@tao.js/utils
 ```
 
 Root scripts also exclude `patois.*` from aggregate test/build unless you target them explicitly.
+
+`nx test` does **not** depend on build — package specs import sibling
+packages through their built `lib/`, so run `pnpm build` first in a fresh
+checkout/worktree or cross-package suites fail confusingly (see the
+2026-07-24 agent note on worktree fall-through).
 
 ### Commit messages
 
@@ -331,6 +367,7 @@ Append durable findings to **Agent notes** below (API quirks, migration status, 
 
 _Append learnings for the next agent. Newest first._
 
+- **2026-07-24** — d.ts emission wired for all 13 release packages (see §5 “TypeScript declarations”). Gotchas from the wiring: (1) TS narrowing cannot survive `param = new X(...)` reassignment when X structurally overlaps the param's other union members (AppCtxRoot has a `t` getter, so it IS a `Trigram`) — use a fresh `const`; (2) TanStack's `useLoaderData` typings require an options arg the adapter deliberately omits — comment-cast at the call site, documented; (3) `typescript` is pinned `^5.9.3` (bare `typescript` resolves to the native TS7 compiler, no JS API); (4) @types/react@19 at the root serves react-tao and the routing hooks' emissions. **Worktree fall-through trap:** a worktree nested inside the main repo resolves missing/unbuilt workspace deps through the MAIN repo's `node_modules` (pnpm symlink realpaths escape the worktree) — jest then mixes main-repo builds with worktree sources and `instanceof AppCtx` fails across the two core instances, and tsc type-checks the main repo's untyped bundles. Always `pnpm install && pnpm build` in a fresh worktree before testing.
 - **2026-07-19** — `@tao.js/react`: prefer named export `TaoProvider`; `Provider` remains a deprecated alias (dev once-warning via `deprecations.js`). Default export of `src/Provider.js` is `TaoProvider`.
 - **2026-07-18** — Host-router adapters: `@tao.js/routing-core` (signal apply + `createImportLoader` + React hook factories without importing React) and peer adapters `@tao.js/routing-react-router`, `@tao.js/routing-tanstack-router`, `@tao.js/routing-next`. Prefer these over investing in legacy `@tao.js/router`. Mutation: `pnpm test:mutation:routing-*`.
 - **2026-07-18** — Envelope/decoration redesign implemented on `feat/network-envelope` per ENVELOPE-SPEC.md (spec committed first; eight normative behavioral invariants in §10). Core: `Network.enter` hop engine (dispatch-once, cascade/hop/chain scopes), `Network.decorate`, `AppCtxHandlers` settlement hook, legacy `setCtxControl`+forward path frozen. Utils adapters migrated (Channel = cascade + onForward mirror; Source/Relay = hop-scope origin marker, Relay's unbound-forward bug fixed; Transponder = cascade entry, chains now propagate on bare kernels; Transceiver = settlement hook, `captureSignal` fork deleted). Adapters throw a clear error on pre-envelope cores (mixed-version installs are real — a surveyed app ran core 0.16.0 with utils 0.16.2; set the peerDependency floor when versions are cut at release). New `@tao.js/telemetry` (+ `@tao.js/opentelemetry` exporter): tracing is a pure decoration — full causal trees for kernel/channel/transponder entries with ZERO instrumentation; one tracer per network (chain key exclusivity). `TaoLogger` moved utils → telemetry with a deprecated re-export left in utils (utils gained a runtime dep on telemetry using the `file:` protocol (repo convention). Do NOT use `workspace:` protocol here — pnpm then isolates utils behind a store copy with its own @tao.js/core instance, breaking single-instance `instanceof AppCtx` sharing inside the workspace (found via tools/smoke). Release NOTE: `file:` deps are not rewritten on publish — version this dependency when cutting releases). Gotchas learned: white-box utils tests assert threading mechanics, not just semantics — rewrite intent, don't delete; Stryker `inPlace: true` mutates sources during runs (don't git-operate or run other suites on that package concurrently); jest 30 fails tests on unhandled rejections (assert legacy rethrow via the dispatch promise instead); channel-attached handler chains still re-enter with a fresh cascade (frozen Channel semantic — trace shows them as new roots). Final mutation scores: core 99.70% (0 survivors), utils 100.00% (0 survivors); telemetry 100.00% and opentelemetry 100.00% (Stryker configs wired; thresholds 100 - the first runs surfaced 47 and 3 survivors respectively despite 100% line coverage, all killed).

--- a/config/tsconfig.types.json
+++ b/config/tsconfig.types.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "declarationMap": false,
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "strict": false
+  }
+}

--- a/package.json
+++ b/package.json
@@ -72,21 +72,21 @@
     "@tao.js/core": "file:packages/tao",
     "@tao.js/feature": "file:packages/tao-feature",
     "@tao.js/koa": "file:packages/koa-tao",
+    "@tao.js/opentelemetry": "file:packages/tao-opentelemetry",
     "@tao.js/path": "file:packages/tao-path",
     "@tao.js/react": "file:packages/react-tao",
     "@tao.js/router": "file:packages/tao-router",
-    "@tao.js/opentelemetry": "file:packages/tao-opentelemetry",
     "@tao.js/routing-core": "file:packages/tao-routing-core",
     "@tao.js/routing-next": "file:packages/tao-routing-next",
     "@tao.js/routing-react-router": "file:packages/tao-routing-react-router",
     "@tao.js/routing-tanstack-router": "file:packages/tao-routing-tanstack",
     "@tao.js/socket.io": "file:packages/tao-socket-io",
+    "@tao.js/telemetry": "file:packages/tao-telemetry",
+    "@tao.js/transport-tck": "file:packages/tao-transport-tck",
     "@tao.js/utils": "file:packages/tao-utils",
     "docs": "file:packages/docs",
     "patois.api": "file:examples/patois.api",
-    "patois.web": "file:examples/patois.web",
-    "@tao.js/telemetry": "file:packages/tao-telemetry",
-    "@tao.js/transport-tck": "file:packages/tao-transport-tck"
+    "patois.web": "file:examples/patois.web"
   },
   "devDependencies": {
     "@babel/cli": "7.1.5",
@@ -145,7 +145,8 @@
     "rollup": "4.62.2",
     "rollup-plugin-node-builtins": "^2.1.2",
     "rollup-plugin-node-globals": "^1.4.0",
-    "rollup-plugin-peer-deps-external": "^2.2.4"
+    "rollup-plugin-peer-deps-external": "^2.2.4",
+    "typescript": "^5.9.3"
   },
   "packageManager": "pnpm@10.13.1+sha512.37ebf1a5c7a30d5fabe0c5df44ee8da4c965ca0c5af3dbab28c3a1681b70a256218d05c81c9c0dcf767ef6b8551eb5b960042b9ed4300c59242336377e01cfad"
 }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "commit:validate": "node scripts/validate-commit-msg.js",
     "version": "cz bump",
     "prepare": "husky",
-    "test:mutation:transport-tck": "pnpm --filter @tao.js/transport-tck test:mutation"
+    "test:mutation:transport-tck": "pnpm --filter @tao.js/transport-tck test:mutation",
+    "test:types": "node tools/types-consumer/run.cjs"
   },
   "type": "module",
   "config": {
@@ -115,6 +116,8 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.3.2",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
     "babel-jest": "30.3.0",
     "babel-plugin-istanbul": "^5.2.0",
     "better-npm-run": "^0.1.1",

--- a/packages/koa-tao/package.json
+++ b/packages/koa-tao/package.json
@@ -10,6 +10,7 @@
   },
   "main": "lib",
   "module": "dist",
+  "types": "lib/index.d.ts",
   "files": [
     "lib",
     "dist"
@@ -17,7 +18,8 @@
   "scripts": {
     "build:clean": "rimraf dist lib",
     "build:package": "rollup --config",
-    "build": "npm run build:clean && npm run build:package",
+    "build:types": "tsc -p tsconfig.types.json",
+    "build": "npm run build:clean && npm run build:package && npm run build:types",
     "test:mutation": "stryker run"
   },
   "author": "eudaimos",

--- a/packages/koa-tao/src/enhanced-middleware.js
+++ b/packages/koa-tao/src/enhanced-middleware.js
@@ -1,3 +1,11 @@
+/**
+ * @typedef {import('@tao.js/utils').NetworkSurface} NetworkSurface
+ * @typedef {import('@tao.js/core').Handler} Handler
+ * @typedef {import('./helpers').TrigramSets} TrigramSets
+ * @typedef {import('./helpers').KoaMiddleware} KoaMiddleware
+ * @typedef {import('./helpers').TaoSignaler} TaoSignaler
+ */
+
 // import { AppCtx } from '@tao.js/core';
 import cartesian from 'cartesian';
 import { Transceiver } from '@tao.js/utils';
@@ -7,12 +15,29 @@ const DEFAULT_NAME = 'koa-enhanced-middleware';
 const TRANSCEIVER_NAME_TYPE = 'transceiver';
 const DEFAULT_TIMEOUT = 0;
 
+/**
+ * Build an id-generator that namespaces generated Transceiver ids as
+ * `{name}-{type}-{newId}`.
+ *
+ * @param {string} type - `'transceiver'`
+ * @param {string} name - the configured middleware name
+ * @returns {function((string|number)): string}
+ */
 function getNameId(type, name) {
   return (newId) => {
     return `${name}-${type}-${newId}`;
   };
 }
 
+/**
+ * Build the request-scoped `ctx.tao` surface over the shared Transceiver,
+ * threading the request's continued trace chain into every signal.
+ *
+ * @param {Transceiver} transceiver - the middleware's long-lived Transceiver
+ * @param {(Object|null)} chain - entry chain state from
+ *        {@link module:@tao.js/koa/helpers~chainFromRequest}
+ * @returns {TaoSignaler}
+ */
 function buildCtxTao(transceiver, chain) {
   return {
     setCtx({ t, term, a, action, o, orient }, data) {
@@ -27,18 +52,45 @@ function buildCtxTao(transceiver, chain) {
 }
 
 /**
+ * The API returned by {@link enhancedMiddleware}: attach the Koa middleware
+ * and manage handlers (all three phases) on the middleware's Transceiver.
+ *
+ * Each `add*`/`remove*` method registers/removes the handler for every
+ * trigram in the cartesian product of the given parts.
+ *
+ * @typedef {Object} EnhancedMiddlewareApi
+ * @property {function(): KoaMiddleware} middleware - build the Koa
+ *           middleware: installs the `ctx.tao` signalling surface
+ *           ({@link TaoSignaler}) over the shared Transceiver, with signals
+ *           continuing the request's `traceparent` chain; after downstream
+ *           middleware settles, `ctx.tao` is reset to `null` (the
+ *           Transceiver itself is long-lived)
+ * @property {function(TrigramSets, Handler): void} addInterceptHandler
+ * @property {function(TrigramSets, Handler): void} addAsyncHandler
+ * @property {function(TrigramSets, Handler): void} addInlineHandler
+ * @property {function(TrigramSets, Handler): void} removeInterceptHandler
+ * @property {function(TrigramSets, Handler): void} removeAsyncHandler
+ * @property {function(TrigramSets, Handler): void} removeInlineHandler
+ */
+
+/**
  * Use the `enhancedMiddleware` to build koa apps that work with your TAO Signal Network on the
  * koa app server. Different from the `simpleMiddleware`, the `enhancedMiddleware` utilizes a
  * Transceiver to provide control for how promises are managed within the handlers attached
  * to the TAO Network that the `enhancedMiddleware` wraps (first arg)
  *
+ * One long-lived `Transceiver` spans all requests (no per-request Channel);
+ * `ctx.tao.setCtx(...)` / `ctx.tao.setAppCtx(...)` resolve per the
+ * Transceiver's settlement semantics. Inbound W3C `traceparent` headers are
+ * continued as the entry chain (ENVELOPE-SPEC.md §9).
+ *
  * @export
- * @param {Kernel} TAO
+ * @param {NetworkSurface} TAO - the Kernel (or other TAO Network surface) to signal on
  * @param {Object} [opt={}]
- * @param {string} [opt.name] - name to prepend to the TAO Channel and Transceiver names that will be generated
- * @param {number} [opt.timeout=0] - timeout in Milliseconds to wait on completing a TAO chain before the Transponder rejects the Promise
- * @param {Promise} [opt.promise=Promise] - Promise constructor used to create promises returned by `setCtx` and `setAppCtx`
- * @returns {Object} - an Object instantiated to attach a `middleware` to a koa app and add/remove response handlers
+ * @param {string} [opt.name] - name to prepend to the TAO Transceiver name that will be generated
+ * @param {number} [opt.timeout=0] - timeout in Milliseconds to wait on completing a TAO chain before the Transceiver rejects the Promise (`0` = no timeout)
+ * @param {PromiseConstructor} [opt.promise=Promise] - Promise constructor used to create promises returned by `setCtx` and `setAppCtx`
+ * @returns {EnhancedMiddlewareApi} - an Object instantiated to attach a `middleware` to a koa app and add/remove handlers
  */
 export default function enhancedMiddleware(TAO, opt = {}) {
   const namer = getNameId(TRANSCEIVER_NAME_TYPE, opt.name || DEFAULT_NAME);

--- a/packages/koa-tao/src/helpers.js
+++ b/packages/koa-tao/src/helpers.js
@@ -1,7 +1,137 @@
+/**
+ * Shared helpers and structural typedefs for the `@tao.js/koa` middleware
+ * factories. Koa is **not** a dependency: the `ctx`/`next` parameters are
+ * typed structurally ({@link KoaContextLike}, {@link KoaNext}) with exactly
+ * the members this package uses, so any conformant context works.
+ *
+ * @module @tao.js/koa/helpers
+ */
+
+/**
+ * @typedef {import('@tao.js/core').Trigram} Trigram
+ * @typedef {import('@tao.js/core').AppCtx} AppCtx
+ * @typedef {import('@tao.js/core').Handler} Handler
+ */
+
+/**
+ * A trigram matcher whose parts may also be **arrays** of values: the
+ * middleware handler registration methods register the given handler for
+ * the cartesian product of the parts (e.g.
+ * `{ t: ['User', 'Account'], a: 'View' }` registers for `{User,View}` and
+ * `{Account,View}`). Short and long keys are both accepted (long-form keys
+ * win); nullish parts are dropped (wildcards).
+ *
+ * @typedef {Object} TrigramSets
+ * @property {(string|string[])} [t] - term (short key)
+ * @property {(string|string[])} [term] - term (long key)
+ * @property {(string|string[])} [a] - action (short key)
+ * @property {(string|string[])} [action] - action (long key)
+ * @property {(string|string[])} [o] - orient (short key)
+ * @property {(string|string[])} [orient] - orient (long key)
+ */
+
+/**
+ * A long-form trigram as normalized by {@link normalizeAC}: short keys
+ * folded into the long ones (long-form keys win); parts may still be
+ * arrays and may be `undefined` until {@link cleanInput} drops them.
+ *
+ * @typedef {Object} LongTrigram
+ * @property {(string|string[])} [term]
+ * @property {(string|string[])} [action]
+ * @property {(string|string[])} [orient]
+ */
+
+/**
+ * Structural shape of the Koa request this package actually reads.
+ *
+ * @typedef {Object} KoaRequestLike
+ * @property {Object.<string, string>} [headers] - request headers; the
+ *           `traceparent` header is read for trace-chain continuation
+ * @property {(Object|function(): (Object|Promise<Object>))} [json] - parsed
+ *           JSON body, or a (possibly async) accessor for it
+ * @property {(Object|function(): (Object|Promise<Object>))} [body] - parsed
+ *           request body, or a (possibly async) accessor for it
+ */
+
+/**
+ * Structural shape of the Koa context this package actually uses. The HTTP
+ * middleware reads `path`/`method`/`request` and writes `status`/`body`;
+ * the simple and enhanced middleware install (and clear) the
+ * request-scoped signalling surface at `ctx.tao`.
+ *
+ * @typedef {Object} KoaContextLike
+ * @property {string} [path] - request path, matched against the middleware's
+ *           root (HTTP middleware)
+ * @property {string} [method] - HTTP method (HTTP middleware)
+ * @property {number} [status] - response status, written by the HTTP
+ *           middleware (404/405/400/500)
+ * @property {*} [body] - response body, written by the HTTP middleware
+ * @property {KoaRequestLike} [request] - the request (headers + body access)
+ * @property {(TaoSignaler|null)} [tao] - request-scoped TAO surface
+ *           installed by the simple/enhanced middleware while downstream
+ *           middleware runs; `null` outside that window
+ */
+
+/**
+ * Koa's downstream continuation.
+ *
+ * @callback KoaNext
+ * @returns {Promise<*>}
+ */
+
+/**
+ * The Koa middleware function the factories' `middleware()` methods return.
+ *
+ * @callback KoaMiddleware
+ * @param {KoaContextLike} ctx
+ * @param {KoaNext} next
+ * @returns {Promise<*>}
+ */
+
+/**
+ * Signal a trigram + data (short or long keys; long-form keys win) on the
+ * request's backing Transponder/Transceiver.
+ *
+ * @callback TaoSignalerSetCtx
+ * @param {Trigram} trigram
+ * @param {*} [data] - the signal's datagram(s)
+ * @returns {Promise<*>}
+ */
+
+/**
+ * Signal an already-constructed AppCtx on the request's backing
+ * Transponder/Transceiver.
+ *
+ * @callback TaoSignalerSetAppCtx
+ * @param {AppCtx} ac
+ * @returns {Promise<*>}
+ */
+
+/**
+ * The request-scoped signalling surface installed at `ctx.tao` by the
+ * simple and enhanced middleware. Both methods signal on the backing
+ * Transponder/Transceiver with the request's continued trace chain
+ * ({@link chainFromRequest}) and return its settlement Promise — resolving
+ * with the first response AppCon handled for the signal (see
+ * `@tao.js/utils` `Transponder`/`Transceiver` for timeout semantics).
+ *
+ * @typedef {Object} TaoSignaler
+ * @property {TaoSignalerSetCtx} setCtx
+ * @property {TaoSignalerSetAppCtx} setAppCtx
+ */
+
 import { TRACE_CHAIN, parseTraceparent } from '@tao.js/telemetry';
 
+/** A shared no-op, used as the default response handler. */
 export const noop = () => {};
 
+/**
+ * Fold a trigram's short keys into the long ones (long-form keys win).
+ * Missing parts stay `undefined` (dropped later by {@link cleanInput}).
+ *
+ * @param {TrigramSets} trigram - short or long keys; parts may be arrays
+ * @returns {LongTrigram} the long-form trigram
+ */
 export function normalizeAC({ t, term, a, action, o, orient }) {
   return {
     term: term || t,
@@ -10,6 +140,13 @@ export function normalizeAC({ t, term, a, action, o, orient }) {
   };
 }
 
+/**
+ * Drop nullish parts from a long-form trigram — the remaining parts feed
+ * the cartesian product used by the handler registration methods.
+ *
+ * @param {LongTrigram} trigram
+ * @returns {LongTrigram} the same parts minus nullish entries
+ */
 export const cleanInput = ({ term, action, orient }) => {
   const incoming = { term, action, orient };
   Object.keys(incoming).forEach(
@@ -21,7 +158,15 @@ export const cleanInput = ({ term, action, orient }) => {
 /**
  * Continue an inbound W3C `traceparent` header as entry chain state
  * (ENVELOPE-SPEC.md §9: request/response transports map the tracing chain
- * key to `traceparent`). Absent or malformed headers yield `null`.
+ * key — `taoTrace` — to `traceparent`). Absent or malformed headers yield
+ * `null` (a fresh chain). Responses carry no chain in 0.20 — there is no
+ * standard W3C response header.
+ *
+ * @param {KoaContextLike} [ctx] - the request context; only
+ *        `ctx.request.headers.traceparent` is read
+ * @returns {(Object|null)} entry chain state
+ *          `{ taoTrace: { traceId, signalId } }` continuing the remote
+ *          trace, or `null`
  */
 export function chainFromRequest(ctx) {
   const header =

--- a/packages/koa-tao/src/index.js
+++ b/packages/koa-tao/src/index.js
@@ -1,3 +1,39 @@
+/**
+ * @tao.js/koa — expose a TAO signal network over HTTP via Koa middleware.
+ *
+ * Three factories, all taking the network surface first:
+ *
+ * - {@link taoHttpMiddleware} (the default export) — serve the TAO HTTP
+ *   surface (`POST /{root}/context`, `GET /{root}/responses`) over a
+ *   shared Channel with per-request Transponders.
+ * - {@link simpleMiddleware} — install a request-scoped `ctx.tao`
+ *   signalling surface backed by a per-request Transponder on a shared
+ *   Channel.
+ * - {@link enhancedMiddleware} — install `ctx.tao` backed by one
+ *   long-lived Transceiver spanning all requests.
+ *
+ * Koa is **not** a dependency: `ctx`/`next` are typed structurally (see
+ * {@link KoaContextLike}) with exactly the members this package uses.
+ * All three factories continue an inbound W3C `traceparent` header as the
+ * signal's entry chain (ENVELOPE-SPEC.md §9).
+ *
+ * @module @tao.js/koa
+ */
+
+/**
+ * Shared shapes re-exported for typed consumers (the JSDoc typedefs are the
+ * source of truth at their defining modules).
+ *
+ * @typedef {import('./helpers').KoaContextLike} KoaContextLike
+ * @typedef {import('./helpers').KoaRequestLike} KoaRequestLike
+ * @typedef {import('./helpers').KoaMiddleware} KoaMiddleware
+ * @typedef {import('./helpers').KoaNext} KoaNext
+ * @typedef {import('./helpers').TaoSignaler} TaoSignaler
+ * @typedef {import('./helpers').TrigramSets} TrigramSets
+ * @typedef {import('./tao-http-middleware').TaoHttpMiddlewareApi} TaoHttpMiddlewareApi
+ * @typedef {import('./simple-middleware').SimpleMiddlewareApi} SimpleMiddlewareApi
+ * @typedef {import('./enhanced-middleware').EnhancedMiddlewareApi} EnhancedMiddlewareApi
+ */
 import taoHttpMiddleware from './tao-http-middleware';
 import simpleMiddleware from './simple-middleware';
 import enhancedMiddleware from './enhanced-middleware';

--- a/packages/koa-tao/src/simple-middleware.js
+++ b/packages/koa-tao/src/simple-middleware.js
@@ -1,3 +1,11 @@
+/**
+ * @typedef {import('@tao.js/utils').NetworkSurface} NetworkSurface
+ * @typedef {import('@tao.js/core').Handler} Handler
+ * @typedef {import('./helpers').TrigramSets} TrigramSets
+ * @typedef {import('./helpers').KoaMiddleware} KoaMiddleware
+ * @typedef {import('./helpers').TaoSignaler} TaoSignaler
+ */
+
 // import { AppCtx } from '@tao.js/core';
 import cartesian from 'cartesian';
 import { Channel, Transponder } from '@tao.js/utils';
@@ -8,12 +16,30 @@ const CHANNEL_NAME_TYPE = 'channel';
 const TRANSPONDER_NAME_TYPE = 'transponder';
 const DEFAULT_TIMEOUT = 3000;
 
+/**
+ * Build an id-generator that namespaces generated Channel/Transponder ids
+ * as `{name}-{type}-{newId}`.
+ *
+ * @param {string} type - `'channel'` or `'transponder'`
+ * @param {string} name - the configured middleware name
+ * @returns {function((string|number)): string}
+ */
 function getNameId(type, name) {
   return (newId) => {
     return `${name}-${type}-${newId}`;
   };
 }
 
+/**
+ * Build the request-scoped `ctx.tao` surface over the request's
+ * Transponder, threading the request's continued trace chain into every
+ * signal.
+ *
+ * @param {Transponder} transponder - the request's Transponder
+ * @param {(Object|null)} chain - entry chain state from
+ *        {@link module:@tao.js/koa/helpers~chainFromRequest}
+ * @returns {TaoSignaler}
+ */
 function buildCtxTao(transponder, chain) {
   return {
     setCtx({ t, term, a, action, o, orient }, data) {
@@ -28,17 +54,43 @@ function buildCtxTao(transponder, chain) {
 }
 
 /**
+ * The API returned by {@link simpleMiddleware}: attach the Koa middleware
+ * and manage response handlers on the middleware's Channel.
+ *
+ * @typedef {Object} SimpleMiddlewareApi
+ * @property {function(): KoaMiddleware} middleware - build the Koa
+ *           middleware: each request gets its own Transponder on the shared
+ *           Channel and a `ctx.tao` signalling surface
+ *           ({@link TaoSignaler}) whose signals continue the request's
+ *           `traceparent` chain; after downstream middleware settles, the
+ *           Transponder is detached and `ctx.tao` is reset to `null`
+ * @property {function(TrigramSets, Handler=): void} addResponseHandler -
+ *           attach an inline handler to the middleware's Channel for every
+ *           trigram in the cartesian product of the given parts (defaults
+ *           to a no-op handler)
+ * @property {function(TrigramSets, Handler=): void} removeResponseHandler -
+ *           remove a previously attached handler for the same trigram
+ *           parts
+ */
+
+/**
  * Use the `simpleMiddleware` to build koa apps that work with your TAO Signal Network on the
  * koa app server.
  *
+ * All requests share one `Channel` on the network; each request signals
+ * through its own short-lived `Transponder` so `ctx.tao.setCtx(...)` /
+ * `ctx.tao.setAppCtx(...)` resolve with the first response AppCon handled
+ * for that request's signal. Inbound W3C `traceparent` headers are
+ * continued as the entry chain (ENVELOPE-SPEC.md §9).
+ *
  * @export
- * @param {Kernel} TAO
+ * @param {NetworkSurface} TAO - the Kernel (or other TAO Network surface) to signal on
  * @param {Object} [opt={}]
  * @param {string} [opt.name] - name to prepend to the TAO Channel and Transponder names that will be generated
  * @param {number} [opt.timeout=3000] - timeout in Milliseconds to wait on completing a TAO chain before the Transponder rejects the Promise
- * @param {Promise} [opt.promise=Promise] - Promise constructor used to create promises returned by `setCtx` and `setAppCtx`
+ * @param {PromiseConstructor} [opt.promise=Promise] - Promise constructor used to create promises returned by `setCtx` and `setAppCtx`
  * @param {boolean} [opt.debug] - print console.log of internal behavior
- * @returns {Object} - an Object instantiated to attach a `middleware` to a koa app and add/remove response handlers
+ * @returns {SimpleMiddlewareApi} - an Object instantiated to attach a `middleware` to a koa app and add/remove response handlers
  */
 export default function simpleMiddleware(TAO, opt = {}) {
   const { debug = false } = opt;

--- a/packages/koa-tao/src/tao-http-middleware.js
+++ b/packages/koa-tao/src/tao-http-middleware.js
@@ -1,3 +1,12 @@
+/**
+ * @typedef {import('@tao.js/utils').NetworkSurface} NetworkSurface
+ * @typedef {import('@tao.js/core').Handler} Handler
+ * @typedef {import('./helpers').TrigramSets} TrigramSets
+ * @typedef {import('./helpers').KoaContextLike} KoaContextLike
+ * @typedef {import('./helpers').KoaNext} KoaNext
+ * @typedef {import('./helpers').KoaMiddleware} KoaMiddleware
+ */
+
 import { AppCtx } from '@tao.js/core';
 import cartesian from 'cartesian';
 import { Channel, Transponder } from '@tao.js/utils';
@@ -11,6 +20,16 @@ const ROUTE_RESPONSES = 'responses';
 const ROUTE_CONTEXT = 'context';
 const DEFAULT_TIMEOUT = 3000;
 
+/**
+ * Resolve the request's body data: the configured `opt.json` field first,
+ * then `ctx.request.json`, then `ctx.request.body` — each may be the value
+ * itself or a (possibly async) accessor function. Resolves `null` when no
+ * source yields data.
+ *
+ * @param {KoaContextLike} ctx
+ * @param {string} [bodyProp] - the configured request field (`opt.json`)
+ * @returns {Promise<(Object|null)>} the body — expected `{ tao, data }`
+ */
 async function getBodyData(ctx, bodyProp) {
   let data = null;
   if (bodyProp && ctx.request[bodyProp]) {
@@ -37,6 +56,16 @@ async function getBodyData(ctx, bodyProp) {
   return data;
 }
 
+/**
+ * `GET /{root}/responses` — reply with the trigrams that currently have at
+ * least one attached response handler, as
+ * `{ responses: [{ t, a, o }, …] }`.
+ *
+ * @param {Map<string, { ac: AppCtx, count: number }>} responseTrigrams
+ * @param {KoaContextLike} ctx
+ * @param {KoaNext} next
+ * @returns {Promise<*>} `next()`'s result
+ */
 function handleResponsesRequest(responseTrigrams, ctx, next) {
   // const out = Array.from(responseTrigrams.values());
   ctx.body = {
@@ -48,6 +77,20 @@ function handleResponsesRequest(responseTrigrams, ctx, next) {
   return next();
 }
 
+/**
+ * `POST /{root}/context` — signal the request body's `{ tao, data }` on the
+ * per-request Transponder (continuing the request's `traceparent` chain)
+ * and reply with the first response AppCon as `{ tao, data }`; a rejected
+ * settlement (e.g. Transponder timeout) replies 500.
+ *
+ * @param {Transponder} transponder - the request's Transponder
+ * @param {(string|undefined)} bodyProp - the configured request body field
+ *        (`opt.json`)
+ * @param {KoaContextLike} ctx
+ * @param {KoaNext} next - unused; settlement is awaited here, `next()` runs
+ *        in the caller
+ * @returns {Promise<void>}
+ */
 async function handleContext(transponder, bodyProp, ctx, next) {
   // getBodyData resolves to null when no matching body/json/configured field is
   // present on the request; guard so a body-less POST can't crash the process.
@@ -66,7 +109,48 @@ async function handleContext(transponder, bodyProp, ctx, next) {
   }
 }
 
+/**
+ * The API returned by {@link taoMiddleware}: attach the Koa middleware and
+ * manage response handlers on the middleware's Channel.
+ *
+ * @typedef {Object} TaoHttpMiddlewareApi
+ * @property {function(): KoaMiddleware} middleware - build the Koa
+ *           middleware serving the TAO HTTP surface under `/{root}`:
+ *           `POST /{root}/context` signals the body's `{ tao, data }`
+ *           through a per-request Transponder — continuing the request's
+ *           W3C `traceparent` chain (ENVELOPE-SPEC.md §9) — and replies
+ *           with the first response AppCon as `{ tao, data }`;
+ *           `GET /{root}/responses` lists the trigrams with attached
+ *           response handlers. Non-matching paths pass through; wrong
+ *           methods get 405, unknown routes 404, extra path segments 400.
+ * @property {function(TrigramSets, Handler=): void} addResponseHandler -
+ *           attach an inline response handler to the middleware's Channel
+ *           for every trigram in the cartesian product of the given parts
+ *           (defaults to a no-op handler), and advertise it on
+ *           `GET /{root}/responses`
+ * @property {function(TrigramSets, Handler=): void} removeResponseHandler -
+ *           remove a previously attached handler and decrement its
+ *           advertised count
+ */
+
+/**
+ * Expose a TAO signal network over HTTP: request/response semantics on top
+ * of the network via a `Channel` (shared by all requests) + per-request
+ * `Transponder`s.
+ *
+ * @export
+ * @param {NetworkSurface} TAO - the Kernel (or other TAO Network surface) to expose
+ * @param {Object} [opt={}]
+ * @param {string} [opt.root='tao'] - URL root the middleware serves (`/{root}/context`, `/{root}/responses`)
+ * @param {string} [opt.name] - name for the middleware's Channel
+ * @param {string} [opt.json] - request field holding the parsed body (checked before `request.json` / `request.body`)
+ * @param {number} [opt.timeout=3000] - timeout in Milliseconds to wait on completing a TAO chain before the Transponder rejects the Promise
+ * @param {PromiseConstructor} [opt.promise=Promise] - Promise constructor used for the per-request settlement promises
+ * @param {boolean} [opt.debug] - print console.log of internal behavior
+ * @returns {TaoHttpMiddlewareApi} - an Object instantiated to attach a `middleware` to a koa app and add/remove response handlers
+ */
 export default function taoMiddleware(TAO, opt = {}) {
+  /** @type {Map<string, { ac: AppCtx, count: number }>} */
   const responseTrigrams = new Map();
   const { debug = false } = opt;
   const bodyProp = opt.json;

--- a/packages/koa-tao/tsconfig.types.json
+++ b/packages/koa-tao/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../config/tsconfig.types.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": ["src"]
+}

--- a/packages/react-tao/package.json
+++ b/packages/react-tao/package.json
@@ -10,6 +10,7 @@
   },
   "main": "lib",
   "module": "dist",
+  "types": "lib/index.d.ts",
   "orig": "orig",
   "bundles": {
     "browser": "bundles/browser.umd.js",
@@ -29,7 +30,8 @@
   "scripts": {
     "build:clean": "rimraf dist lib orig bundles",
     "build:package": "rollup --config",
-    "build": "npm run build:clean && npm run build:package",
+    "build:types": "tsc -p tsconfig.types.json",
+    "build": "npm run build:clean && npm run build:package && npm run build:types",
     "test:mutation": "stryker run"
   },
   "author": "eudaimos",

--- a/packages/react-tao/src/Adapter.js
+++ b/packages/react-tao/src/Adapter.js
@@ -4,51 +4,118 @@ import { AppCtx } from '@tao.js/core';
 
 import { noop, normalizeClean } from './helpers';
 
-const wrappedHandler = (ComponentHandler = null, props, _adapter) => (
-  tao,
-  data
-) => {
-  _adapter._current = {
-    ComponentHandler,
-    tao,
-    props: {
-      ...props,
-      ...data
-    }
-  };
-  _adapter._reactors.forEach(notify => notify());
-};
+/** @typedef {import('@tao.js/core').Kernel} Kernel */
+/** @typedef {import('@tao.js/core').Handler} Handler */
+/** @typedef {import('./helpers').TrigramProps} TrigramProps */
+/** @typedef {import('./helpers').NormalizedTrigram} NormalizedTrigram */
+/** @typedef {import('./helpers').TaoSignal} TaoSignal */
 
+/**
+ * Snapshot of the latest matched component handler, rendered by `Reactor`.
+ * @typedef {Object} AdapterCurrent
+ * @property {import('react').ComponentType<*>|null} ComponentHandler - the
+ *           component registered for the matched trigram (`null` renders
+ *           nothing)
+ * @property {TaoSignal} tao - trigram of the AppCon that fired
+ * @property {Object<string, *>} props - registration props merged with the
+ *           AppCon data
+ */
+
+/**
+ * @param {import('react').ComponentType<*>|null} ComponentHandler
+ * @param {Object<string, *>} props
+ * @param {Adapter} _adapter
+ * @returns {Handler}
+ */
+const wrappedHandler =
+  (ComponentHandler = null, props, _adapter) =>
+  (tao, data) => {
+    _adapter._current = {
+      ComponentHandler,
+      tao,
+      props: {
+        ...props,
+        ...data,
+      },
+    };
+    _adapter._reactors.forEach((notify) => notify());
+  };
+
+/**
+ * Original ("orig" entry) API: registers React components as inline handlers
+ * on a Kernel and tracks the latest match for a `Reactor` to render.
+ * Legacy — prefer the current component/hook API from the package root.
+ */
 class Adapter {
+  /**
+   * @param {Kernel} TAO - the Kernel to register inline handlers on
+   */
   constructor(TAO) {
     this._tao = TAO;
+    /** @type {?AdapterCurrent} */
     this._current = null;
+    /** @type {NormalizedTrigram} */
     this._default = {};
+    /** @type {Map<object, () => void>} */
     this._reactors = new Map();
+    /** @type {Map<*, {handlers: Map<AppCtx, Handler>, index: Map<string, AppCtx>}>} */
     this._components = new Map();
   }
 
+  /**
+   * The latest matched component snapshot, or `null` before any match.
+   * @returns {?AdapterCurrent}
+   */
   get current() {
     return this._current;
   }
 
+  /**
+   * Copy of the default trigram parts merged under every add/remove call.
+   * @returns {NormalizedTrigram}
+   */
   get defaultCtx() {
     return { ...this._default };
   }
 
+  /**
+   * Set the default trigram parts (short/long keys, arrays allowed;
+   * assigning `undefined` resets to empty).
+   * @param {TrigramProps} trigramProps
+   */
+  // @ts-ignore TS1052 — the `= {}` initializer is valid JS (assigning `undefined` resets the default, asserted in tests)
   set defaultCtx({ t, term, a, action, o, orient } = {}) {
     this._default = normalizeClean({ t, term, a, action, o, orient });
   }
 
+  /**
+   * Chainable form of the `defaultCtx` setter.
+   * @param {TrigramProps} [trigramProps]
+   * @returns {this}
+   */
   setDefaultCtx({ t, term, a, action, o, orient } = {}) {
     this.defaultCtx = { t, term, a, action, o, orient };
     return this;
   }
 
+  /**
+   * Register `ComponentHandler` to render for every permutation of the
+   * trigram (merged over `defaultCtx`). No-op when the merged trigram is
+   * empty; a nullish `ComponentHandler` makes the Reactor render nothing
+   * for those trigrams.
+   * @param {TrigramProps} [trigramProps] - trigram(s) to match
+   * @param {import('react').ComponentType<*>} [ComponentHandler] - component
+   *        to render on match
+   * @param {Object<string, *>} [props] - extra props for the rendered
+   *        component (AppCon data overrides same-named keys)
+   * @returns {this}
+   * @throws {Error} when `ComponentHandler` is neither a React.Component
+   *         nor a function
+   */
   addComponentHandler(
     { t, term, a, action, o, orient } = {},
     ComponentHandler,
-    props
+    props,
   ) {
     if (
       ComponentHandler &&
@@ -58,7 +125,7 @@ class Adapter {
       )
     ) {
       throw new Error(
-        'cannot add a Component handler that is not a React.Component or Function'
+        'cannot add a Component handler that is not a React.Component or Function',
       );
     }
     const tao = normalizeClean({ t, term, a, action, o, orient });
@@ -71,11 +138,11 @@ class Adapter {
     if (!this._components.has(ComponentHandler)) {
       this._components.set(ComponentHandler, {
         handlers: new Map(),
-        index: new Map()
+        index: new Map(),
       });
     }
     const componentHandlers = this._components.get(ComponentHandler);
-    permutations.forEach(tao => {
+    permutations.forEach((tao) => {
       const { term, action, orient } = tao;
       const acKey = AppCtx.getKey(term, action, orient);
       if (!componentHandlers.index.has(acKey)) {
@@ -91,9 +158,18 @@ class Adapter {
     return this;
   }
 
+  /**
+   * Unregister a component: with trigram parts, removes those permutations;
+   * with an empty trigram (and empty `defaultCtx`), removes every handler
+   * registered for `ComponentHandler`.
+   * @param {TrigramProps} [trigramProps] - trigram(s) to remove
+   * @param {import('react').ComponentType<*>} [ComponentHandler] - the
+   *        registered component
+   * @returns {this}
+   */
   removeComponentHandler(
     { t, term, a, action, o, orient } = {},
-    ComponentHandler
+    ComponentHandler,
   ) {
     if (!this._components.has(ComponentHandler)) {
       return this;
@@ -128,10 +204,22 @@ class Adapter {
     return this;
   }
 
+  /**
+   * Subscribe a Reactor (or any identity) to be notified on new matches.
+   * @param {object} reactor - the subscriber identity
+   * @param {() => void} [notify] - called when a matching AppCon updates
+   *        `current`
+   * @returns {void}
+   */
   registerReactor(reactor, notify = noop) {
     this._reactors.set(reactor, notify);
   }
 
+  /**
+   * Remove a previously registered Reactor subscription.
+   * @param {object} reactor - the subscriber identity
+   * @returns {void}
+   */
   unregisterReactor(reactor) {
     this._reactors.delete(reactor);
   }

--- a/packages/react-tao/src/DataConsumer.js
+++ b/packages/react-tao/src/DataConsumer.js
@@ -4,6 +4,29 @@ import PropTypes from 'prop-types';
 import { Context } from './Provider';
 import { warnDeprecated } from './deprecations';
 
+/**
+ * Render-prop children of {@link DataConsumer}: one positional arg per
+ * requested `context` name, in order (missing names yield `null`).
+ * @callback DataConsumerChildren
+ * @param {...*} contextData - data bag values for the `context` names
+ * @returns {import('react').ReactNode}
+ */
+
+/**
+ * Props for the deprecated {@link DataConsumer}.
+ * @typedef {Object} DataConsumerProps
+ * @property {string|string[]} context - DataHandler name(s) to read from the
+ *           (deprecated) Provider data bag
+ * @property {DataConsumerChildren} children - render prop receiving the
+ *           named data as positional args
+ */
+
+/**
+ * Read one named value from the deprecated Provider data bag.
+ * @param {Object<string, *>} data
+ * @param {string} ctxName
+ * @returns {*}
+ */
 function readNamedData(data, ctxName) {
   // Stryker disable next-line ConditionalExpression: missing key still yields undefined≈null for consumers that only check truthiness; warn path is asserted separately
   if (data == null || !Object.prototype.hasOwnProperty.call(data, ctxName)) {
@@ -19,7 +42,10 @@ function readNamedData(data, ctxName) {
 }
 
 /**
+ * Render-prop consumer of named DataHandler data from the Provider bag.
  * @deprecated Since 0.17 — prefer `useTaoData('name')` in function components.
+ * @param {DataConsumerProps} props
+ * @returns {import('react').ReactNode}
  */
 function DataConsumer({ context, children }) {
   // Stryker disable all: deprecation copy; asserted via stringContaining in tests

--- a/packages/react-tao/src/DataHandler.js
+++ b/packages/react-tao/src/DataHandler.js
@@ -5,10 +5,39 @@ import { Context } from './Provider';
 import { DataLayerContext } from './DataLayerContext';
 import useTaoDataState from './useTaoDataState';
 
+/** @typedef {import('./helpers').TrigramPart} TrigramPart */
+/**
+ * @template [S=any]
+ * @typedef {import('./useTaoDataState').TaoDataHandler<S>} TaoDataHandler
+ */
+
+/**
+ * Props for {@link DataHandler}. Trigram parts (`t`/`term`, `a`/`action`,
+ * `o`/`orient`) accept single values or arrays (multi-match); missing parts
+ * are wildcards.
+ * @typedef {Object} DataHandlerProps
+ * @property {string} name - tree-scoped lookup key for `useTaoData(name)`
+ *           in descendants (inner DataHandlers shadow outer ones)
+ * @property {TaoDataHandler<*>} [handler] - derives the next data per
+ *           matching AppCon (`(tao, data, set, current) => …`); omitted =
+ *           the AppCon data replaces the value
+ * @property {*} [default] - initial data or a lazy initializer function
+ *           (defaults to `{}`)
+ * @property {import('react').ReactNode} [children]
+ * @property {TrigramPart} [term] - the term: the domain thing
+ * @property {TrigramPart} [action] - the action: the operation on the term
+ * @property {TrigramPart} [orient] - the orient: perspective / role / surface
+ * @property {TrigramPart} [t] - the term (short key)
+ * @property {TrigramPart} [a] - the action (short key)
+ * @property {TrigramPart} [o] - the orient (short key)
+ */
+
 /**
  * Subscribes to TAO trigrams and exposes named state to descendants.
  * Pushes onto the tree-scoped data layer (ancestor walk) and merges into
  * Provider `data[name]` for deprecated bag consumers during the 0.17 overlap.
+ * @param {DataHandlerProps} props
+ * @returns {import('react').ReactElement}
  */
 function DataHandler({
   name,

--- a/packages/react-tao/src/DataLayerContext.js
+++ b/packages/react-tao/src/DataLayerContext.js
@@ -1,11 +1,24 @@
 import { createContext, useContext } from 'react';
 
 /**
+ * One tree-scoped named data layer pushed by a `DataHandler`.
+ * @typedef {Object} DataLayer
+ * @property {string} name - the DataHandler `name` prop (the lookup key)
+ * @property {*} value - that DataHandler's current handler-managed data
+ */
+
+/**
  * Ancestor stack of `{ name, value }` from nested DataHandlers.
  * Root is `[]`. Lookup walks from the end (nearest wins).
+ * @type {import('react').Context<DataLayer[]>}
  */
 export const DataLayerContext = createContext([]);
 
+/**
+ * The ancestor DataHandler layer stack for this position in the tree
+ * (empty array at the root / outside any DataHandler).
+ * @returns {DataLayer[]}
+ */
 export function useDataLayers() {
   return useContext(DataLayerContext);
 }

--- a/packages/react-tao/src/Provider.js
+++ b/packages/react-tao/src/Provider.js
@@ -6,9 +6,27 @@ import { DataLayerContext } from './DataLayerContext';
 import { warnDeprecated } from './deprecations';
 
 /**
+ * Value provided by {@link TaoProvider} (and re-provided by each nested
+ * `DataHandler`): the Kernel for this tree plus the merged named-data bag.
+ * @typedef {Object} ProviderContextValue
+ * @property {Kernel} TAO - the Kernel descendants signal and subscribe on
+ * @property {Object<string, *>} data - merged `name -> data` bag from
+ *           ancestor DataHandlers (deprecated consume surface — prefer
+ *           `useTaoData(name)`)
+ */
+
+/**
+ * Props for {@link TaoProvider} (and the deprecated `Provider` alias).
+ * @typedef {Object} TaoProviderProps
+ * @property {Kernel} TAO - the Kernel instance this React tree uses
+ * @property {import('react').ReactNode} [children]
+ */
+
+/**
  * Root TAO + empty data bag / data-layer stack.
  * Each DataHandler nests Provider `data[name]` (deprecated bag) and pushes
  * onto DataLayerContext for tree-scoped `useTaoData` lookups.
+ * @type {import('react').Context<ProviderContextValue>}
  */
 const Context = React.createContext({
   TAO,
@@ -17,6 +35,12 @@ const Context = React.createContext({
 
 export { Context };
 
+/**
+ * Makes a Kernel available to all @tao.js/react components and hooks in the
+ * tree (and resets the tree-scoped DataHandler layer stack).
+ * @param {TaoProviderProps} props
+ * @returns {import('react').ReactElement}
+ */
 function TaoProvider({ TAO: kernel, children }) {
   // Root layer stack must be empty so useTaoData() is undefined until a DataHandler pushes.
   const emptyLayers = [];
@@ -39,6 +63,8 @@ TaoProvider.propTypes = {
 
 /**
  * @deprecated Use {@link TaoProvider} instead.
+ * @param {TaoProviderProps} props
+ * @returns {import('react').ReactElement}
  */
 function Provider(props) {
   warnDeprecated(

--- a/packages/react-tao/src/Reactor.js
+++ b/packages/react-tao/src/Reactor.js
@@ -4,6 +4,21 @@ import Adapter from './Adapter';
 
 const DUMMY_STATE = {};
 
+/**
+ * Props for {@link Reactor}: the adapter plus passthrough props spread onto
+ * whichever component the adapter's current match renders.
+ * @typedef {{ adapter: Adapter } & Object<string, *>} ReactorProps
+ */
+
+/**
+ * Original ("orig" entry) API: renders the component its {@link Adapter}
+ * registered for the most recent matching AppCon — or nothing before any
+ * match. The rendered component receives the trigram (`t`/`a`/`o`), the
+ * Reactor's passthrough props, and the registration props merged with the
+ * AppCon data. NOTE: children are ignored.
+ * Legacy — prefer `RenderHandler` / `SwitchHandler` from the package root.
+ * @extends {React.Component<ReactorProps>}
+ */
 class Reactor extends React.Component {
   static get propTypes() {
     return {
@@ -11,6 +26,9 @@ class Reactor extends React.Component {
     };
   }
 
+  /**
+   * @param {ReactorProps} props
+   */
   constructor(props) {
     super(props);
     // this._adapter = adapter;
@@ -27,6 +45,9 @@ class Reactor extends React.Component {
     adapter && adapter.unregisterReactor && adapter.unregisterReactor(this);
   }
 
+  /**
+   * @param {ReactorProps} prevProps
+   */
   componentDidUpdate(prevProps) {
     const { adapter } = this.props;
     if (adapter !== prevProps.adapter) {
@@ -35,6 +56,10 @@ class Reactor extends React.Component {
     }
   }
 
+  /**
+   * @param {ReactorProps} nextProps
+   * @returns {boolean}
+   */
   shouldComponentUpdate(nextProps) {
     return true;
   }

--- a/packages/react-tao/src/RenderHandler.js
+++ b/packages/react-tao/src/RenderHandler.js
@@ -13,6 +13,55 @@ import { Context } from './Provider';
 import useTaoInlineSubscription from './useTaoInlineSubscription';
 import { warnDeprecated } from './deprecations';
 
+/** @typedef {import('./helpers').TrigramPart} TrigramPart */
+/** @typedef {import('./helpers').TrigramProps} TrigramProps */
+/** @typedef {import('./helpers').TaoSignal} TaoSignal */
+
+/**
+ * Render-prop children of {@link RenderHandler}: called with the matched
+ * AppCon's trigram and data. Extra positional `contextData` args are only
+ * appended when the deprecated `context` prop is used.
+ * @callback RenderHandlerChildren
+ * @param {TaoSignal} tao - trigram of the AppCon that matched (or `initialTao`)
+ * @param {*} data - data of that AppCon (or `initialData`)
+ * @param {...*} contextData - deprecated: data-bag values for the `context`
+ *        prop names, in order — use `useTaoData(name)` in a child instead
+ * @returns {import('react').ReactNode}
+ */
+
+/**
+ * Props for {@link RenderHandler}. Trigram parts (`t`/`term`, `a`/`action`,
+ * `o`/`orient`) accept single values or arrays (multi-match); missing parts
+ * are wildcards.
+ * @typedef {Object} RenderHandlerProps
+ * @property {TrigramPart} [term] - the term: the domain thing
+ * @property {TrigramPart} [action] - the action: the operation on the term
+ * @property {TrigramPart} [orient] - the orient: perspective / role / surface
+ * @property {TrigramPart} [t] - the term (short key)
+ * @property {TrigramPart} [a] - the action (short key)
+ * @property {TrigramPart} [o] - the orient (short key)
+ * @property {string|string[]} [context] - deprecated (removal planned):
+ *           DataHandler name(s) appended to the render prop as positional
+ *           args — use `useTaoData(name)` in a child component instead
+ * @property {TrigramProps} [refreshOn] - extra trigram parts merged over the
+ *           match trigram to also re-render on (e.g. `{ action: 'Refresh' }`);
+ *           ignored when it normalizes to empty
+ * @property {boolean} [debug=false] - log subscription/render diagnostics
+ * @property {boolean} [shouldRender=false] - render immediately with
+ *           `initialTao`/`initialData` before any signal arrives
+ * @property {TaoSignal} [initialTao] - trigram passed to children before the
+ *           first signal (with `shouldRender`)
+ * @property {*} [initialData] - data passed to children before the first
+ *           signal (with `shouldRender`)
+ * @property {RenderHandlerChildren} children - render prop `(tao, data) => …`
+ */
+
+/**
+ * Read one named value from the deprecated Provider data bag.
+ * @param {Object<string, *>} dataBag
+ * @param {string} ctxName
+ * @returns {*}
+ */
 function readNamedData(dataBag, ctxName) {
   // Stryker disable all: dataBag==null short-circuit redundant with Provider {}; console is diagnostic
   if (
@@ -29,6 +78,13 @@ function readNamedData(dataBag, ctxName) {
   return dataBag[ctxName];
 }
 
+/**
+ * Subscribes to the trigram(s) and calls its `children` render prop with the
+ * latest matching AppCon (`(tao, data) => …`). Renders nothing until a
+ * signal arrives unless `shouldRender` is set.
+ * @param {RenderHandlerProps} props
+ * @returns {import('react').ReactElement|null}
+ */
 function RenderHandler({
   term,
   action,

--- a/packages/react-tao/src/SwitchContext.js
+++ b/packages/react-tao/src/SwitchContext.js
@@ -1,11 +1,26 @@
 import { createContext, useContext } from 'react';
 
 /**
+ * Selection context a `SwitchHandler` provides to its subtree.
+ * @typedef {Object} SwitchContextValue
+ * @property {import('./helpers').NormalizedTrigram} defaults - the
+ *           SwitchHandler's normalized default trigram parts
+ * @property {{tao: import('./helpers').TaoSignal|undefined, data: *}} signal -
+ *           the latest chosen AppCon signal (`tao`/`data` are undefined
+ *           before any match)
+ */
+
+/**
  * Set by SwitchHandler when wrapping RenderHandlers.
  * `null` means RenderHandler is standalone.
+ * @type {import('react').Context<SwitchContextValue|null>}
  */
 export const SwitchContext = createContext(null);
 
+/**
+ * The nearest SwitchHandler's selection context, or `null` when standalone.
+ * @returns {SwitchContextValue|null}
+ */
 export function useSwitchContext() {
   return useContext(SwitchContext);
 }

--- a/packages/react-tao/src/SwitchHandler.js
+++ b/packages/react-tao/src/SwitchHandler.js
@@ -16,16 +16,52 @@ import { useTaoContext } from './hooks';
 import { SwitchContext } from './SwitchContext';
 import RenderHandler from './RenderHandler';
 
+/** @typedef {import('@tao.js/core').Trigram} Trigram */
+/** @typedef {import('./helpers').TrigramPart} TrigramPart */
+/** @typedef {import('./helpers').NormalizedTrigram} NormalizedTrigram */
+
+/**
+ * Props for {@link SwitchHandler}. Trigram parts (`t`/`term`, `a`/`action`,
+ * `o`/`orient`) are defaults merged under each RenderHandler child's own
+ * trigram parts; values may be arrays (multi-match), missing parts are
+ * wildcards.
+ * @typedef {Object} SwitchHandlerProps
+ * @property {TrigramPart} [term] - default term for RenderHandler children
+ * @property {TrigramPart} [action] - default action for RenderHandler children
+ * @property {TrigramPart} [orient] - default orient for RenderHandler children
+ * @property {TrigramPart} [t] - default term (short key)
+ * @property {TrigramPart} [a] - default action (short key)
+ * @property {TrigramPart} [o] - default orient (short key)
+ * @property {boolean} [debug=false] - log subscription/selection diagnostics
+ * @property {import('react').ReactNode} children - RenderHandler children to
+ *           switch between (non-RenderHandler children always render)
+ */
+
+/**
+ * Whether a child is a RenderHandler element — directly, or via the
+ * `isTaoRenderHandler` static marker for wrapping components.
+ * @param {import('react').ReactNode} child
+ * @returns {child is import('react').ReactElement<any>}
+ */
 // Stryker disable all: type identity checks; proxy vs RenderHandler covered; ||/&& mutants equivalent under mixed children
 function isRenderHandlerElement(child) {
   return (
     isValidElement(child) &&
     !!child.type &&
-    (child.type === RenderHandler || !!child.type.isTaoRenderHandler)
+    (child.type === RenderHandler ||
+      !!(/** @type {*} */ (child.type).isTaoRenderHandler))
   );
 }
 // Stryker restore all
 
+/**
+ * Build the match table from RenderHandler children: one entry per child
+ * with its identity `matchKey` and the concrete trigram permutations it
+ * subscribes to (child trigram parts override the SwitchHandler defaults).
+ * @param {import('react').ReactNode} children
+ * @param {NormalizedTrigram} defaults
+ * @returns {Array<{matchKey: string, permutations: Trigram[], child: import('react').ReactElement<any>}>}
+ */
 function buildMatchTable(children, defaults) {
   const entries = [];
   Children.forEach(children, (child) => {
@@ -40,6 +76,13 @@ function buildMatchTable(children, defaults) {
   return entries;
 }
 
+/**
+ * Renders only the RenderHandler children whose trigrams matched the most
+ * recent AppCon wave (one Kernel dispatch; all children matching that same
+ * signal render, others unmount). Non-RenderHandler children pass through.
+ * @param {SwitchHandlerProps} props
+ * @returns {import('react').ReactElement}
+ */
 function SwitchHandler({
   term,
   action,
@@ -203,18 +246,21 @@ function SwitchHandler({
         // Stryker restore all
         // shouldRender: matching AppCon already fired; freshly mounted
         // RenderHandlers would otherwise miss it and stay blank.
-        return cloneElement(child, {
-          term,
-          action,
-          orient,
-          t,
-          a,
-          o,
-          ...child.props,
-          shouldRender: true,
-          initialTao: chosen.tao,
-          initialData: chosen.data,
-        });
+        return cloneElement(
+          /** @type {import('react').ReactElement<any>} */ (child),
+          {
+            term,
+            action,
+            orient,
+            t,
+            a,
+            o,
+            .../** @type {Object<string, *>} */ (child.props),
+            shouldRender: true,
+            initialTao: chosen.tao,
+            initialData: chosen.data,
+          },
+        );
       })}
     </SwitchContext.Provider>
   );

--- a/packages/react-tao/src/all.js
+++ b/packages/react-tao/src/all.js
@@ -1,2 +1,7 @@
+/**
+ * Combined surface: the current component/hook API plus the original
+ * `Adapter` / `Reactor` API (used for the ESM `dist` and `all` UMD builds).
+ * @module @tao.js/react/all
+ */
 export * from './index';
 export * from './orig';

--- a/packages/react-tao/src/createContextHandler.js
+++ b/packages/react-tao/src/createContextHandler.js
@@ -2,9 +2,35 @@ import React, { createContext } from 'react';
 
 import useTaoDataState from './useTaoDataState';
 
+/** @typedef {import('./helpers').TrigramProps} TrigramProps */
+/**
+ * @template [S=any]
+ * @typedef {import('./useTaoDataState').TaoDataHandler<S>} TaoDataHandler
+ */
+
+/**
+ * A Provider/Consumer pair bound to trigram-driven handler state.
+ * @template [S=any]
+ * @typedef {Object} ContextHandler
+ * @property {import('react').FunctionComponent<{children?: import('react').ReactNode}>} Provider -
+ *           subscribes to the trigram(s) while mounted and provides the
+ *           current handler state to descendants
+ * @property {import('react').Consumer<S>} Consumer - render-prop consumer of
+ *           the current handler state
+ */
+
 /**
  * Factory returning a Provider/Consumer pair bound to trigram handler state.
  * Used by `withContext` and as a lower-level escape hatch.
+ * @template [S=any]
+ * @param {?TrigramProps} tao - trigram(s) to subscribe to (array parts
+ *        multi-match; null/empty = one all-wildcard subscription)
+ * @param {?TaoDataHandler<S>} [handler] - derives the next state per signal
+ *        (`(tao, data, set, current) => …`); omitted = AppCon data becomes
+ *        the state
+ * @param {S|(() => S)} [defaultValue] - initial state or lazy initializer
+ * @returns {ContextHandler<S>}
+ * @throws {Error} when `handler` is given but not a function
  */
 export default function createContextHandler(tao, handler, defaultValue) {
   if (handler != null && typeof handler !== 'function') {
@@ -12,8 +38,12 @@ export default function createContextHandler(tao, handler, defaultValue) {
   }
 
   // Default unused when Provider always supplies value; keep null sentinel.
-  const WrappingContext = createContext(null);
+  const WrappingContext = createContext(/** @type {S} */ (null));
 
+  /**
+   * Subscribes while mounted and provides the handler state to descendants.
+   * @param {{children?: import('react').ReactNode}} props
+   */
   function Provider({ children }) {
     const state = useTaoDataState(tao, handler, defaultValue);
     return (

--- a/packages/react-tao/src/deprecations.js
+++ b/packages/react-tao/src/deprecations.js
@@ -2,6 +2,9 @@ const warned = new Set();
 
 /**
  * Dev-only, once-per-process deprecation warning (see AGENTS.md data-context migration).
+ * @param {string} key - once-per-process dedupe key for this warning
+ * @param {string} message - the console.warn message
+ * @returns {void}
  */
 export function warnDeprecated(key, message) {
   // Stryker disable next-line all: NODE_ENV / process guards; production path covered in deprecations.spec

--- a/packages/react-tao/src/env.d.ts
+++ b/packages/react-tao/src/env.d.ts
@@ -1,0 +1,9 @@
+/**
+ * Ambient declaration for the Node/bundler `process.env.NODE_ENV` guard in
+ * deprecations.js. Checking-only: tsc does not re-emit input .d.ts files,
+ * so this never lands in lib/. (@types/node is deliberately not installed —
+ * the runtime guard is `typeof process !== 'undefined'`.)
+ */
+declare var process:
+  | { env: { NODE_ENV?: string; [name: string]: string | undefined } }
+  | undefined;

--- a/packages/react-tao/src/helpers.js
+++ b/packages/react-tao/src/helpers.js
@@ -1,7 +1,55 @@
 import cartesian from 'cartesian';
 
+/** @typedef {import('@tao.js/core').Trigram} Trigram */
+
+/**
+ * One part of a trigram prop: a single value or an array of values (arrays
+ * expand to every combination via cartesian product). A missing, empty, or
+ * `'*'` part is a wildcard.
+ * @typedef {string|string[]} TrigramPart
+ */
+
+/**
+ * Trigram props accepted by @tao.js/react components and hooks: short
+ * (`t`/`a`/`o`) and long (`term`/`action`/`orient`) keys are interchangeable
+ * (long keys win when both are given for the same part), values may be
+ * arrays to match multiple trigrams, and missing parts are wildcards.
+ * @typedef {Object} TrigramProps
+ * @property {TrigramPart} [t] - the term (short key)
+ * @property {TrigramPart} [term] - the term: the domain thing
+ * @property {TrigramPart} [a] - the action (short key)
+ * @property {TrigramPart} [action] - the action: the operation on the term
+ * @property {TrigramPart} [o] - the orient (short key)
+ * @property {TrigramPart} [orient] - the orient: perspective / role / surface
+ */
+
+/**
+ * A normalized long-key trigram: only present parts, each still possibly an
+ * array (multi-match) — the cleaned form used for permutation + hashing.
+ * @typedef {Object} NormalizedTrigram
+ * @property {TrigramPart} [term]
+ * @property {TrigramPart} [action]
+ * @property {TrigramPart} [orient]
+ */
+
+/**
+ * The concrete trigram a handler receives when an AppCon dispatches
+ * (always short keys, always concrete strings).
+ * @typedef {Object} TaoSignal
+ * @property {string} t - the term
+ * @property {string} a - the action
+ * @property {string} o - the orient
+ */
+
+/** No-op placeholder function. */
 export const noop = () => {};
 
+/**
+ * Normalize short/long trigram keys to long keys (long keys win when both
+ * styles are present for the same part).
+ * @param {TrigramProps} trigramProps
+ * @returns {NormalizedTrigram}
+ */
 export function normalizeAC({ t, term, a, action, o, orient }) {
   return {
     term: term || t,
@@ -10,6 +58,11 @@ export function normalizeAC({ t, term, a, action, o, orient }) {
   };
 }
 
+/**
+ * Drop nullish parts from a long-key trigram (missing parts = wildcards).
+ * @param {NormalizedTrigram} trigram
+ * @returns {NormalizedTrigram}
+ */
 export function cleanInput({ term, action, orient }) {
   const incoming = { term, action, orient };
   Object.keys(incoming).forEach(
@@ -18,10 +71,23 @@ export function cleanInput({ term, action, orient }) {
   return incoming;
 }
 
+/**
+ * Normalize trigram props to cleaned long keys (see {@link normalizeAC} +
+ * {@link cleanInput}).
+ * @param {TrigramProps} trigramProps
+ * @returns {NormalizedTrigram}
+ */
 export function normalizeClean({ t, term, a, action, o, orient }) {
   return cleanInput(normalizeAC({ t, term, a, action, o, orient }));
 }
 
+/**
+ * Expand trigram props into concrete single-valued trigram permutations
+ * (cartesian product of any array parts). Returns `[{}]` — one all-wildcard
+ * trigram — when no parts are given, so subscriptions still register.
+ * @param {TrigramProps} trigramProps
+ * @returns {Trigram[]}
+ */
 export function getPermutations({ t, term, a, action, o, orient }) {
   const trigram = normalizeClean({ t, term, a, action, o, orient });
   const permutations = cartesian(trigram);
@@ -31,15 +97,29 @@ export function getPermutations({ t, term, a, action, o, orient }) {
   return [{}];
 }
 
+/**
+ * @param {TrigramPart} [trigram] - one part (missing = `'%'` marker)
+ * @returns {string}
+ */
 function trigramHash(trigram) {
   return !trigram ? '%' : Array.isArray(trigram) ? trigram.join(',') : trigram;
 }
 
+/**
+ * Stable identity key for a (possibly multi-valued) trigram spec — used by
+ * SwitchHandler to match chosen RenderHandler children across renders.
+ * @param {NormalizedTrigram} trigram
+ * @returns {string}
+ */
 export function handlerHash({ term, action, orient }) {
   return `${trigramHash(term)}|${trigramHash(action)}|${trigramHash(orient)}`;
 }
 
-/** Stable dep key for Kernel subscription lists (arrays, order). */
+/**
+ * Stable dep key for Kernel subscription lists (arrays, order).
+ * @param {object[]} [trigrams]
+ * @returns {string}
+ */
 export function serializeTrigrams(trigrams) {
   return JSON.stringify(trigrams || []);
 }

--- a/packages/react-tao/src/hooks.js
+++ b/packages/react-tao/src/hooks.js
@@ -4,11 +4,27 @@ import { Context } from './Provider';
 import { useDataLayers } from './DataLayerContext';
 import { getPermutations } from './helpers';
 
+/** @typedef {import('@tao.js/core').Kernel} Kernel */
+/** @typedef {import('@tao.js/core').Handler} Handler */
+/** @typedef {import('./helpers').TrigramProps} TrigramProps */
+
+/**
+ * The Kernel provided by the nearest `TaoProvider`.
+ * @returns {Kernel}
+ */
 export function useTaoContext() {
   const { TAO } = React.useContext(Context);
   return TAO;
 }
 
+/**
+ * Shared add/remove effect behind the phase-specific handler hooks.
+ * @param {'Inline'|'Async'|'Intercept'} handlerType
+ * @param {TrigramProps} trigramProps
+ * @param {Handler} handler
+ * @param {import('react').DependencyList} [dependencies]
+ * @returns {void}
+ */
 function useTaoEffect(
   handlerType,
   { t, term, a, action, o, orient },
@@ -29,6 +45,16 @@ function useTaoEffect(
   }, dependencies);
 }
 
+/**
+ * Register `handler` as an inline-phase handler for every permutation of the
+ * trigram while mounted.
+ * @param {TrigramProps} trigramProps - trigram(s) to match (array parts
+ *        multi-match; missing parts are wildcards)
+ * @param {Handler} handler - `(tao, data) => …`; may return an AppCtx to chain
+ * @param {import('react').DependencyList} [dependencies] - effect deps
+ *        controlling re-subscription (omit to resubscribe every render)
+ * @returns {void}
+ */
 export function useTaoInlineHandler(
   { t, term, a, action, o, orient },
   handler,
@@ -42,6 +68,16 @@ export function useTaoInlineHandler(
   );
 }
 
+/**
+ * Register `handler` as an async-phase handler for every permutation of the
+ * trigram while mounted.
+ * @param {TrigramProps} trigramProps - trigram(s) to match (array parts
+ *        multi-match; missing parts are wildcards)
+ * @param {Handler} handler - `(tao, data) => …`; may return an AppCtx to chain
+ * @param {import('react').DependencyList} [dependencies] - effect deps
+ *        controlling re-subscription (omit to resubscribe every render)
+ * @returns {void}
+ */
 export function useTaoAsyncHandler(
   { t, term, a, action, o, orient },
   handler,
@@ -55,6 +91,17 @@ export function useTaoAsyncHandler(
   );
 }
 
+/**
+ * Register `handler` as an intercept-phase handler for every permutation of
+ * the trigram while mounted (truthy return halts the dispatch; returning an
+ * AppCtx replaces it).
+ * @param {TrigramProps} trigramProps - trigram(s) to match (array parts
+ *        multi-match; missing parts are wildcards)
+ * @param {Handler} handler - `(tao, data) => …`
+ * @param {import('react').DependencyList} [dependencies] - effect deps
+ *        controlling re-subscription (omit to resubscribe every render)
+ * @returns {void}
+ */
 export function useTaoInterceptHandler(
   { t, term, a, action, o, orient },
   handler,
@@ -69,8 +116,12 @@ export function useTaoInterceptHandler(
 }
 
 /**
- * Tree-scoped named data from ancestor DataHandlers.
- * @param {string} [name] — when omitted, returns the nearest DataHandler value
+ * Tree-scoped named data from ancestor DataHandlers (nearest wins — an inner
+ * DataHandler shadows an outer one with the same name).
+ * @param {string} [name] - the DataHandler `name` to look up; omitted or
+ *        empty returns the nearest DataHandler's value
+ * @returns {*} the matching DataHandler's current data, or `undefined` when
+ *        no ancestor DataHandler matches
  */
 export function useTaoData(name) {
   const layers = useDataLayers();
@@ -90,6 +141,8 @@ export function useTaoData(name) {
 /**
  * @deprecated Since 0.17 — alias of `useTaoData`; prefer `useTaoData(name)`.
  * Still reads the tree-scoped layer (same as useTaoData) for a named slot.
+ * @param {string} [name] - the DataHandler `name` to look up
+ * @returns {*} the matching DataHandler's current data, or `undefined`
  */
 export function useTaoDataContext(name) {
   return useTaoData(name);

--- a/packages/react-tao/src/index.js
+++ b/packages/react-tao/src/index.js
@@ -1,3 +1,42 @@
+/**
+ * @tao.js/react — React adapter for the TAO signal network.
+ *
+ * Wrap a tree in {@link TaoProvider} with a `Kernel` (or the default `TAO`)
+ * from `@tao.js/core`, then react to AppCons with `RenderHandler` /
+ * `SwitchHandler`, share handler-managed data with `DataHandler` +
+ * `useTaoData(name)`, and register handlers with the `useTaoInlineHandler` /
+ * `useTaoAsyncHandler` / `useTaoInterceptHandler` hooks.
+ *
+ * @module @tao.js/react
+ */
+
+/**
+ * Shared shapes re-exported for typed consumers (the JSDoc typedefs are the
+ * source of truth at their defining modules).
+ *
+ * @typedef {import('./helpers').TrigramPart} TrigramPart
+ * @typedef {import('./helpers').TrigramProps} TrigramProps
+ * @typedef {import('./helpers').NormalizedTrigram} NormalizedTrigram
+ * @typedef {import('./helpers').TaoSignal} TaoSignal
+ * @typedef {import('./DataLayerContext').DataLayer} DataLayer
+ * @typedef {import('./Provider').ProviderContextValue} ProviderContextValue
+ * @typedef {import('./Provider').TaoProviderProps} TaoProviderProps
+ * @typedef {import('./DataHandler').DataHandlerProps} DataHandlerProps
+ * @typedef {import('./RenderHandler').RenderHandlerProps} RenderHandlerProps
+ * @typedef {import('./RenderHandler').RenderHandlerChildren} RenderHandlerChildren
+ * @typedef {import('./SwitchHandler').SwitchHandlerProps} SwitchHandlerProps
+ * @typedef {import('./SwitchContext').SwitchContextValue} SwitchContextValue
+ * @typedef {import('./DataConsumer').DataConsumerProps} DataConsumerProps
+ * @typedef {import('./DataConsumer').DataConsumerChildren} DataConsumerChildren
+ */
+/**
+ * @template [S=any]
+ * @typedef {import('./useTaoDataState').TaoDataHandler<S>} TaoDataHandler
+ */
+/**
+ * @template [S=any]
+ * @typedef {import('./createContextHandler').ContextHandler<S>} ContextHandler
+ */
 export { TaoProvider, Provider } from './Provider';
 export { default as DataConsumer } from './DataConsumer';
 export { default as DataHandler } from './DataHandler';

--- a/packages/react-tao/src/orig.js
+++ b/packages/react-tao/src/orig.js
@@ -1,2 +1,8 @@
+/**
+ * @tao.js/react original ("orig") API — the legacy `Adapter` / `Reactor`
+ * pair, published as the `orig` entry (`@tao.js/react/orig`). Prefer the
+ * current component/hook API from the package root for new code.
+ * @module @tao.js/react/orig
+ */
 export { default as Adapter } from './Adapter';
 export { default as Reactor } from './Reactor';

--- a/packages/react-tao/src/useTaoDataState.js
+++ b/packages/react-tao/src/useTaoDataState.js
@@ -4,6 +4,38 @@ import { AppCtx } from '@tao.js/core';
 import { getPermutations } from './helpers';
 import useTaoInlineSubscription from './useTaoInlineSubscription';
 
+/** @typedef {import('./helpers').TrigramProps} TrigramProps */
+/** @typedef {import('./helpers').TaoSignal} TaoSignal */
+
+/**
+ * Derives the next handler-managed data from a matching AppCon. Used by
+ * `DataHandler`, `createContextHandler`, and `withContext`.
+ *
+ * Three ways to produce state (in precedence order):
+ * 1. call `set(next)` — replaces state with `next`, clearing any previous
+ *    keys `next` omits (`set(null)` clears every key to undefined); once
+ *    `set` is used, a non-AppCtx return value is ignored;
+ * 2. return the next state directly (nullish return = no state change);
+ * 3. return an {@link AppCtx} — it is chained on the network instead of
+ *    becoming state (works alongside a prior `set` call).
+ *
+ * @template [S=any]
+ * @callback TaoDataHandler
+ * @param {TaoSignal} tao - the dispatched AppCon's concrete trigram
+ * @param {*} data - the AppCon's data (always an object, may be empty)
+ * @param {(next: ?S) => void} set - imperative state setter (see above)
+ * @param {S} current - the state at dispatch time
+ * @returns {S|AppCtx|void} next state, an AppCtx to chain, or nothing
+ */
+
+/**
+ * Build the next state from `newState`, clearing (to `undefined`) every key
+ * of `previousState` that `newState` omits; `null`/`undefined` clears all
+ * previous keys.
+ * @param {Object<string, *>} previousState
+ * @param {?Object<string, *>} [newState]
+ * @returns {Object<string, *>}
+ */
 export function cleanState(previousState, newState) {
   const keys = Object.keys(previousState);
   if (newState == null) {
@@ -21,14 +53,26 @@ export function cleanState(previousState, newState) {
 
 /**
  * Local state driven by Kernel inline handlers for a trigram (+ optional handler).
+ * Without a `handler`, each matching AppCon's data replaces the state.
+ * @template [S=any]
+ * @param {?TrigramProps} trigramProps - trigram(s) to subscribe to (array
+ *        parts multi-match; null/empty = one all-wildcard subscription)
+ * @param {?TaoDataHandler<S>} [handler] - derives the next state per signal;
+ *        omitted = the AppCon data becomes the state
+ * @param {S|(() => S)} [defaultValue] - initial state or lazy initializer
+ *        (defaults to `{}`)
+ * @returns {S} the current handler-managed state
  */
 export default function useTaoDataState(trigramProps, handler, defaultValue) {
-  const [state, setState] = useState(() =>
-    typeof defaultValue === 'function'
-      ? defaultValue()
-      : defaultValue != null
-        ? defaultValue
-        : {},
+  const [state, setState] = useState(
+    /** @type {() => S} */ (
+      () =>
+        typeof defaultValue === 'function'
+          ? /** @type {() => S} */ (defaultValue)()
+          : defaultValue != null
+            ? defaultValue
+            : {}
+    ),
   );
   const stateRef = useRef(state);
   stateRef.current = state;
@@ -45,7 +89,7 @@ export default function useTaoDataState(trigramProps, handler, defaultValue) {
           tao,
           data,
           (next) => {
-            const update = cleanState(current, next);
+            const update = /** @type {S} */ (cleanState(current, next));
             setState(update);
             usedSet = true;
           },

--- a/packages/react-tao/src/useTaoInlineSubscription.js
+++ b/packages/react-tao/src/useTaoInlineSubscription.js
@@ -3,9 +3,17 @@ import { useEffect, useRef } from 'react';
 import { useTaoContext } from './hooks';
 import { serializeTrigrams } from './helpers';
 
+/** @typedef {import('@tao.js/core').Trigram} Trigram */
+/** @typedef {import('@tao.js/core').Handler} Handler */
+
 /**
  * Reconcile Kernel inline handlers to the declared `trigrams` list.
  * Uses a stable wrapper so callback identity churn does not resubscribe.
+ * @param {Trigram[]} trigrams - concrete trigram permutations to subscribe to
+ *        (resubscribes when the serialized list changes)
+ * @param {Handler} handler - `(tao, data) => …`; the latest render's handler
+ *        is always invoked; may return an AppCtx to chain on the network
+ * @returns {void}
  */
 export default function useTaoInlineSubscription(trigrams, handler) {
   const TAO = useTaoContext();

--- a/packages/react-tao/src/withContext.js
+++ b/packages/react-tao/src/withContext.js
@@ -2,6 +2,27 @@ import React from 'react';
 
 import createContextHandler from './createContextHandler';
 
+/** @typedef {import('./helpers').TrigramProps} TrigramProps */
+/**
+ * @template [S=any]
+ * @typedef {import('./useTaoDataState').TaoDataHandler<S>} TaoDataHandler
+ */
+
+/**
+ * HOC factory: subscribes to trigram-driven handler state and injects it
+ * into the wrapped component as the `data` prop (all other props pass
+ * through unchanged).
+ * @template [S=any]
+ * @param {?TrigramProps} tao - trigram(s) to subscribe to (array parts
+ *        multi-match; null/empty = one all-wildcard subscription)
+ * @param {TaoDataHandler<S>} handler - derives the next state per signal
+ *        (`(tao, data, set, current) => …`); required
+ * @param {S|(() => S)} [defaultValue] - initial state or lazy initializer
+ * @returns {(ComponentToWrap: import('react').ComponentType<*>) => import('react').FunctionComponent<*>}
+ *          HOC rendering `ComponentToWrap` with `data` = the current handler
+ *          state plus all passthrough props
+ * @throws {Error} when `handler` is not a function
+ */
 export default function withContext(tao, handler, defaultValue) {
   if (typeof handler !== 'function') {
     throw new Error('withContext `handler` must be a function');

--- a/packages/react-tao/tsconfig.types.json
+++ b/packages/react-tao/tsconfig.types.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../config/tsconfig.types.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib",
+    "jsx": "react"
+  },
+  "include": ["src"]
+}

--- a/packages/tao-opentelemetry/README.md
+++ b/packages/tao-opentelemetry/README.md
@@ -19,7 +19,7 @@ const otelTracer = trace.getTracer('my-app'); // from your configured SDK
 const tracer = new Tracer(TAO, {
   sinks: [new OpenTelemetrySink(otelTracer)],
 });
-tracer.instrument(TAO);
+// that's it — the Tracer is a pure decoration; nothing to instrument
 ```
 
 Every AppCon becomes a span named `Term.Action.Orient` with attributes

--- a/packages/tao-opentelemetry/package.json
+++ b/packages/tao-opentelemetry/package.json
@@ -10,6 +10,7 @@
   },
   "main": "lib",
   "module": "dist",
+  "types": "lib/index.d.ts",
   "bundles": {
     "browser": "bundles/browser.umd.js"
   },
@@ -25,8 +26,9 @@
   "scripts": {
     "build:clean": "rimraf dist lib bundles",
     "build:package": "rollup --config",
-    "build": "npm run build:clean && npm run build:package",
-    "test:mutation": "stryker run"
+    "build": "npm run build:clean && npm run build:package && npm run build:types",
+    "test:mutation": "stryker run",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "author": "eudaimos",
   "license": "Apache-2.0",

--- a/packages/tao-opentelemetry/src/OpenTelemetrySink.js
+++ b/packages/tao-opentelemetry/src/OpenTelemetrySink.js
@@ -5,6 +5,8 @@ import {
   TraceFlags,
 } from '@opentelemetry/api';
 
+/** @typedef {import('@tao.js/telemetry').TraceRecord} TraceRecord */
+
 /**
  * A `@tao.js/telemetry` sink that exports each signal record as an OpenTelemetry
  * span, preserving causal parentage.
@@ -28,14 +30,20 @@ export default class OpenTelemetrySink {
    * Creates an instance of OpenTelemetrySink.
    * @param {import('@opentelemetry/api').Tracer} tracer - an OTel Tracer from your TracerProvider
    * @param {Object} [opts]
-   * @param {function} [opts.rootContext] - returns the OTel Context to parent
-   *        root signals under; defaults to `() => context.active()` so TAO
-   *        cascades nest beneath an ambient span (e.g. an incoming HTTP request)
+   * @param {function(): import('@opentelemetry/api').Context} [opts.rootContext] -
+   *        returns the OTel Context to parent root signals under; defaults to
+   *        `() => context.active()` so TAO cascades nest beneath an ambient
+   *        span (e.g. an incoming HTTP request). Also used when a record's
+   *        parent is unseen locally (see `_parentage`)
    * @param {boolean} [opts.endImmediately=true] - end each span at the signal
    *        timestamp (point-in-time semantics); pass false to end spans yourself
-   * @param {Object} [opts.attributes] - static attributes added to every span
+   * @param {Object<string, *>} [opts.attributes] - static attributes added to
+   *        every span; applied last, so a static key wins over an emitted
+   *        `tao.*` attribute on collision
    * @param {number} [opts.maxRetainedSignals=10000] - size of the
-   *        signalId → SpanContext map used for parentage (FIFO eviction)
+   *        signalId → SpanContext map used for parentage (FIFO eviction; a
+   *        child arriving after its parent's eviction degrades to a span link)
+   * @throws when `tracer` is absent or is not an OTel Tracer (no `startSpan`)
    * @memberof OpenTelemetrySink
    */
   constructor(
@@ -63,6 +71,33 @@ export default class OpenTelemetrySink {
     this._spanContexts = new Map();
   }
 
+  /**
+   * Sink interface: export one signal record as a span named
+   * `Term.Action.Orient`, started (and, unless `endImmediately: false`,
+   * ended) at the record's timestamp. Emitted attributes:
+   *
+   * - `tao.term` / `tao.action` / `tao.orient` — the signal's trigram
+   * - `tao.trace.id` — the tao-internal W3C-shaped trace id (32 hex) shared
+   *   by the whole causal tree, including its remote continuations
+   * - `tao.signal.id` — this signal's tao-internal id (16 hex); distinct
+   *   from the OTel span id the SDK assigns
+   * - `tao.signal.parent_id` — the causing signal's id; omitted on trace
+   *   roots
+   * - `tao.signal.via` — the handler phase that chained this signal
+   *   (`Intercept` | `Async` | `Inline`); omitted on entry hops, which no
+   *   phase produced
+   * - `tao.handlers.intercept` / `tao.handlers.async` / `tao.handlers.inline`
+   *   — counts of handlers matching the trigram at dispatch time on the main
+   *   network only (wildcard registrations included; Channels' private
+   *   registries are not); omitted when the record carries no counts
+   *
+   * Parentage and the span-link fallback are resolved by `_parentage`.
+   *
+   * @param {TraceRecord} record
+   * @returns {import('@opentelemetry/api').Span} the started span (already
+   *          ended unless `endImmediately: false`)
+   * @memberof OpenTelemetrySink
+   */
   signal(record) {
     const { ctx, links } = this._parentage(record);
     const attributes = {
@@ -100,6 +135,23 @@ export default class OpenTelemetrySink {
     return span;
   }
 
+  /**
+   * Resolve a record's OTel parentage, in fallback order:
+   *
+   * 1. no `parentId` — a root: parent under `rootContext()` (ambient
+   *    nesting beneath e.g. an instrumented HTTP request's span);
+   * 2. parent seen locally — a real child: the remembered parent
+   *    SpanContext set on ROOT_CONTEXT (explicit parent; ambient context
+   *    deliberately ignored);
+   * 3. parent unseen (remote hop, or evicted past `maxRetainedSignals`) —
+   *    parent under `rootContext()` and keep the causal reference as a span
+   *    *link* built from the W3C-shaped tao ids (`traceId`,
+   *    `spanId: parentId`, sampled) — honest linkage, never a guessed
+   *    parent.
+   *
+   * @param {TraceRecord} record
+   * @returns {{ ctx: import('@opentelemetry/api').Context, links: (Array<{context: Object}>|undefined) }}
+   */
   _parentage(record) {
     if (!record.parentId) {
       return { ctx: this._rootContext(), links: undefined };
@@ -127,6 +179,13 @@ export default class OpenTelemetrySink {
     };
   }
 
+  /**
+   * Retain a signal's SpanContext for future child parentage, evicting the
+   * oldest entry (FIFO) once the map reaches `maxRetainedSignals`.
+   *
+   * @param {string} signalId
+   * @param {import('@opentelemetry/api').SpanContext} spanContext
+   */
   _remember(signalId, spanContext) {
     if (this._spanContexts.size >= this._max) {
       this._spanContexts.delete(this._spanContexts.keys().next().value);

--- a/packages/tao-opentelemetry/tsconfig.types.json
+++ b/packages/tao-opentelemetry/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../config/tsconfig.types.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": ["src"]
+}

--- a/packages/tao-router/package.json
+++ b/packages/tao-router/package.json
@@ -10,6 +10,7 @@
   },
   "main": "lib",
   "module": "dist",
+  "types": "lib/index.d.ts",
   "bundles": {
     "browser": "bundles/browser.umd.js"
   },
@@ -21,7 +22,8 @@
   "scripts": {
     "build:clean": "rimraf dist lib bundles",
     "build:package": "rollup --config",
-    "build": "npm run build:clean && npm run build:package",
+    "build:types": "tsc -p tsconfig.types.json",
+    "build": "npm run build:clean && npm run build:package && npm run build:types",
     "test:mutation": "stryker run"
   },
   "author": "eudaimos",

--- a/packages/tao-router/src/Router.js
+++ b/packages/tao-router/src/Router.js
@@ -1,3 +1,11 @@
+/**
+ * The legacy TAO-native URL routing bridge: a two-way binding between a
+ * `history` instance and a TAO signal network, configured entirely through
+ * TAO signals (`{Routes,Configure}`, `{Route,Add|Remove|Attach|Detach}`)
+ * rather than a route table. See {@link Router} for the full protocol.
+ *
+ * @module @tao.js/router/Router
+ */
 // import createHistory from 'history/createBrowserHistory';
 /* v8 ignore next -- module imports are recorded as an unreachable branch by V8. */
 import { createBrowserHistory as createHistory } from 'history';
@@ -8,8 +16,67 @@ import { AppCtx } from '@tao.js/core';
 
 import makeRouteHandler, { deconstructPath, convertPath } from './routeHandler';
 
+/**
+ * @typedef {import('@tao.js/core').Kernel} Kernel
+ * @typedef {import('@tao.js/core').Trigram} Trigram
+ * @typedef {import('@tao.js/core').Handler} Handler
+ * @typedef {import('./routeHandler').HistoryLike} HistoryLike
+ * @typedef {import('./routeHandler').RouteConfig} RouteConfig
+ * @typedef {import('./routeHandler').PathPart} PathPart
+ */
+
+/**
+ * A node in the route match tree: a `routington` node extended with the
+ * Router's own bookkeeping (written by the `{Route,Attach}` handler).
+ *
+ * @typedef {Object} RouteNode
+ * @property {RouteConfig} route - the route as originally attached
+ * @property {(boolean|undefined)} lowerCase - when set, path-extracted
+ *           trigram parts are re-capitalized (pushed URLs are lowercased)
+ * @property {PathPart[]} deconstruction - the route's deconstructed path
+ *           template
+ * @property {AppCtx[]} attached - trigrams attached to this route (fired on
+ *           a URL match; wildcard parts are filled from the URL)
+ * @property {Map<string, Object>} defaultData - default AppCon data per
+ *           attached trigram (keyed by the trigram's AppCtx key)
+ */
+
+/**
+ * A match of the current pathname against the route tree.
+ *
+ * @typedef {Object} RouteMatch
+ * @property {RouteNode} node - the matched route's node
+ * @property {Object.<string, string>} param - values captured from the URL
+ *           per path parameter
+ */
+
+/**
+ * Options for the {@link Router} (and the package's default `init` export).
+ *
+ * @typedef {Object} RouterOptions
+ * @property {(Trigram|AppCtx)} [initAc] - trigram whose inline handler
+ *           chains `{Router,Init,<orient of the signal>}` on startup
+ * @property {(Trigram|AppCtx|Array<Trigram|AppCtx>)} [incomingAc] -
+ *           trigram(s) that trigger matching the current location against
+ *           the route tree (firing the matched route's attached AppCons);
+ *           the first one is also chained after `{Routes,Configure}`
+ * @property {string} [defaultRoute] - path matched instead when the current
+ *           location has no route match on an incoming AC
+ * @property {string} [orient] - orient the Router's configuration trigrams
+ *           (`{Routes,Configure}`, `{Route,Add|Remove|Attach|Detach}`)
+ *           listen on; empty/omitted = wildcard
+ * @property {boolean} [debug=false] - console.log internal activity
+ */
+
 const CHANGE_ACTION_SIGNAL = 'POP';
 
+/**
+ * Uppercase a captured path segment's first character (used to restore
+ * trigram casing for `lowerCase` routes); non-strings pass through.
+ *
+ * @param {string} str
+ * @returns {string}
+ */
 function capitalize(str) {
   // Stryker disable next-line LogicalOperator,ConditionalExpression: equivalent - str is always undefined or a string captured from a URL path segment here, never a truthy non-string, so `!str` alone (or forcing this guard true/false) can't diverge from the full guard for any reachable input
   if (!str || typeof str !== 'string') {
@@ -18,12 +85,28 @@ function capitalize(str) {
   return `${str.substring(0, 1).toUpperCase()}${str.substring(1)}`;
 }
 
+/**
+ * Coerce a trigram (short or long keys) into a data-less AppCtx; AppCtx
+ * instances pass through.
+ *
+ * @param {(Trigram|AppCtx)} ac
+ * @returns {AppCtx}
+ */
 function wrapAc(ac) {
   return ac instanceof AppCtx
     ? ac
     : new AppCtx(ac.t || ac.term, ac.a || ac.action, ac.o || ac.orient);
 }
 
+/**
+ * Wrap a route handler so it skips AppCons matching any of the `ignore`
+ * trigrams (`Add.ignore` on `{Route,Add}`).
+ *
+ * @param {Handler} handler - the compiled route handler
+ * @param {(Trigram|AppCtx|Array<Trigram|AppCtx>)} [ignore] - trigram(s) the
+ *        handler must not react to
+ * @returns {Handler}
+ */
 function wrapIgnore(handler, ignore) {
   if (!ignore) {
     return handler;
@@ -39,6 +122,15 @@ function wrapIgnore(handler, ignore) {
   };
 }
 
+/**
+ * Deep-merge a route's default data into the path-extracted data without
+ * overwriting values the URL provided.
+ *
+ * @param {Object} pathData - the path-extracted data (mutated)
+ * @param {Object} defaultData - the attached trigram's default data
+ * @param {string} [parentPath] - current key path while recursing
+ * @returns {void}
+ */
 function mergeData(pathData, defaultData, parentPath) {
   Object.entries(defaultData).forEach(([key, val]) => {
     const dataPath = parentPath ? `${parentPath}.${key}` : key;
@@ -50,6 +142,18 @@ function mergeData(pathData, defaultData, parentPath) {
   });
 }
 
+/**
+ * Fire the AppCons for a URL match: for every trigram attached to the
+ * matched route, build an AppCtx from the URL-captured data (+ the
+ * trigram's default data; wildcard parts filled from the URL, re-cased for
+ * `lowerCase` routes), signal `{Route,Match,<orient>}` with
+ * `[route, appCtx]`, then set the AppCtx itself.
+ *
+ * @param {Kernel} TAO - the kernel to signal on
+ * @param {RouteMatch} match - the matched route
+ * @param {boolean} [debug=false] - console.log internal activity
+ * @returns {void}
+ */
 // Stryker disable next-line BooleanLiteral: unreachable - every internal caller of reactToRoute always passes an explicit boolean `this._debug`, so the `= false` default is never actually evaluated
 function reactToRoute(TAO, match, debug = false) {
   // Stryker disable all: optional debug logging
@@ -66,7 +170,7 @@ function reactToRoute(TAO, match, debug = false) {
       set(pathData, dataPath, paramData);
     }
     return pathData;
-  }, {});
+  }, /** @type {Object.<string, *>} */ ({}));
   if (match.node.lowerCase) {
     pathMatched.t = capitalize(pathMatched.t);
     pathMatched.a = capitalize(pathMatched.a);
@@ -100,21 +204,67 @@ function reactToRoute(TAO, match, debug = false) {
   });
 }
 
+/**
+ * The legacy TAO-native URL bridge. Constructing a Router registers inline
+ * handlers on the kernel that turn TAO signals into route configuration,
+ * and wires history so URL changes fire AppCons (and matching AppCons push
+ * URLs):
+ *
+ * - `opts.initAc` → chains `{Router,Init,<orient of the signal>}`.
+ * - `{Routes,Configure,<orient>}` → fans each entry of `data.Routes` out as
+ *   `{Route,Add|Remove|Attach|Detach}` signals (keyed by the entry's
+ *   `Add`/`Remove`/`Attach`/`Detach` properties), then chains the first
+ *   `opts.incomingAc`.
+ * - `{Route,Add,<orient>}` → compiles the route
+ *   (`makeRouteHandler`) and registers it as an **async** handler for
+ *   `Add`'s trigram (`Add.tao` or `Add` itself): matching AppCons push the
+ *   route's URL onto history when it differs, chaining `{Route,Set}`.
+ *   Re-adding a trigram replaces its previous handler; `Add.ignore` lists
+ *   trigrams the handler must skip; `Add.attach: true` chains
+ *   `{Route,Attach,<orient>}` with the same `[Route, Add]` data.
+ * - `{Route,Remove,<orient>}` → unregisters the trigram's route handler;
+ *   `Remove.detach: true` chains `{Route,Detach,<orient>}`.
+ * - `{Route,Attach,<orient>}` → binds `Attach`'s trigram (`Attach.tao` or
+ *   `Attach` itself, with `Attach.data` as default AppCon data) to the
+ *   route's path pattern in the match tree, so URL changes fire it.
+ * - `{Route,Detach,<orient>}` → unbinds the trigram from the route.
+ *
+ * Inbound direction: history `POP` events (back/forward) and any
+ * `opts.incomingAc` signal match the current pathname against the attached
+ * routes (falling back to `opts.defaultRoute` for incoming ACs) and fire
+ * `{Route,Match}` + the attached AppCons — see `reactToRoute`.
+ *
+ * The instance keeps no public state; it lives through the handlers it
+ * registers (the package's default `init` export does not even return it).
+ *
+ * @export
+ * @class Router
+ */
 export default class Router {
+  /**
+   * Creates a Router and registers all of its TAO handlers.
+   *
+   * @param {Kernel} TAO - the kernel to bridge
+   * @param {(HistoryLike|RouterOptions|null)} [history] - the history to
+   *        drive; omit (or pass the options object here) to create a
+   *        browser history
+   * @param {RouterOptions} [opts]
+   */
   constructor(TAO, history, opts) {
     this._tao = TAO;
     if (!opts) {
-      opts = history;
+      opts = /** @type {RouterOptions} */ (history);
       history = null;
     }
     opts = opts || {};
     const { debug = false } = opts;
     this._debug = debug;
-    this._history = history || createHistory();
+    this._history = /** @type {HistoryLike} */ (history || createHistory());
     this.setupEvents = this.setupEvents.bind(this);
     this.historyChange = this.historyChange.bind(this);
     this.getPathFrom = this.getPathFrom.bind(this);
     this.getAcsFrom = this.getAcsFrom.bind(this);
+    /** @type {Map<string, Handler>} */
     this._routes = new Map();
     this._router = routington();
     this.setupEvents(
@@ -127,6 +277,19 @@ export default class Router {
     );
   }
 
+  /**
+   * Register the Router's handlers (see the class doc for the protocol).
+   * Called once from the constructor.
+   *
+   * @param {Kernel} TAO - the kernel to bridge
+   * @param {HistoryLike} history - the history to drive
+   * @param {(Trigram|AppCtx)} [initAc] - see `RouterOptions.initAc`
+   * @param {(Trigram|AppCtx|Array<Trigram|AppCtx>)} [incomingAc] - see
+   *        `RouterOptions.incomingAc`
+   * @param {string} [defaultRoute] - see `RouterOptions.defaultRoute`
+   * @param {string} [orient] - see `RouterOptions.orient`
+   * @returns {void}
+   */
   setupEvents = (TAO, history, initAc, incomingAc, defaultRoute, orient) => {
     this._unlistenHistory = history.listen(this.historyChange);
     const incoming = !incomingAc
@@ -297,6 +460,14 @@ export default class Router {
   // this should move to just being an added Async Handler on the individual routes
   // OR would that make the TAO sets too big?
   // they would certainly be completely directed with no middle man interpreter
+  /**
+   * Vestigial: hardcoded tao→path mapping from the original prototype
+   * (`{Space,View}` → `/space`); not called by anything today.
+   *
+   * @param {Object} tao - a `{ t, a, o }` trigram
+   * @param {*} data
+   * @returns {(string|undefined)}
+   */
   getPathFrom = (tao, data) => {
     if (tao.a !== 'View') {
       return;
@@ -304,10 +475,27 @@ export default class Router {
     return tao.t === 'Space' ? '/space' : '';
   };
 
+  /**
+   * Vestigial: always returns an empty list; not called by anything today.
+   *
+   * @param {Object} location - a history location
+   * @param {Object} tao - a `{ t, a, o }` trigram
+   * @param {*} data
+   * @returns {AppCtx[]}
+   */
   getAcsFrom = (location, tao, data) => {
     return [];
   };
 
+  /**
+   * History listener: on `POP` (back/forward navigation), match the new
+   * pathname against the route tree and fire the matched route's attached
+   * AppCons (`reactToRoute`). Pushes from route handlers do not re-fire.
+   *
+   * @param {{ pathname: string }} location - the new location
+   * @param {string} action - the history action (`'PUSH'`/`'REPLACE'`/`'POP'`)
+   * @returns {void}
+   */
   historyChange = (location, action) => {
     // match the new location to our route tree to find Trigrams and fire ACs from path data
     // Stryker disable next-line all: optional debug logging

--- a/packages/tao-router/src/index.js
+++ b/packages/tao-router/src/index.js
@@ -1,8 +1,45 @@
+/**
+ * @tao.js/router — the legacy TAO-native URL routing bridge.
+ *
+ * Connects URL routing with a TAO signal network: a {@link Router} listens
+ * for TAO signals (`{Routes,Configure}`, `{Route,Add|Remove|Attach|Detach}`)
+ * to build its route table, pushes URLs onto history when route-mapped
+ * AppCons fire, and fires AppCons (via `{Route,Match}`) when the URL
+ * changes. The {@link route} template tag builds URL paths from data
+ * objects.
+ *
+ * Prefer the host-router adapters (`@tao.js/routing-core` +
+ * `@tao.js/routing-react-router` / `-tanstack-router` / `-next`) for new
+ * work; this package documents the original TAO-native approach.
+ *
+ * @module @tao.js/router
+ */
+
+/**
+ * Shared shapes re-exported for typed consumers (the JSDoc typedefs are the
+ * source of truth at their defining modules).
+ *
+ * @typedef {import('./routeHandler').HistoryLike} HistoryLike
+ * @typedef {import('./routeHandler').RouteConfig} RouteConfig
+ * @typedef {import('./routeHandler').PathPart} PathPart
+ * @typedef {import('./Router').RouterOptions} RouterOptions
+ * @typedef {import('./Router').RouteMatch} RouteMatch
+ * @typedef {import('./Router').RouteNode} RouteNode
+ */
 import router from './Router';
 import { routeTag as route } from './routeTag';
 
 export { route };
 
+/**
+ * Initialize the routing bridge: constructs a `Router` bound to the kernel
+ * (see `Router` for the signal protocol). The instance is not returned —
+ * it lives through the TAO handlers it registers.
+ *
+ * @param {ConstructorParameters<typeof router>} args - `(TAO, history?, opts?)`
+ *        as the `Router` constructor
+ * @returns {void}
+ */
 export default function init(...args) {
   new router(...args);
 }

--- a/packages/tao-router/src/routeHandler.js
+++ b/packages/tao-router/src/routeHandler.js
@@ -1,7 +1,53 @@
+/**
+ * Path-template plumbing for the legacy TAO-native Router: deconstruct
+ * `{data.path}` templates, convert them for `path-to-regexp`, and build the
+ * async route handler that pushes an AppCon's URL onto history.
+ *
+ * @module @tao.js/router/routeHandler
+ */
 import pathToRegexp from 'path-to-regexp';
 import get from 'get-value';
 
 import { AppCtx } from '@tao.js/core';
+
+/** @typedef {import('@tao.js/core').Handler} Handler */
+
+/**
+ * Structural shape of the history object this package drives —
+ * `createBrowserHistory` from the bundled `history` v4 is the default, and
+ * any object with these members works (memory history, mocks).
+ *
+ * @typedef {Object} HistoryLike
+ * @property {{ pathname: string }} location - the current location
+ * @property {function(string): void} push - push a new path onto history
+ * @property {function(function(Object, string): void): function(): void} listen -
+ *           subscribe to location changes as `(location, action)`; returns
+ *           an unlisten function
+ */
+
+/**
+ * A route definition: a path template string, or an object holding one at
+ * `path` (plus `lowerCase` to canonicalize pushed URLs). Templates embed
+ * data paths in `{…}` placeholders — e.g. `/users/{User.id}/{t}` — where
+ * each placeholder is a `get-value` path resolved against the AppCon
+ * (trigram short keys `t`/`a`/`o`, the datum aliases
+ * `term`/`action`/`orient`, and the AppCon data).
+ *
+ * @typedef {(string|{ path: string, lowerCase?: boolean })} RouteConfig
+ */
+
+/**
+ * One segment of a deconstructed path template.
+ *
+ * @typedef {Object} PathPart
+ * @property {string} part - the original path segment
+ * @property {number} idx - the segment's index in the path
+ * @property {string} use - the segment converted for `path-to-regexp`
+ *           (`:param` form, `.` encoded as `__0__`)
+ * @property {(RegExpExecArray|null)} match - the `{data.path}` placeholder
+ *           match when the segment holds one (`match[2]` is the `get-value`
+ *           data path); `null` for literal segments
+ */
 
 const PATH_VAR_RE = /(\{((\w|\.)+)(\(.+\))?\})/m;
 const DOT_REPLACER = '__0__';
@@ -16,6 +62,14 @@ const DOT_REPLACER = '__0__';
 // 1. a function that turns trigram into a path to push onto history
 // 2. a function that receives a url and converts it to a trigram to set onto the TAO
 
+/**
+ * Split a path template into per-segment {@link PathPart}s, converting
+ * `{data.path}` placeholders into `path-to-regexp` `:param` form (dots
+ * encoded as `__0__`).
+ *
+ * @param {string} origPath - the path template (e.g. `/users/{User.id}`)
+ * @returns {PathPart[]}
+ */
 export function deconstructPath(origPath) {
   return origPath.split('/').map((p, i) => {
     const match = PATH_VAR_RE.exec(p);
@@ -36,6 +90,13 @@ export function deconstructPath(origPath) {
   });
 }
 
+/**
+ * Reassemble a deconstructed path into the `path-to-regexp`-usable form
+ * (each segment's `use`).
+ *
+ * @param {PathPart[]} deconstruction - from {@link deconstructPath}
+ * @returns {string}
+ */
 // convert path to usable path for path-to-regexp
 export function convertPath(deconstruction) {
   return deconstruction.map((p) => p.use).join('/');
@@ -93,6 +154,18 @@ export function convertPath(deconstruction) {
 //   return pathData;
 // }
 
+/**
+ * Collect the path parameters for a handled AppCon: each placeholder's
+ * `get-value` path is resolved against the trigram (`t`/`a`/`o`), the
+ * datum aliases (`term`/`action`/`orient` → `data[t]`/`data[a]`/`data[o]`),
+ * and the AppCon data; nullish resolutions are omitted.
+ *
+ * @param {Object} tao - the concrete `{ t, a, o }` trigram handled
+ * @param {Object} data - the AppCon data
+ * @param {PathPart[]} deconstructedPath - from {@link deconstructPath}
+ * @returns {Object.<string, *>} `path-to-regexp` params keyed by `:param`
+ *          name
+ */
 function pathDataGet(tao, data, deconstructedPath) {
   const allData = {
     ...tao,
@@ -119,9 +192,21 @@ function pathDataGet(tao, data, deconstructedPath) {
   }, {});
 }
 
+/**
+ * Compile a route into the async handler the Router registers for the
+ * route's attached trigram: on a matching AppCon it builds the URL from
+ * the AppCon's data (lowercased when `route.lowerCase`), and — only when
+ * it differs from the current location — pushes it onto history and chains
+ * `{Route,Set,<orient of the signal>}` with `{ Route: <route>, Set: <path> }`.
+ *
+ * @param {HistoryLike} history - the history to push routes onto
+ * @param {RouteConfig} route - the route to compile
+ * @param {boolean} [debug=false] - console.log handler activity
+ * @returns {Handler} the async route handler `(tao, data) => AppCtx|undefined`
+ */
 function makeRouteHandler(history, route, debug = false) {
-  let pathString = route.path || route;
-  const deconstructedPath = deconstructPath(pathString);
+  let pathString = /** @type {{ path?: string }} */ (route).path || route;
+  const deconstructedPath = deconstructPath(/** @type {string} */ (pathString));
   const usablePath = convertPath(deconstructedPath);
   const toPath = pathToRegexp.compile(usablePath);
   return (tao, data) => {
@@ -133,7 +218,7 @@ function makeRouteHandler(history, route, debug = false) {
     // Stryker disable next-line all: optional debug logging
     debug && console.log('routeHandler::pathData', pathData);
     let routeValue = toPath(pathData);
-    if (route.lowerCase) {
+    if (/** @type {{ lowerCase?: boolean }} */ (route).lowerCase) {
       routeValue = routeValue.toLowerCase();
     }
     if (history.location.pathname !== routeValue) {

--- a/packages/tao-router/src/routeTag.js
+++ b/packages/tao-router/src/routeTag.js
@@ -1,5 +1,21 @@
 import get from 'get-value';
 
+/**
+ * Template-literal tag compiling a URL template into a route-building
+ * function. Each interpolation is a `get-value` lookup path resolved
+ * against the data object the returned function is called with; missing
+ * values render as `''`.
+ *
+ * ```js
+ * const userRoute = route`/users/${'user.id'}`;
+ * userRoute({ user: { id: 7 } }); // => '/users/7'
+ * ```
+ *
+ * @param {TemplateStringsArray} strings - the template's literal parts
+ * @param {...string} keys - `get-value` lookup paths (the interpolations)
+ * @returns {function(Object=): string} builds the route path from a data
+ *          object
+ */
 export function routeTag(strings, ...keys) {
   return (...values) => {
     const vals = values[0];

--- a/packages/tao-router/tsconfig.types.json
+++ b/packages/tao-router/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../config/tsconfig.types.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": ["src"]
+}

--- a/packages/tao-routing-core/package.json
+++ b/packages/tao-routing-core/package.json
@@ -10,6 +10,7 @@
   },
   "main": "lib",
   "module": "dist",
+  "types": "lib/index.d.ts",
   "sideEffects": false,
   "files": [
     "lib",
@@ -18,7 +19,8 @@
   "scripts": {
     "build:clean": "rimraf dist lib",
     "build:package": "rollup --config",
-    "build": "npm run build:clean && npm run build:package",
+    "build:types": "tsc -p tsconfig.types.json",
+    "build": "npm run build:clean && npm run build:package && npm run build:types",
     "test:mutation": "stryker run"
   },
   "author": "eudaimos",

--- a/packages/tao-routing-core/src/apply-signal.js
+++ b/packages/tao-routing-core/src/apply-signal.js
@@ -1,5 +1,42 @@
 import { AppCtx } from '@tao.js/core';
 
+/** @typedef {import('@tao.js/core').Trigram} Trigram */
+
+/**
+ * Positional route-entry signal: a trigram plus optional context data,
+ * spread into `kernel.setCtx(...)`.
+ *
+ * @typedef {[tao: Trigram, data?: *]} SignalTuple
+ */
+
+/**
+ * Keyed route-entry signal: a trigram under `tao` plus optional context
+ * data under `data`, applied as `kernel.setCtx(tao, data)`.
+ *
+ * @typedef {{ tao: Trigram, data?: * }} SignalDescriptor
+ */
+
+/**
+ * A route-entry signal — the value a host-router loader produces (under
+ * `{ signal }`) and the route-entry hooks apply to the Kernel:
+ * - an {@link AppCtx} instance → `setAppCtx`
+ * - a {@link SignalTuple} `[tao, data?]` → `setCtx(...signal)`
+ * - a {@link SignalDescriptor} `{ tao, data? }` → `setCtx(tao, data)`
+ *
+ * @typedef {AppCtx | SignalTuple | SignalDescriptor} RouteSignal
+ */
+
+/**
+ * The Kernel-shaped target a route-entry signal is applied to. Structural
+ * on purpose (this package never imports React or requires a concrete
+ * Kernel): any object with `setCtx` / `setAppCtx` — a `@tao.js/core`
+ * Kernel satisfies it.
+ *
+ * @typedef {object} SignalTarget
+ * @property {(trigram: Trigram, data?: *) => void} setCtx
+ * @property {(appCtx: AppCtx) => void} setAppCtx
+ */
+
 /**
  * Apply a route-entry signal to a Kernel.
  *
@@ -8,8 +45,8 @@ import { AppCtx } from '@tao.js/core';
  * - `[tao, data?]` → `setCtx(...signal)` when non-empty
  * - `{ tao, data? }` → `setCtx(tao, data)` when `tao` is truthy
  *
- * @param {{ setAppCtx: Function, setCtx: Function }} kernel
- * @param {*} signal
+ * @param {SignalTarget} kernel
+ * @param {RouteSignal | null | undefined} signal
  * @returns {boolean} whether a context was set
  */
 export function applySignal(kernel, signal) {
@@ -23,7 +60,8 @@ export function applySignal(kernel, signal) {
   }
 
   if (Array.isArray(signal)) {
-    if (signal.length === 0) {
+    // Runtime defends against [] even though the tuple type starts at length 1.
+    if (/** @type {ReadonlyArray<*>} */ (signal).length === 0) {
       return false;
     }
     kernel.setCtx(...signal);

--- a/packages/tao-routing-core/src/create-import-loader.js
+++ b/packages/tao-routing-core/src/create-import-loader.js
@@ -1,3 +1,61 @@
+/** @typedef {import('@tao.js/core').Kernel} Kernel */
+/** @typedef {import('./apply-signal').RouteSignal} RouteSignal */
+
+/**
+ * A TAO feature module, as dynamic-imported by an import loader:
+ * - `default` — `initialize(kernel)` ({@link FeatureInitializer}; required
+ *   unless the loader was created with `skipInit`)
+ * - `load` — value or helpers handed to the loader's `loadSignal`
+ *
+ * @typedef {object} FeatureModule
+ * @property {FeatureInitializer} [default]
+ * @property {*} [load]
+ */
+
+/**
+ * A feature module's `initialize` (its default export): wires handlers onto
+ * the Kernel; may return a cleanup function, which the import loader
+ * invokes immediately after initialization.
+ *
+ * @typedef {(kernel: Kernel) => void | (() => void)} FeatureInitializer
+ */
+
+/**
+ * Derive the route-entry signal from a feature module's `load` export plus
+ * the extra arguments given to the import loader (route params etc.).
+ *
+ * @typedef {(load: *, ...args: *[]) => RouteSignal | null | undefined} LoadSignalFn
+ */
+
+/**
+ * What an import loader resolves with (and route-entry hooks consume via
+ * `getSignal`): the route-entry signal keyed under `signal`.
+ *
+ * @typedef {{ signal?: RouteSignal | null }} LoaderResult
+ */
+
+/**
+ * A host-router loader helper produced by `createImportLoader`: awaits a
+ * dynamic-imported {@link FeatureModule}, runs its initializer, and
+ * resolves with the {@link LoaderResult} for the route data APIs (or
+ * `null` when the loader was created with `skipLoad`).
+ *
+ * @typedef {(script: FeatureModule | Promise<FeatureModule>, ...args: *[]) => Promise<LoaderResult | null>} ImportLoader
+ */
+
+/**
+ * Options for `createImportLoader`.
+ *
+ * @typedef {object} ImportLoaderOptions
+ * @property {LoadSignalFn} [loadSignal] `(load, ...args) => signal`;
+ *           defaults to passing `load` through as the signal
+ * @property {boolean} [skipLoad] resolve `null` instead of a
+ *           {@link LoaderResult}
+ * @property {boolean} [skipInit] do not require/run the module's
+ *           `initialize`
+ */
+
+/** @type {LoadSignalFn} */
 const defaultLoadSignal = (load) => load;
 
 /**
@@ -9,11 +67,9 @@ const defaultLoadSignal = (load) => load;
  *
  * Returns `{ signal }` for the route data APIs, or `null` when `skipLoad`.
  *
- * @param {*} TAO Kernel instance
- * @param {object} [options]
- * @param {Function} [options.loadSignal] `(load, ...args) => signal`
- * @param {boolean} [options.skipLoad]
- * @param {boolean} [options.skipInit]
+ * @param {Kernel} TAO Kernel instance
+ * @param {ImportLoaderOptions} [options]
+ * @returns {ImportLoader}
  */
 export function createImportLoader(
   TAO,

--- a/packages/tao-routing-core/src/create-use-route-signal.js
+++ b/packages/tao-routing-core/src/create-use-route-signal.js
@@ -1,14 +1,35 @@
 import { applySignal } from './apply-signal';
 
+/** @typedef {import('./apply-signal').RouteSignal} RouteSignal */
+/** @typedef {import('./create-use-signal-effect').UseEffectHook} UseEffectHook */
+/** @typedef {import('./create-use-signal-effect').UseRefHook} UseRefHook */
+/** @typedef {import('./create-use-signal-effect').UseTaoContextHook} UseTaoContextHook */
+/** @typedef {import('./create-use-signal-effect').ApplySignalFn} ApplySignalFn */
+
+/**
+ * The hook a `createUseRouteSignal` factory returns: applies each new
+ * identity of an explicitly-passed route-entry signal to the ambient
+ * Kernel exactly once.
+ *
+ * @typedef {(signal: RouteSignal | null | undefined) => void} UseRouteSignalHook
+ */
+
+/**
+ * Dependencies injected into `createUseRouteSignal`.
+ *
+ * @typedef {object} UseRouteSignalDeps
+ * @property {UseEffectHook} useEffect
+ * @property {UseRefHook} useRef
+ * @property {UseTaoContextHook} useTaoContext
+ * @property {ApplySignalFn} [apply]
+ */
+
 /**
  * Factory for a React hook that applies an explicit route-entry signal
  * (Next.js pages, RSC props, etc. — no host loader data API).
  *
- * @param {object} deps
- * @param {Function} deps.useEffect
- * @param {Function} deps.useRef
- * @param {Function} deps.useTaoContext
- * @param {Function} [deps.apply]
+ * @param {UseRouteSignalDeps} deps
+ * @returns {UseRouteSignalHook}
  */
 export function createUseRouteSignal({
   useEffect,

--- a/packages/tao-routing-core/src/create-use-signal-effect.js
+++ b/packages/tao-routing-core/src/create-use-signal-effect.js
@@ -1,16 +1,70 @@
 import { applySignal } from './apply-signal';
 
+/** @typedef {import('./apply-signal').RouteSignal} RouteSignal */
+/** @typedef {import('./apply-signal').SignalTarget} SignalTarget */
+
+/**
+ * React `useEffect`-shaped function, typed structurally so this package
+ * never imports React — inject `React.useEffect` (or a compatible stand-in
+ * for tests).
+ *
+ * @typedef {(effect: () => void | (() => void), deps?: ReadonlyArray<*>) => void} UseEffectHook
+ */
+
+/**
+ * React `useRef`-shaped function, typed structurally so this package never
+ * imports React — inject `React.useRef` (or a compatible stand-in).
+ *
+ * @typedef {(initialValue: *) => { current: * }} UseRefHook
+ */
+
+/**
+ * Hook returning the ambient TAO Kernel (any {@link SignalTarget}) —
+ * `useTaoContext` from `@tao.js/react`, or a compatible stand-in.
+ *
+ * @typedef {() => SignalTarget} UseTaoContextHook
+ */
+
+/**
+ * Hook reading the current route-entry signal from the host router's data
+ * API (must call hooks internally, e.g. wrap `useLoaderData`).
+ *
+ * @typedef {() => RouteSignal | null | undefined} UseSignalHook
+ */
+
+/**
+ * Apply a route-entry signal to a Kernel-shaped target — `applySignal`'s
+ * shape (injectable for tests).
+ *
+ * @typedef {(kernel: SignalTarget, signal: RouteSignal | null | undefined) => boolean} ApplySignalFn
+ */
+
+/**
+ * The hook a `createUseSignalEffect` factory returns: reads the host
+ * router's signal each render and applies each new signal identity to the
+ * ambient Kernel exactly once.
+ *
+ * @typedef {() => void} UseSignalEffectHook
+ */
+
+/**
+ * Dependencies injected into `createUseSignalEffect`.
+ *
+ * @typedef {object} UseSignalEffectDeps
+ * @property {UseEffectHook} useEffect
+ * @property {UseRefHook} useRef
+ * @property {UseTaoContextHook} useTaoContext
+ * @property {UseSignalHook} useSignal `() => signal` (must call hooks internally)
+ * @property {ApplySignalFn} [apply]
+ */
+
 /**
  * Factory for a React hook that applies a signal from a host-router data API.
  *
  * Inject React / router / TAO hooks so this package stays free of React imports.
  *
- * @param {object} deps
- * @param {Function} deps.useEffect
- * @param {Function} deps.useRef
- * @param {Function} deps.useTaoContext
- * @param {Function} deps.useSignal `() => signal` (must call hooks internally)
- * @param {Function} [deps.apply]
+ * @param {UseSignalEffectDeps} deps
+ * @returns {UseSignalEffectHook}
  */
 export function createUseSignalEffect({
   useEffect,

--- a/packages/tao-routing-core/src/get-signal.js
+++ b/packages/tao-routing-core/src/get-signal.js
@@ -1,8 +1,13 @@
+/** @typedef {import('./create-import-loader').LoaderResult} LoaderResult */
+/** @typedef {import('./apply-signal').RouteSignal} RouteSignal */
+
 /**
  * Read `signal` from a loader/route data bag (`{ signal }`).
  *
- * @param {*} loaderData
- * @returns {*}
+ * @param {LoaderResult | null | undefined} loaderData - typically the host
+ *        router's loader data (the {@link LoaderResult} an import loader
+ *        produced); tolerates anything nullish or signal-less
+ * @returns {RouteSignal | null | undefined}
  */
 export function getSignal(loaderData) {
   if (loaderData == null) {

--- a/packages/tao-routing-core/src/index.js
+++ b/packages/tao-routing-core/src/index.js
@@ -1,3 +1,41 @@
+/**
+ * @tao.js/routing-core — the framework-agnostic route-entry → AppCon
+ * contract for tao.js host-router adapters.
+ *
+ * Route loaders dynamic-import a feature module (via `createImportLoader`),
+ * initialize it against the Kernel, and hand the route data API a
+ * `{ signal }` bag; route-entry hooks (built from the hook factories) read
+ * that signal back and `applySignal` it to the Kernel. The hook factories
+ * take React-shaped functions as injected dependencies so this package
+ * never imports React.
+ *
+ * @module @tao.js/routing-core
+ */
+
+/**
+ * Shared shapes re-exported for typed consumers (the JSDoc typedefs are the
+ * source of truth at their defining modules).
+ *
+ * @typedef {import('./apply-signal').RouteSignal} RouteSignal
+ * @typedef {import('./apply-signal').SignalTuple} SignalTuple
+ * @typedef {import('./apply-signal').SignalDescriptor} SignalDescriptor
+ * @typedef {import('./apply-signal').SignalTarget} SignalTarget
+ * @typedef {import('./create-import-loader').FeatureModule} FeatureModule
+ * @typedef {import('./create-import-loader').FeatureInitializer} FeatureInitializer
+ * @typedef {import('./create-import-loader').LoadSignalFn} LoadSignalFn
+ * @typedef {import('./create-import-loader').LoaderResult} LoaderResult
+ * @typedef {import('./create-import-loader').ImportLoader} ImportLoader
+ * @typedef {import('./create-import-loader').ImportLoaderOptions} ImportLoaderOptions
+ * @typedef {import('./create-use-signal-effect').UseEffectHook} UseEffectHook
+ * @typedef {import('./create-use-signal-effect').UseRefHook} UseRefHook
+ * @typedef {import('./create-use-signal-effect').UseTaoContextHook} UseTaoContextHook
+ * @typedef {import('./create-use-signal-effect').UseSignalHook} UseSignalHook
+ * @typedef {import('./create-use-signal-effect').ApplySignalFn} ApplySignalFn
+ * @typedef {import('./create-use-signal-effect').UseSignalEffectDeps} UseSignalEffectDeps
+ * @typedef {import('./create-use-signal-effect').UseSignalEffectHook} UseSignalEffectHook
+ * @typedef {import('./create-use-route-signal').UseRouteSignalDeps} UseRouteSignalDeps
+ * @typedef {import('./create-use-route-signal').UseRouteSignalHook} UseRouteSignalHook
+ */
 export { applySignal } from './apply-signal';
 export { getSignal } from './get-signal';
 export { createImportLoader } from './create-import-loader';

--- a/packages/tao-routing-core/tsconfig.types.json
+++ b/packages/tao-routing-core/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../config/tsconfig.types.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": ["src"]
+}

--- a/packages/tao-routing-next/package.json
+++ b/packages/tao-routing-next/package.json
@@ -10,6 +10,7 @@
   },
   "main": "lib",
   "module": "dist",
+  "types": "lib/index.d.ts",
   "sideEffects": false,
   "files": [
     "lib",
@@ -18,7 +19,8 @@
   "scripts": {
     "build:clean": "rimraf dist lib",
     "build:package": "rollup --config",
-    "build": "npm run build:clean && npm run build:package",
+    "build:types": "tsc -p tsconfig.types.json",
+    "build": "npm run build:clean && npm run build:package && npm run build:types",
     "test:mutation": "stryker run"
   },
   "author": "eudaimos",

--- a/packages/tao-routing-next/src/enter-route.js
+++ b/packages/tao-routing-next/src/enter-route.js
@@ -1,11 +1,15 @@
 import { applySignal } from '@tao.js/routing-core';
 
+/** @typedef {import('@tao.js/routing-core').SignalTarget} SignalTarget */
+/** @typedef {import('@tao.js/routing-core').RouteSignal} RouteSignal */
+
 /**
  * Server-friendly entry: apply a route signal to a Kernel (RSC / route handlers).
  *
- * @param {*} kernel
- * @param {*} signal
- * @returns {boolean}
+ * @param {SignalTarget} kernel - the Kernel (or any `setCtx`/`setAppCtx`
+ *        target) to signal
+ * @param {RouteSignal | null | undefined} signal
+ * @returns {boolean} whether a context was set
  */
 export function enterRoute(kernel, signal) {
   return applySignal(kernel, signal);

--- a/packages/tao-routing-next/src/import-loader.js
+++ b/packages/tao-routing-next/src/import-loader.js
@@ -1,7 +1,18 @@
 import { createImportLoader } from '@tao.js/routing-core';
 
+/** @typedef {import('@tao.js/core').Kernel} Kernel */
+/** @typedef {import('@tao.js/routing-core').ImportLoaderOptions} ImportLoaderOptions */
+/** @typedef {import('@tao.js/routing-core').ImportLoader} ImportLoader */
+
 /**
- * Next.js-oriented alias of `createImportLoader` for route/feature modules.
+ * Next.js-oriented alias of `createImportLoader` for route/feature modules:
+ * dynamic-imports a TAO feature module, initializes it against the Kernel,
+ * and resolves with the `{ signal }` bag to hand `useRouteSignal` /
+ * `enterRoute` (via `getSignal`).
+ *
+ * @param {Kernel} TAO
+ * @param {ImportLoaderOptions} [options]
+ * @returns {ImportLoader}
  */
 export function importLoader(TAO, options) {
   return createImportLoader(TAO, options);

--- a/packages/tao-routing-next/src/index.js
+++ b/packages/tao-routing-next/src/index.js
@@ -1,3 +1,29 @@
+/**
+ * @tao.js/routing-next — Next.js adapter for the tao.js route-entry →
+ * AppCon contract: `importLoader` dynamic-imports TAO feature modules and
+ * produces a `{ signal }` bag; `useRouteSignal` applies an explicit
+ * route-entry signal from page/server props on the client, and
+ * `enterRoute` applies one on the server (RSC / route handlers).
+ *
+ * @module @tao.js/routing-next
+ */
+
+/**
+ * Shared shapes re-exported for typed consumers (defined by
+ * `@tao.js/routing-core`).
+ *
+ * @typedef {import('@tao.js/routing-core').RouteSignal} RouteSignal
+ * @typedef {import('@tao.js/routing-core').SignalTuple} SignalTuple
+ * @typedef {import('@tao.js/routing-core').SignalDescriptor} SignalDescriptor
+ * @typedef {import('@tao.js/routing-core').SignalTarget} SignalTarget
+ * @typedef {import('@tao.js/routing-core').FeatureModule} FeatureModule
+ * @typedef {import('@tao.js/routing-core').FeatureInitializer} FeatureInitializer
+ * @typedef {import('@tao.js/routing-core').LoadSignalFn} LoadSignalFn
+ * @typedef {import('@tao.js/routing-core').LoaderResult} LoaderResult
+ * @typedef {import('@tao.js/routing-core').ImportLoader} ImportLoader
+ * @typedef {import('@tao.js/routing-core').ImportLoaderOptions} ImportLoaderOptions
+ * @typedef {import('@tao.js/routing-core').UseRouteSignalHook} UseRouteSignalHook
+ */
 export { importLoader } from './import-loader';
 export { useRouteSignal } from './use-route-signal';
 export { enterRoute } from './enter-route';

--- a/packages/tao-routing-next/src/use-route-signal.js
+++ b/packages/tao-routing-next/src/use-route-signal.js
@@ -4,6 +4,8 @@ import { createUseRouteSignal } from '@tao.js/routing-core';
 
 /**
  * Apply an explicit route-entry signal (from server props / page data) to the Kernel.
+ *
+ * @type {import('@tao.js/routing-core').UseRouteSignalHook}
  */
 export const useRouteSignal = createUseRouteSignal({
   useEffect,

--- a/packages/tao-routing-next/tsconfig.types.json
+++ b/packages/tao-routing-next/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../config/tsconfig.types.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": ["src"]
+}

--- a/packages/tao-routing-react-router/package.json
+++ b/packages/tao-routing-react-router/package.json
@@ -10,6 +10,7 @@
   },
   "main": "lib",
   "module": "dist",
+  "types": "lib/index.d.ts",
   "sideEffects": false,
   "files": [
     "lib",
@@ -18,7 +19,8 @@
   "scripts": {
     "build:clean": "rimraf dist lib",
     "build:package": "rollup --config",
-    "build": "npm run build:clean && npm run build:package",
+    "build:types": "tsc -p tsconfig.types.json",
+    "build": "npm run build:clean && npm run build:package && npm run build:types",
     "test:mutation": "stryker run"
   },
   "author": "eudaimos",

--- a/packages/tao-routing-react-router/src/import-loader.js
+++ b/packages/tao-routing-react-router/src/import-loader.js
@@ -1,8 +1,19 @@
 import { createImportLoader } from '@tao.js/routing-core';
 
+/** @typedef {import('@tao.js/core').Kernel} Kernel */
+/** @typedef {import('@tao.js/routing-core').ImportLoaderOptions} ImportLoaderOptions */
+/** @typedef {import('@tao.js/routing-core').ImportLoader} ImportLoader */
+
 /**
  * React Router-oriented alias of `createImportLoader`.
- * Use the returned function as a route `loader` helper.
+ * Use the returned function as a route `loader` helper: it dynamic-imports
+ * a TAO feature module, initializes it against the Kernel, and resolves
+ * with the `{ signal }` bag `useLoaderSignal` reads back via
+ * `useLoaderData`.
+ *
+ * @param {Kernel} TAO
+ * @param {ImportLoaderOptions} [options]
+ * @returns {ImportLoader}
  */
 export function importLoader(TAO, options) {
   return createImportLoader(TAO, options);

--- a/packages/tao-routing-react-router/src/index.js
+++ b/packages/tao-routing-react-router/src/index.js
@@ -1,3 +1,29 @@
+/**
+ * @tao.js/routing-react-router — React Router adapter for the tao.js
+ * route-entry → AppCon contract: `importLoader` builds route `loader`
+ * helpers that dynamic-import TAO feature modules and produce a
+ * `{ signal }` bag; `useLoaderSignal` reads it back via `useLoaderData`
+ * and applies it to the ambient Kernel.
+ *
+ * @module @tao.js/routing-react-router
+ */
+
+/**
+ * Shared shapes re-exported for typed consumers (defined by
+ * `@tao.js/routing-core`).
+ *
+ * @typedef {import('@tao.js/routing-core').RouteSignal} RouteSignal
+ * @typedef {import('@tao.js/routing-core').SignalTuple} SignalTuple
+ * @typedef {import('@tao.js/routing-core').SignalDescriptor} SignalDescriptor
+ * @typedef {import('@tao.js/routing-core').SignalTarget} SignalTarget
+ * @typedef {import('@tao.js/routing-core').FeatureModule} FeatureModule
+ * @typedef {import('@tao.js/routing-core').FeatureInitializer} FeatureInitializer
+ * @typedef {import('@tao.js/routing-core').LoadSignalFn} LoadSignalFn
+ * @typedef {import('@tao.js/routing-core').LoaderResult} LoaderResult
+ * @typedef {import('@tao.js/routing-core').ImportLoader} ImportLoader
+ * @typedef {import('@tao.js/routing-core').ImportLoaderOptions} ImportLoaderOptions
+ * @typedef {import('@tao.js/routing-core').UseSignalEffectHook} UseSignalEffectHook
+ */
 export { importLoader } from './import-loader';
 export { useLoaderSignal } from './use-loader-signal';
 export {

--- a/packages/tao-routing-react-router/src/use-loader-signal.js
+++ b/packages/tao-routing-react-router/src/use-loader-signal.js
@@ -3,6 +3,15 @@ import { useLoaderData } from 'react-router';
 import { useTaoContext } from '@tao.js/react';
 import { createUseSignalEffect, getSignal } from '@tao.js/routing-core';
 
+/** @typedef {import('@tao.js/routing-core').RouteSignal} RouteSignal */
+/** @typedef {import('@tao.js/routing-core').LoaderResult} LoaderResult */
+
+/**
+ * Read the route-entry signal from the current React Router loader data
+ * (the {@link LoaderResult} `{ signal }` bag an `importLoader` produced).
+ *
+ * @returns {RouteSignal | null | undefined}
+ */
 function useReactRouterSignal() {
   const data = useLoaderData();
   return getSignal(data);
@@ -10,6 +19,8 @@ function useReactRouterSignal() {
 
 /**
  * Apply the `{ signal }` from the current React Router loader data to the Kernel.
+ *
+ * @type {import('@tao.js/routing-core').UseSignalEffectHook}
  */
 export const useLoaderSignal = createUseSignalEffect({
   useEffect,

--- a/packages/tao-routing-react-router/tsconfig.types.json
+++ b/packages/tao-routing-react-router/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../config/tsconfig.types.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": ["src"]
+}

--- a/packages/tao-routing-tanstack/package.json
+++ b/packages/tao-routing-tanstack/package.json
@@ -10,6 +10,7 @@
   },
   "main": "lib",
   "module": "dist",
+  "types": "lib/index.d.ts",
   "sideEffects": false,
   "files": [
     "lib",
@@ -18,7 +19,8 @@
   "scripts": {
     "build:clean": "rimraf dist lib",
     "build:package": "rollup --config",
-    "build": "npm run build:clean && npm run build:package",
+    "build:types": "tsc -p tsconfig.types.json",
+    "build": "npm run build:clean && npm run build:package && npm run build:types",
     "test:mutation": "stryker run"
   },
   "author": "eudaimos",

--- a/packages/tao-routing-tanstack/src/import-loader.js
+++ b/packages/tao-routing-tanstack/src/import-loader.js
@@ -1,7 +1,18 @@
 import { createImportLoader } from '@tao.js/routing-core';
 
+/** @typedef {import('@tao.js/core').Kernel} Kernel */
+/** @typedef {import('@tao.js/routing-core').ImportLoaderOptions} ImportLoaderOptions */
+/** @typedef {import('@tao.js/routing-core').ImportLoader} ImportLoader */
+
 /**
  * TanStack Router-oriented alias of `createImportLoader`.
+ * Use the returned function inside a route `loader`: it dynamic-imports a
+ * TAO feature module, initializes it against the Kernel, and resolves with
+ * the `{ signal }` bag `useLoaderSignal` reads back via `useLoaderData`.
+ *
+ * @param {Kernel} TAO
+ * @param {ImportLoaderOptions} [options]
+ * @returns {ImportLoader}
  */
 export function importLoader(TAO, options) {
   return createImportLoader(TAO, options);

--- a/packages/tao-routing-tanstack/src/index.js
+++ b/packages/tao-routing-tanstack/src/index.js
@@ -1,3 +1,29 @@
+/**
+ * @tao.js/routing-tanstack-router — TanStack Router adapter for the tao.js
+ * route-entry → AppCon contract: `importLoader` builds route `loader`
+ * helpers that dynamic-import TAO feature modules and produce a
+ * `{ signal }` bag; `useLoaderSignal` reads it back via `useLoaderData`
+ * and applies it to the ambient Kernel.
+ *
+ * @module @tao.js/routing-tanstack-router
+ */
+
+/**
+ * Shared shapes re-exported for typed consumers (defined by
+ * `@tao.js/routing-core`).
+ *
+ * @typedef {import('@tao.js/routing-core').RouteSignal} RouteSignal
+ * @typedef {import('@tao.js/routing-core').SignalTuple} SignalTuple
+ * @typedef {import('@tao.js/routing-core').SignalDescriptor} SignalDescriptor
+ * @typedef {import('@tao.js/routing-core').SignalTarget} SignalTarget
+ * @typedef {import('@tao.js/routing-core').FeatureModule} FeatureModule
+ * @typedef {import('@tao.js/routing-core').FeatureInitializer} FeatureInitializer
+ * @typedef {import('@tao.js/routing-core').LoadSignalFn} LoadSignalFn
+ * @typedef {import('@tao.js/routing-core').LoaderResult} LoaderResult
+ * @typedef {import('@tao.js/routing-core').ImportLoader} ImportLoader
+ * @typedef {import('@tao.js/routing-core').ImportLoaderOptions} ImportLoaderOptions
+ * @typedef {import('@tao.js/routing-core').UseSignalEffectHook} UseSignalEffectHook
+ */
 export { importLoader } from './import-loader';
 export { useLoaderSignal } from './use-loader-signal';
 export {

--- a/packages/tao-routing-tanstack/src/use-loader-signal.js
+++ b/packages/tao-routing-tanstack/src/use-loader-signal.js
@@ -3,13 +3,30 @@ import { useLoaderData } from '@tanstack/react-router';
 import { useTaoContext } from '@tao.js/react';
 import { createUseSignalEffect, getSignal } from '@tao.js/routing-core';
 
+/** @typedef {import('@tao.js/routing-core').RouteSignal} RouteSignal */
+/** @typedef {import('@tao.js/routing-core').LoaderResult} LoaderResult */
+
+/**
+ * Read the route-entry signal from the current TanStack Router loader data
+ * (the {@link LoaderResult} `{ signal }` bag an `importLoader` produced).
+ *
+ * TanStack's typings require an options argument (`from`/`strict`) for
+ * route-registry-aware inference; this hook deliberately reads whatever
+ * route is current with the zero-argument runtime call, so the hook is
+ * comment-cast loose and the result re-asserted as a {@link LoaderResult}.
+ *
+ * @returns {RouteSignal | null | undefined}
+ */
 function useTanStackSignal() {
-  const data = useLoaderData();
+  /** @type {LoaderResult | null | undefined} */
+  const data = /** @type {*} */ (useLoaderData)();
   return getSignal(data);
 }
 
 /**
  * Apply the `{ signal }` from the current TanStack Router loader data to the Kernel.
+ *
+ * @type {import('@tao.js/routing-core').UseSignalEffectHook}
  */
 export const useLoaderSignal = createUseSignalEffect({
   useEffect,

--- a/packages/tao-routing-tanstack/tsconfig.types.json
+++ b/packages/tao-routing-tanstack/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../config/tsconfig.types.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": ["src"]
+}

--- a/packages/tao-socket-io/package.json
+++ b/packages/tao-socket-io/package.json
@@ -10,6 +10,7 @@
   },
   "main": "lib",
   "module": "dist",
+  "types": "lib/index.d.ts",
   "bundles": {
     "browser": "bundles/browser.umd.js"
   },
@@ -21,7 +22,8 @@
   "scripts": {
     "build:clean": "rimraf dist lib bundles",
     "build:package": "rollup --config",
-    "build": "npm run build:clean && npm run build:package",
+    "build:types": "tsc -p tsconfig.types.json",
+    "build": "npm run build:clean && npm run build:package && npm run build:types",
     "test:mutation": "stryker run"
   },
   "author": "eudaimos",

--- a/packages/tao-socket-io/src/index.js
+++ b/packages/tao-socket-io/src/index.js
@@ -1,3 +1,133 @@
+/**
+ * @tao.js/socket.io — wire a TAO signal network to socket.io on either side
+ * of the connection.
+ *
+ * One factory, {@link wireTaoJsToSocketIO}, adapts to its environment
+ * (detected by `typeof window` at module load):
+ *
+ * - in the **browser** it connects a socket.io client and bridges it to the
+ *   kernel as a duplex transport,
+ * - on the **server** it attaches per-connection middleware that scopes each
+ *   client to its own `Channel` with a per-client reply path.
+ *
+ * socket.io itself is **not** a dependency: the `io` and socket parameters
+ * are typed structurally ({@link SocketIoClientFactory},
+ * {@link SocketIoServerLike}, {@link SocketLike}) with exactly the members
+ * this package uses, so any conformant implementation works.
+ *
+ * Both directions speak the 0.20 wire contract (ENVELOPE-SPEC.md §9): a
+ * signal crosses the socket as `{ tao, data, envelope: { v, chain } }` —
+ * only the envelope's `chain` scope is portable — and the receiving side
+ * re-enters it stamping its own hop-scope `source` marker for echo
+ * suppression, continuing the received chain through its local reducers.
+ *
+ * @module @tao.js/socket.io
+ */
+
+/**
+ * @typedef {import('@tao.js/core').Trigram} Trigram
+ * @typedef {import('@tao.js/utils').NetworkSurface} NetworkSurface
+ * @typedef {import('@tao.js/utils').WireEnvelope} WireEnvelope
+ */
+
+/**
+ * The payload framing a TAO signal on the socket (ENVELOPE-SPEC.md §9),
+ * emitted as the `'fromClient'` / `'fromServer'` events.
+ *
+ * @typedef {Object} SocketPayload
+ * @property {Trigram} tao - the signal's trigram (short or long keys;
+ *           long-form keys win on receipt)
+ * @property {*} data - the signal's datagram(s)
+ * @property {WireEnvelope} [envelope] - the portable wire envelope
+ *           `{ v, chain }`; absent from pre-0.20 senders and then treated as
+ *           a fresh (`null`) chain — one-sided backward compatibility
+ */
+
+/**
+ * Structural shape of the socket.io Socket this package actually uses —
+ * client and server sockets both conform.
+ *
+ * @typedef {Object} SocketLike
+ * @property {string} [id] - socket identifier (server side): names the
+ *           per-client Channel and the `socket:<id>` origin marker
+ * @property {{ auth: * }} [handshake] - connection handshake (server side);
+ *           `handshake.auth` is handed to {@link AuthTransform}
+ * @property {function(string, SocketPayload): *} emit - emit a TAO event
+ *           (`'fromServer'` from the server, `'fromClient'` from the client)
+ * @property {function(string, Function): *} on - subscribe to socket events
+ *           (`'fromServer'` / `'fromClient'` / `'disconnect'`)
+ */
+
+/**
+ * A socket.io client factory (the `io` export of `socket.io-client`): called
+ * with `` `${host}/${namespace}` `` and the `opts.io` connection options.
+ *
+ * @callback SocketIoClientFactory
+ * @param {string} url - `` `${host}/${namespace}` ``
+ * @param {Object} [opts] - connection options, passed through verbatim from
+ *        `opts.io`
+ * @returns {SocketLike} the connected namespace socket
+ */
+
+/**
+ * Structural shape of a socket.io Server: only `of(nsp)` is used, to obtain
+ * the namespace the connection middleware is attached to.
+ *
+ * @typedef {Object} SocketIoServerLike
+ * @property {function(string): { use: function(SocketIoMiddleware): * }} of -
+ *           resolve the `/{namespace}` namespace
+ */
+
+/**
+ * Per-connection middleware: attached via `namespace.use(...)` when a server
+ * is given, or returned from {@link wireTaoJsToSocketIO} for manual
+ * attachment.
+ *
+ * @callback SocketIoMiddleware
+ * @param {SocketLike} socket - the connecting client socket
+ * @param {function(): *} [next] - socket.io's middleware continuation;
+ *        called (and its value returned) when provided
+ * @returns {*}
+ */
+
+/**
+ * Server-side connection hook: receives the per-client Channel and the raw
+ * socket. An optional returned function is invoked with the disconnect
+ * reason when the client disconnects.
+ *
+ * @callback OnConnect
+ * @param {Channel} clientTAO - the Channel scoping this client's signals
+ * @param {SocketLike} socket - the connected socket
+ * @returns {(function(string=): void|*)} optional disconnect cleanup
+ */
+
+/**
+ * Server-side hook transforming inbound data before it enters the network —
+ * e.g. stamping the socket's handshake auth onto the datagram.
+ *
+ * @callback AuthTransform
+ * @param {Trigram} tao - the inbound signal's trigram
+ * @param {*} data - the inbound datagram(s)
+ * @param {*} auth - `socket.handshake.auth`
+ * @returns {(Promise<*>|*)} the data to enter (awaited)
+ */
+
+/**
+ * Options for {@link wireTaoJsToSocketIO}.
+ *
+ * @typedef {Object} WireOptions
+ * @property {string} [namespace='tao'] - socket.io namespace to connect
+ *           to / attach on
+ * @property {string} [ns] - alias for `namespace` (`namespace` wins)
+ * @property {string} [host=''] - client only: host prefix for the connection
+ *           url `` `${host}/${namespace}` ``
+ * @property {Object} [io] - client only: connection options passed verbatim
+ *           to the client factory
+ * @property {OnConnect} [onConnect] - server only: per-connection hook
+ * @property {AuthTransform} [authTransform] - server only: inbound data
+ *           transform
+ */
+
 import { AppCtx } from '@tao.js/core';
 import {
   Channel,
@@ -14,6 +144,22 @@ const EVENTS = ['fromServer', 'fromClient'];
 
 const NOOP = () => {};
 
+/**
+ * Client side: bridge the kernel and the socket as a duplex transport
+ * (`createTransport` from `@tao.js/utils`).
+ *
+ * Outbound, every hop on the network is emitted — phase-blind — as
+ * `'fromClient'` with its wire envelope (the chain crosses the boundary —
+ * ENVELOPE-SPEC.md §9), except hops that arrived from this socket (echo
+ * suppression with the bidirectional reflex). Inbound `'fromServer'`
+ * payloads go through `transport.receive`, entering the network with the
+ * transport's own hop-scope `source` marker and the received chain.
+ *
+ * @param {NetworkSurface} TAO - the kernel (or bare Network) to bridge
+ * @param {SocketLike} socket - the connected client socket
+ * @returns {{ name: string, receive: Function, dispose: Function }} the
+ *          transport handle
+ */
 function decorateNetwork(TAO, socket) {
   // duplex transport: every hop is emitted with its wire envelope (chain
   // crosses the boundary — ENVELOPE-SPEC.md §9); arriving signals enter
@@ -28,10 +174,26 @@ function decorateNetwork(TAO, socket) {
   return transport;
 }
 
+/**
+ * Build an AppCtx from a wire trigram + datagram(s); long-form keys win.
+ *
+ * @param {Trigram} trigram - short or long keys
+ * @param {*} data - datagram(s)
+ * @returns {AppCtx}
+ */
 function makeAppCtx({ t, term, a, action, o, orient }, data) {
   return new AppCtx(term || t, action || a, orient || o, data);
 }
 
+/**
+ * Server side: inbound `'fromClient'` handler without an auth transform —
+ * enters the payload on the per-client Channel with the socket's origin
+ * marker and the continued wire chain (§9).
+ *
+ * @param {Channel} TAO - the per-client Channel
+ * @param {string} sourceName - this socket's origin marker (`socket:<id>`)
+ * @returns {function(SocketPayload): void}
+ */
 function onEventPlain(TAO, sourceName) {
   return ({ tao, data, envelope }) =>
     TAO.enter(makeAppCtx(tao, data), {
@@ -40,6 +202,17 @@ function onEventPlain(TAO, sourceName) {
     });
 }
 
+/**
+ * Server side: inbound `'fromClient'` handler that awaits
+ * `authTransform(tao, data, handshake.auth)` and enters the transformed
+ * data — same origin marker + chain continuation as {@link onEventPlain}.
+ *
+ * @param {Channel} TAO - the per-client Channel
+ * @param {*} auth - `socket.handshake.auth`
+ * @param {AuthTransform} authTransform
+ * @param {string} sourceName - this socket's origin marker (`socket:<id>`)
+ * @returns {function(SocketPayload): Promise<void>}
+ */
 function onEventAuth(TAO, auth, authTransform, sourceName) {
   return async ({ tao, data, envelope }) => {
     const useData = await authTransform(tao, data, auth);
@@ -50,6 +223,18 @@ function onEventAuth(TAO, auth, authTransform, sourceName) {
   };
 }
 
+/**
+ * Server side: wire one client socket to its Channel — the inbound entry
+ * path (`'fromClient'` → `Channel.enter` with `hop.source` = `socket:<id>`
+ * per ENVELOPE-SPEC.md §9) and the per-client reply path (an `onProceed`
+ * decoration on the Channel's private network emitting `'fromServer'`).
+ * The decoration is disposed on disconnect.
+ *
+ * @param {Channel} TAO - the per-client Channel
+ * @param {SocketLike} socket - the connected socket
+ * @param {AuthTransform} [authTransform] - optional inbound data transform
+ * @returns {void}
+ */
 function decorateSocket(TAO, socket, authTransform) {
   const { auth } = socket.handshake;
   // §9: the receiving side stamps its own hop-scope origin marker so any
@@ -85,11 +270,23 @@ function decorateSocket(TAO, socket, authTransform) {
   });
 }
 
+/**
+ * Server side: build the per-connection middleware. Each connecting socket
+ * gets its own `Channel` on the kernel (id = `socket.id`), wired by
+ * {@link decorateSocket}; `onConnect` runs with the Channel + socket, and
+ * its returned cleanup (when a function) is invoked with the disconnect
+ * reason.
+ *
+ * @param {NetworkSurface} TAO - the kernel the per-client Channels wrap
+ * @param {{ onConnect?: OnConnect, authTransform?: AuthTransform }} [opts]
+ * @returns {SocketIoMiddleware}
+ */
 // change, options object now instead of just onConnect
 const ioMiddleware =
   (TAO, { onConnect, authTransform } = {}) =>
   (socket, next) => {
     let clientTAO = new Channel(TAO, socket.id);
+    /** @type {function(string=): void} */
     let onDisconnect = NOOP;
     decorateSocket(clientTAO, socket, authTransform);
     if (onConnect && typeof onConnect === 'function') {
@@ -108,6 +305,40 @@ const ioMiddleware =
     }
   };
 
+/**
+ * Wire a TAO signal network to socket.io — the 0.20 wire contract
+ * (ENVELOPE-SPEC.md §9) on both sides of the connection. Environment is
+ * detected by `typeof window` at module load:
+ *
+ * **Client** (`window` defined) — `io` must be a socket.io client factory;
+ * it is called with `` `${host}/${namespace}` `` and `opts.io`, and the
+ * resulting socket is bridged to `TAO` as a duplex transport
+ * (`createTransport`): every hop is emitted as `'fromClient'` with
+ * `{ tao, data, envelope: { v, chain } }`, and every inbound `'fromServer'`
+ * payload re-enters through `transport.receive` — stamping the transport's
+ * own hop-scope `source` marker (echo suppression) and continuing the
+ * received chain. Returns the connected socket; returns `undefined` when
+ * `io` is not a function.
+ *
+ * **Server** (no `window`) — each connecting socket gets its own `Channel`
+ * on `TAO` (id = `socket.id`). Inbound `'fromClient'` payloads enter the
+ * Channel with `hop: { source: 'socket:<id>' }` and the wire envelope's
+ * continued chain (absent/unknown-version envelopes enter with a fresh
+ * chain); replies are emitted per client as `'fromServer'` by an
+ * `onProceed` decoration on the Channel — veto-respecting, so
+ * intercept-halted/-diverted signals are never emitted — carrying the
+ * dispatch envelope's chain as `{ v, chain }`. When `io` exposes `of()`,
+ * the middleware is attached to `io.of('/{namespace}')` and `undefined` is
+ * returned; otherwise the middleware function is returned for manual
+ * attachment.
+ *
+ * @param {NetworkSurface} TAO - the Kernel (or bare Network) to bridge
+ * @param {(SocketIoClientFactory|SocketIoServerLike|null)} [io] - client
+ *        factory (browser), server (attach middleware), or `null`/non-server
+ *        to get the middleware back (server)
+ * @param {WireOptions} [opts]
+ * @returns {(SocketLike|SocketIoMiddleware|undefined)}
+ */
 export default function wireTaoJsToSocketIO(TAO, io, opts = {}) {
   const ns = opts.namespace || opts.ns || DEFAULT_NAMESPACE;
   if (!IS_SERVER) {
@@ -119,8 +350,10 @@ export default function wireTaoJsToSocketIO(TAO, io, opts = {}) {
     }
   } else {
     const { onConnect, authTransform } = opts;
-    if (io && typeof io.of === 'function') {
-      const namespacedEngine = io.of(`/${ns}`);
+    if (io && typeof /** @type {SocketIoServerLike} */ (io).of === 'function') {
+      const namespacedEngine = /** @type {SocketIoServerLike} */ (io).of(
+        `/${ns}`,
+      );
       namespacedEngine.use(ioMiddleware(TAO, { onConnect, authTransform }));
     } else {
       return ioMiddleware(TAO, { onConnect, authTransform });

--- a/packages/tao-socket-io/tsconfig.types.json
+++ b/packages/tao-socket-io/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../config/tsconfig.types.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": ["src"]
+}

--- a/packages/tao-telemetry/README.md
+++ b/packages/tao-telemetry/README.md
@@ -45,6 +45,8 @@ Each signal produces one record:
   parentId,  // 16 hex | null — the signal whose handler chained this one
   t, a, o, key,
   timestamp,
+  via,       // 'Intercept' | 'Async' | 'Inline' — the phase that produced
+             // this hop; absent on entry hops (0.20)
   handlers: { intercept, async, inline },  // matching-handler counts
   data,      // only with the captureData option (true | (data, ac) => any)
 }

--- a/packages/tao-telemetry/package.json
+++ b/packages/tao-telemetry/package.json
@@ -10,6 +10,7 @@
   },
   "main": "lib",
   "module": "dist",
+  "types": "lib/index.d.ts",
   "bundles": {
     "browser": "bundles/browser.umd.js"
   },
@@ -25,8 +26,9 @@
   "scripts": {
     "build:clean": "rimraf dist lib bundles",
     "build:package": "rollup --config",
-    "build": "npm run build:clean && npm run build:package",
-    "test:mutation": "stryker run"
+    "build": "npm run build:clean && npm run build:package && npm run build:types",
+    "test:mutation": "stryker run",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "author": "eudaimos",
   "license": "Apache-2.0",

--- a/packages/tao-telemetry/src/ConsoleSink.js
+++ b/packages/tao-telemetry/src/ConsoleSink.js
@@ -1,3 +1,5 @@
+/** @typedef {import('./Tracer').TraceRecord} TraceRecord */
+
 /**
  * Streams signals to a console-like logger as they occur, indented by causal
  * depth — the live-logging successor to `TaoLogger`'s full-wildcard idiom.
@@ -6,6 +8,17 @@
  * @class ConsoleSink
  */
 export default class ConsoleSink {
+  /**
+   * Creates an instance of ConsoleSink.
+   * @param {Object} [opts]
+   * @param {{ info: function }} [opts.logger=console] - console-like target
+   * @param {boolean} [opts.showData=false] - also log each record's captured
+   *        data on a second line
+   * @param {number} [opts.limit=10000] - cap on the signalId → depth map used
+   *        for indentation (FIFO eviction; a child of an evicted parent logs
+   *        at root depth)
+   * @memberof ConsoleSink
+   */
   constructor({ logger = console, showData = false, limit = 10000 } = {}) {
     this._logger = logger;
     this._showData = showData;
@@ -13,6 +26,13 @@ export default class ConsoleSink {
     this._depths = new Map();
   }
 
+  /**
+   * Sink interface: log one signal as it occurs, indented beneath its cause
+   * (with its producing phase when present).
+   *
+   * @param {TraceRecord} record
+   * @memberof ConsoleSink
+   */
   signal(record) {
     const depth =
       record.parentId && this._depths.has(record.parentId)

--- a/packages/tao-telemetry/src/InMemorySink.js
+++ b/packages/tao-telemetry/src/InMemorySink.js
@@ -1,3 +1,22 @@
+/** @typedef {import('./Tracer').TraceRecord} TraceRecord */
+
+/**
+ * A node of the reassembled causal tree returned by
+ * {@link InMemorySink#toTree}.
+ *
+ * @typedef {Object} TraceTreeNode
+ * @property {TraceRecord} record
+ * @property {TraceTreeNode[]} children
+ */
+
+/**
+ * Render one record as a tree-node label: the trigram, its producing phase
+ * when present, and (optionally) its captured data.
+ *
+ * @param {TraceRecord} record
+ * @param {boolean} showData
+ * @returns {string}
+ */
 function nodeLabel(record, showData) {
   let label = `☯ {${record.t}, ${record.a}, ${record.o}}`;
   if (record.via) {
@@ -22,11 +41,26 @@ function nodeLabel(record, showData) {
  * @class InMemorySink
  */
 export default class InMemorySink {
+  /**
+   * Creates an instance of InMemorySink.
+   * @param {Object} [opts]
+   * @param {number} [opts.limit=10000] - ring-buffer capacity: at capacity
+   *        the oldest record is evicted, and its orphaned children surface
+   *        as roots
+   * @memberof InMemorySink
+   */
   constructor({ limit = 10000 } = {}) {
     this._limit = limit;
     this.clear();
   }
 
+  /**
+   * Sink interface: retain one dispatched signal and index it by id and by
+   * parent.
+   *
+   * @param {TraceRecord} record
+   * @memberof InMemorySink
+   */
   signal(record) {
     if (this._records.length >= this._limit) {
       this._evictOldest();
@@ -41,18 +75,47 @@ export default class InMemorySink {
     }
   }
 
+  /**
+   * All retained records in arrival order (a fresh copy).
+   *
+   * @type {TraceRecord[]}
+   * @readonly
+   * @memberof InMemorySink
+   */
   get records() {
     return [...this._records];
   }
 
+  /**
+   * Number of records currently retained.
+   *
+   * @type {number}
+   * @readonly
+   * @memberof InMemorySink
+   */
   get size() {
     return this._records.length;
   }
 
+  /**
+   * Look up a retained record by its signal id.
+   *
+   * @param {string} signalId
+   * @returns {TraceRecord|undefined} undefined when never seen or evicted
+   * @memberof InMemorySink
+   */
   byId(signalId) {
     return this._byId.get(signalId);
   }
 
+  /**
+   * Records chained by the given signal's handlers, in arrival order
+   * (a fresh copy).
+   *
+   * @param {string} signalId
+   * @returns {TraceRecord[]}
+   * @memberof InMemorySink
+   */
   childrenOf(signalId) {
     return [...(this._children.get(signalId) || [])];
   }
@@ -60,6 +123,9 @@ export default class InMemorySink {
   /**
    * Local roots: records with no parent, or whose parent was never seen
    * locally (remote continuation) or has been evicted.
+   *
+   * @returns {TraceRecord[]}
+   * @memberof InMemorySink
    */
   roots() {
     return this._records.filter(
@@ -67,6 +133,12 @@ export default class InMemorySink {
     );
   }
 
+  /**
+   * Reassemble the retained records into causal trees, one per local root.
+   *
+   * @returns {TraceTreeNode[]}
+   * @memberof InMemorySink
+   */
   toTree() {
     const toNode = (record) => ({
       record,
@@ -75,6 +147,15 @@ export default class InMemorySink {
     return this.roots().map(toNode);
   }
 
+  /**
+   * Render the causal trees as an ASCII tree, one line per signal.
+   *
+   * @param {Object} [opts]
+   * @param {boolean} [opts.showData=false] - append each record's captured
+   *        data to its label
+   * @returns {string}
+   * @memberof InMemorySink
+   */
   format({ showData = false } = {}) {
     const lines = [];
     const walk = (node, prefix, childPrefix) => {
@@ -94,12 +175,21 @@ export default class InMemorySink {
     return lines.join('\n');
   }
 
+  /**
+   * Drop every retained record and index.
+   *
+   * @memberof InMemorySink
+   */
   clear() {
     this._records = [];
     this._byId = new Map();
     this._children = new Map();
   }
 
+  /**
+   * Evict the oldest record (ring-buffer overflow), unindexing it from its
+   * parent's children and releasing its own child index.
+   */
   _evictOldest() {
     const evicted = this._records.shift();
     this._byId.delete(evicted.signalId);

--- a/packages/tao-telemetry/src/TaoLogger.js
+++ b/packages/tao-telemetry/src/TaoLogger.js
@@ -1,3 +1,44 @@
+/**
+ * Runtime control surface returned by {@link TaoLogger}. Every option is
+ * live-switchable after construction.
+ *
+ * @typedef {Object} TaoLoggerControls
+ * @property {function(Object, Object): void} handler - the signal handler to
+ *           attach (full-wildcard intercept idiom); receives `(tao, data)`
+ *           and always returns undefined — pure observation, never halts
+ * @property {function(boolean): void} doLogging - toggle logging entirely
+ * @property {function(boolean): void} verbose - toggle datagram logging
+ * @property {function(?number): void} depth - set the inspection depth
+ * @property {function(boolean): void} group - toggle grouped output
+ * @property {function(Object): void} setLogger - swap the console-like target
+ * @property {function(?function(*, number): *): void} setInspect - swap the
+ *           object formatter
+ */
+
+/**
+ * The classic live signal logger (moved here from `@tao.js/utils`): logs
+ * each signal's trigram — and, when verbose or grouped, the t/a/o portions
+ * of its datagram — as it dispatches. Attach the returned `handler` as a
+ * full-wildcard intercept: `TAO.addInterceptHandler({}, logger.handler)`.
+ *
+ * Shows the sequence of signals; the `Tracer` shows their causality.
+ *
+ * @export
+ * @param {boolean} [doLogging=true] - master switch; the handler is a no-op
+ *        when false
+ * @param {Object} [opts]
+ * @param {boolean} [opts.verbose=false] - also log the datagram portions
+ *        (grouped output always does)
+ * @param {?number} [opts.depth=0] - depth handed to `inspect`; when unset the
+ *        datagram portions are logged raw
+ * @param {boolean} [opts.group=false] - wrap each signal in
+ *        `logger.groupCollapsed` / `logger.groupEnd`
+ * @param {{ info: function, groupCollapsed?: function, groupEnd?: function }} [opts.logger=console] -
+ *        console-like target
+ * @param {?function(*, number): *} [opts.inspect] - object formatter (e.g.
+ *        `util.inspect`) applied to each datagram portion at `depth`
+ * @returns {TaoLoggerControls}
+ */
 export function TaoLogger(
   doLogging = true,
   {

--- a/packages/tao-telemetry/src/Tracer.js
+++ b/packages/tao-telemetry/src/Tracer.js
@@ -2,11 +2,49 @@ import { AppCtx } from '@tao.js/core';
 import { newTraceId, newSignalId, parseTraceparent } from './ids';
 
 /**
+ * One traced signal, as delivered to every sink's `signal(record)`.
+ *
+ * A record describes a network dispatch, not a handler execution — a
+ * channel's mirrored dispatch of the same AppCon on its private registry is
+ * not a second record.
+ *
+ * @typedef {Object} TraceRecord
+ * @property {string} traceId - 32 lowercase hex chars (W3C trace id), shared
+ *           by every signal in the causal tree
+ * @property {string} signalId - 16 lowercase hex chars (W3C span id) naming
+ *           this signal
+ * @property {string|null} parentId - `signalId` of the signal whose handler
+ *           chained this one; null for a trace root
+ * @property {string} t - term of the signal's trigram
+ * @property {string} a - action of the signal's trigram
+ * @property {string} o - orient of the signal's trigram
+ * @property {string} key - the trigram's AppCtx key (`t|a|o`)
+ * @property {number} timestamp - ms-epoch time from the tracer's clock
+ * @property {'Intercept'|'Async'|'Inline'} [via] - handler phase that chained
+ *           this signal (ENVELOPE-SPEC.md §4); entry hops carry no `via`
+ * @property {{ intercept: number, async: number, inline: number }} [handlers] -
+ *           counts of handlers matching this trigram (wildcard registrations
+ *           included) on the decorated network at dispatch time; handlers
+ *           attached to Channels' private registries are not counted
+ * @property {*} [data] - the AppCon data, only with the `captureData` option
+ */
+
+/**
  * Namespaced chain key under which trace context is derived per hop by the
- * envelope engine (see ENVELOPE-SPEC.md).
+ * envelope engine (see ENVELOPE-SPEC.md). Chain keys are exclusive — a
+ * Network accepts one reducer per key — so constructing a second Tracer on
+ * the same network throws. This is also the key transports carry across
+ * process boundaries (§9): an inbound W3C `traceparent` maps to
+ * `chain: { [TRACE_CHAIN]: { traceId, signalId } }` on entry.
  */
 export const TRACE_CHAIN = 'taoTrace';
 
+/**
+ * Count a handler iterator without materializing it.
+ *
+ * @param {Iterable<function>} iterator
+ * @returns {number}
+ */
 function countHandlers(iterator) {
   let count = 0;
   for (const handler of iterator) {
@@ -30,13 +68,21 @@ function countHandlers(iterator) {
 export default class Tracer {
   /**
    * Creates an instance of Tracer.
-   * @param {Kernel|Network} kernel - Kernel (or raw Network) whose signals to trace
+   * @param {Object} kernel - Kernel (or Channel, or raw Network) whose signals
+   *        to trace; anything exposing the shared network via `_network`, or a
+   *        Network itself, is decorated
    * @param {Object} [opts]
-   * @param {Array<{signal: function}>} [opts.sinks] - sinks receiving one record per signal
-   * @param {function} [opts.clock] - returns a ms-epoch timestamp (defaults to Date.now)
-   * @param {boolean|function} [opts.captureData] - false (default) omits AppCon data;
-   *        true attaches `ac.data` by reference; a function receives `(data, ac)` and
-   *        its return value is attached (use to redact / clone)
+   * @param {Array<{signal: function(TraceRecord): void}>} [opts.sinks] - sinks
+   *        receiving one record per signal
+   * @param {function(): number} [opts.clock] - returns a ms-epoch timestamp
+   *        (defaults to Date.now)
+   * @param {boolean|function(*, AppCtx): *} [opts.captureData] - false (default)
+   *        omits AppCon data; true attaches `ac.data` by reference; a function
+   *        receives `(data, ac)` and its return value is attached (use to
+   *        redact / clone)
+   * @throws when `kernel` is absent, when the core predates envelope support,
+   *         or when the network's {@link TRACE_CHAIN} chain key is already
+   *         reduced by another decoration (one Tracer per network)
    * @memberof Tracer
    */
   // Stryker disable next-line ArrayDeclaration: junk entries in the sinks default are call-guarded by the per-sink try
@@ -77,6 +123,13 @@ export default class Tracer {
     });
   }
 
+  /**
+   * Attach a sink to receive one {@link TraceRecord} per signal.
+   *
+   * @param {{ signal: function(TraceRecord): void }} sink
+   * @returns {this}
+   * @memberof Tracer
+   */
   addSink(sink) {
     if (!sink || typeof sink.signal !== 'function') {
       throw new Error('a sink must implement signal(record)');
@@ -85,6 +138,13 @@ export default class Tracer {
     return this;
   }
 
+  /**
+   * Detach a previously attached sink (a no-op when not attached).
+   *
+   * @param {{ signal: function(TraceRecord): void }} sink
+   * @returns {this}
+   * @memberof Tracer
+   */
   removeSink(sink) {
     this._sinks.delete(sink);
     return this;
@@ -97,10 +157,15 @@ export default class Tracer {
    * Plain `kernel.setCtx` entries are traced identically — this entry point
    * only adds the continuation capability.
    *
-   * @param {Object} trigram - `{ t, a, o }` or `{ term, action, orient }`
-   * @param {Object} [data]
-   * @param {Object} [traceContext] - `{ traceparent }` (W3C header value) or
-   *        `{ traceId, parentId }` to continue a trace started elsewhere
+   * @param {{ t?: string, a?: string, o?: string, term?: string, action?: string, orient?: string }} trigram -
+   *        `{ t, a, o }` or `{ term, action, orient }` (long forms win when
+   *        both are present)
+   * @param {*} [data]
+   * @param {{ traceparent?: string, traceId?: string, parentId?: string|null }} [traceContext] -
+   *        `{ traceparent }` (W3C header value) or `{ traceId, parentId }` to
+   *        continue a trace started elsewhere: the entry keeps the remote
+   *        `traceId` and is parented to `parentId`. An absent or malformed
+   *        context starts a new root trace instead
    * @memberof Tracer
    */
   setCtx({ t, term, a, action, o, orient }, data, traceContext) {
@@ -113,8 +178,15 @@ export default class Tracer {
   /**
    * Set an AppCtx on the network, optionally continuing a remote trace.
    *
-   * @param {AppCtx} ac
-   * @param {Object} [traceContext]
+   * A continuation seeds the entry's chain with
+   * `{ [TRACE_CHAIN]: { traceId, signalId: parentId } }`, which the chain
+   * reducer treats exactly like a parent hop's stamp — the remote signal
+   * becomes the entry's parent.
+   *
+   * @param {AppCtx} ac - dropped silently when wildcard and the attached
+   *        kernel disallows wildcard entry (parity with `Kernel.setAppCtx`)
+   * @param {{ traceparent?: string, traceId?: string, parentId?: string|null }} [traceContext] -
+   *        see {@link Tracer#setCtx}
    * @memberof Tracer
    */
   setAppCtx(ac, traceContext) {
@@ -137,6 +209,14 @@ export default class Tracer {
     );
   }
 
+  /**
+   * Normalize a continuation context to `{ traceId, parentId }`, preferring
+   * a W3C `traceparent` header when given. Returns null (start a new root)
+   * when absent or malformed.
+   *
+   * @param {{ traceparent?: string, traceId?: string, parentId?: string|null }} [traceContext]
+   * @returns {{ traceId: string, parentId: string|null }|null}
+   */
   _remoteContext(traceContext) {
     if (!traceContext) {
       return null;
@@ -153,6 +233,17 @@ export default class Tracer {
     return null;
   }
 
+  /**
+   * The `onDispatch` observer: assemble one {@link TraceRecord} from the
+   * hop's {@link TRACE_CHAIN} chain stamp and fan it out to every sink.
+   * Handler counts are taken from the matched registry entry at dispatch
+   * time (the decorated main network only); a throwing sink is isolated so
+   * it never breaks signal dispatch.
+   *
+   * @param {AppCtx} ac
+   * @param {{ cascade: Object, hop: Object, chain: Object }} envelope
+   * @param {Object} handler - the matched AppCtxHandlers registry entry
+   */
   _record(ac, envelope, handler) {
     const stamp = envelope.chain[TRACE_CHAIN];
     const record = {

--- a/packages/tao-telemetry/src/Tracer.js
+++ b/packages/tao-telemetry/src/Tracer.js
@@ -246,16 +246,17 @@ export default class Tracer {
    */
   _record(ac, envelope, handler) {
     const stamp = envelope.chain[TRACE_CHAIN];
+    /** @type {TraceRecord} */
     const record = {
       traceId: stamp.traceId,
       signalId: stamp.signalId,
       parentId: stamp.parentId || null,
+      t: ac.t,
+      a: ac.a,
+      o: ac.o,
+      key: ac.key,
+      timestamp: this._clock(),
     };
-    record.t = ac.t;
-    record.a = ac.a;
-    record.o = ac.o;
-    record.key = ac.key;
-    record.timestamp = this._clock();
     if (envelope.hop.via) {
       // the handler phase that produced this hop (ENVELOPE-SPEC.md §4)
       record.via = envelope.hop.via;

--- a/packages/tao-telemetry/src/Tracer.js
+++ b/packages/tao-telemetry/src/Tracer.js
@@ -65,10 +65,22 @@ function countHandlers(iterator) {
  * @export
  * @class Tracer
  */
+
+/**
+ * Any surface a Tracer can attach to: a Kernel-/Channel-shaped wrapper
+ * exposing the shared network via `_network`, or a bare `Network`
+ * (exposing `enter` + `decorate`) decorated directly.
+ *
+ * @typedef {Object} TraceableSurface
+ * @property {Function} [enter] - present on a bare Network
+ * @property {Function} [decorate] - present on a bare Network
+ * @property {import('@tao.js/core').Network} [_network] - present on Kernel-/Channel-shaped wrappers
+ * @property {boolean} [canSetWildcard] - mirrored onto traced wildcard handling when present
+ */
 export default class Tracer {
   /**
    * Creates an instance of Tracer.
-   * @param {Object} kernel - Kernel (or Channel, or raw Network) whose signals
+   * @param {TraceableSurface} kernel - Kernel (or Channel, or raw Network) whose signals
    *        to trace; anything exposing the shared network via `_network`, or a
    *        Network itself, is decorated
    * @param {Object} [opts]

--- a/packages/tao-telemetry/src/ids.js
+++ b/packages/tao-telemetry/src/ids.js
@@ -4,6 +4,14 @@ const TRACE_ID_RX = /^[0-9a-f]{32}$/;
 const SPAN_ID_RX = /^[0-9a-f]{16}$/;
 const VERSION_RX = /^[0-9a-f]{2}$/;
 
+/**
+ * Produce `chars` random lowercase hex characters, cryptographically strong
+ * when the platform provides `crypto.getRandomValues` (Math.random fallback
+ * for exotic embedders).
+ *
+ * @param {number} chars - even count of hex characters to produce
+ * @returns {string}
+ */
 function randomHex(chars) {
   // Stryker disable next-line ConditionalExpression,StringLiteral: equivalent - globalThis always exists in every runnable JS environment we can test; the guard is for exotic embedders
   const cryptoObj = typeof globalThis !== 'undefined' && globalThis.crypto;
@@ -24,7 +32,10 @@ function randomHex(chars) {
 }
 
 /**
- * Generate a new W3C-compatible trace id (32 lowercase hex chars, non-zero).
+ * Generate a new W3C-compatible trace id (32 lowercase hex chars; the
+ * all-zero id is invalid per Trace Context and is never produced).
+ *
+ * @returns {string}
  */
 export function newTraceId() {
   let id;
@@ -35,7 +46,10 @@ export function newTraceId() {
 }
 
 /**
- * Generate a new W3C-compatible span/signal id (16 lowercase hex chars, non-zero).
+ * Generate a new W3C-compatible span/signal id (16 lowercase hex chars; the
+ * all-zero id is invalid per Trace Context and is never produced).
+ *
+ * @returns {string}
  */
 export function newSignalId() {
   let id;
@@ -46,9 +60,11 @@ export function newSignalId() {
 }
 
 /**
- * Format a signal stamp or record as a W3C `traceparent` header value.
+ * Format a signal stamp or record as a W3C `traceparent` header value:
+ * `00-<traceId>-<signalId>-01` (version `00`, flags `01` = sampled).
  *
- * @param {{ traceId: string, signalId: string }} stamp
+ * @param {{ traceId: string, signalId: string }} stamp - a chain stamp or a
+ *        `TraceRecord` (structurally compatible)
  * @returns {string} e.g. `00-<32 hex>-<16 hex>-01`
  */
 export function toTraceparent({ traceId, signalId }) {
@@ -57,6 +73,12 @@ export function toTraceparent({ traceId, signalId }) {
 
 /**
  * Parse a W3C `traceparent` header value into trace continuation context.
+ *
+ * Tolerant per the Trace Context spec: case and surrounding whitespace are
+ * normalized, and future versions with extra dash-separated fields are
+ * accepted (at least 4 parts; extras ignored). Rejected as malformed: a
+ * non-hex or forbidden (`ff`) version, and non-hex, wrong-length, or
+ * all-zero trace/parent ids.
  *
  * @param {string} header
  * @returns {{ traceId: string, parentId: string } | null} null when malformed

--- a/packages/tao-telemetry/src/index.js
+++ b/packages/tao-telemetry/src/index.js
@@ -9,6 +9,9 @@ import {
   parseTraceparent,
 } from './ids';
 
+/** @typedef {import('./Tracer').TraceRecord} TraceRecord */
+/** @typedef {import('./InMemorySink').TraceTreeNode} TraceTreeNode */
+
 export default Tracer;
 export {
   Tracer,

--- a/packages/tao-telemetry/tsconfig.types.json
+++ b/packages/tao-telemetry/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../config/tsconfig.types.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": ["src"]
+}

--- a/packages/tao-transport-tck/package.json
+++ b/packages/tao-transport-tck/package.json
@@ -36,13 +36,12 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@tao.js/core": ">=0.20.0"
-  },
-  "dependencies": {
-    "@tao.js/telemetry": "file:../tao-telemetry"
+    "@tao.js/core": ">=0.20.0",
+    "@tao.js/telemetry": ">=0.20.0"
   },
   "devDependencies": {
     "@tao.js/core": "file:../tao",
+    "@tao.js/telemetry": "file:../tao-telemetry",
     "@tao.js/utils": "file:../tao-utils"
   }
 }

--- a/packages/tao-transport-tck/package.json
+++ b/packages/tao-transport-tck/package.json
@@ -10,6 +10,7 @@
   },
   "main": "lib",
   "module": "dist",
+  "types": "lib/index.d.ts",
   "bundles": {
     "browser": "bundles/browser.umd.js"
   },
@@ -25,8 +26,9 @@
   "scripts": {
     "build:clean": "rimraf dist lib bundles",
     "build:package": "rollup --config",
-    "build": "npm run build:clean && npm run build:package",
-    "test:mutation": "stryker run"
+    "build": "npm run build:clean && npm run build:package && npm run build:types",
+    "test:mutation": "stryker run",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "author": "eudaimos",
   "license": "Apache-2.0",

--- a/packages/tao-transport-tck/rollup.config.js
+++ b/packages/tao-transport-tck/rollup.config.js
@@ -19,9 +19,10 @@ export default [
       exports: 'named',
       globals: {
         '@tao.js/core': 'tao',
+        '@tao.js/telemetry': 'tao.telemetry',
       },
     },
-    external: ['@tao.js/core'],
+    external: ['@tao.js/core', '@tao.js/telemetry'],
     plugins: [
       external(),
       babel({

--- a/packages/tao-transport-tck/src/compliance.js
+++ b/packages/tao-transport-tck/src/compliance.js
@@ -1,6 +1,29 @@
 import { AppCtx } from '@tao.js/core';
 import { Tracer, InMemorySink } from '@tao.js/telemetry';
 
+/**
+ * A connected pair of Kernels bridged by the transport under test —
+ * what the `makeLink` factory must produce (a fresh one per check).
+ *
+ * @typedef {Object} Link
+ * @property {Object} a - Kernel on the near side; each check enters signals here
+ * @property {Object} b - Kernel on the far side; entries on `a` must reach it
+ * @property {function(): (void|Promise<void>)} [close] - tear the link down;
+ *           awaited after the check when provided
+ */
+
+/**
+ * Outcome of a single conformance check.
+ *
+ * @typedef {Object} ComplianceResult
+ * @property {string} name - the check's name, stable across releases
+ *           ('delivery', 'echo suppression + bidirectional reflex',
+ *           'multi-hop emission', 'chain continuity', 'cascade scoping')
+ * @property {boolean} pass
+ * @property {string|null} detail - failure explanation (including a thrown
+ *           check's message); null on pass
+ */
+
 const DEFAULT_TIMEOUT = 2000;
 const SETTLE_MS = 25;
 
@@ -8,6 +31,13 @@ function wait(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/**
+ * Poll the predicate every 10ms until truthy or the timeout elapses.
+ *
+ * @param {function(): boolean} predicate
+ * @param {number} timeoutMs
+ * @returns {Promise<boolean>} the predicate's final verdict
+ */
 async function waitUntil(predicate, timeoutMs) {
   const deadline = Date.now() + timeoutMs;
   // Stryker disable next-line EqualityOperator: off-by-one on the deadline only shifts the final poll by one interval
@@ -20,6 +50,14 @@ async function waitUntil(predicate, timeoutMs) {
   return predicate();
 }
 
+/**
+ * Like {@link waitUntil}, followed by a settle window so exactly-once
+ * assertions can catch late duplicate deliveries.
+ *
+ * @param {function(): boolean} predicate
+ * @param {number} timeoutMs
+ * @returns {Promise<boolean>}
+ */
 async function settled(predicate, timeoutMs) {
   // reach the condition, then give late (incorrect) deliveries time to land
   const reached = await waitUntil(predicate, timeoutMs);
@@ -27,10 +65,23 @@ async function settled(predicate, timeoutMs) {
   return reached;
 }
 
+/**
+ * Build a probe trigram in the kit's reserved `{ *, run, tck }` namespace.
+ *
+ * @param {string} t
+ * @returns {{ t: string, a: string, o: string }}
+ */
 function trigram(t) {
   return { t, a: 'run', o: 'tck' };
 }
 
+/**
+ * Resolve a link side to its envelope surface (`enter`/`decorate`): the
+ * Kernel's shared network, or the object itself when it already is one.
+ *
+ * @param {Object} kernel
+ * @returns {Object} the underlying Network
+ */
 function surfaceOf(kernel) {
   // Stryker disable next-line all: defensive resolution - the makeLink contract supplies Kernels (no enter), so only the _network branch is reachable
   return typeof kernel.enter === 'function' ? kernel : kernel._network;
@@ -38,7 +89,13 @@ function surfaceOf(kernel) {
 
 /**
  * Delivery: a signal entered on A reaches handlers on B with its trigram and
- * datagram intact.
+ * datagram intact, exactly once. The executable form of the §9 wire envelope
+ * itself — `{ tao: { t, a, o }, data, envelope }` crossing the boundary with
+ * trigram and datagram verbatim, delivered once per hop.
+ *
+ * @param {Link} link
+ * @param {number} timeoutMs
+ * @returns {Promise<string|null>} failure detail, or null on pass
  */
 async function checkDelivery({ a, b }, timeoutMs) {
   const seen = [];
@@ -70,6 +127,14 @@ async function checkDelivery({ a, b }, timeoutMs) {
 /**
  * Echo suppression + bidirectional reflex: the arriving signal is not sent
  * back to its origin, but descendants chained on the receiving side are.
+ * Verifies §10 invariant 4 — descendants of a received signal must be
+ * re-emitted to the sender, because the receiver's `hop.source` marker is
+ * hop-scoped (suppressing only the stamped arrival hop), never
+ * cascade-scoped.
+ *
+ * @param {Link} link
+ * @param {number} timeoutMs
+ * @returns {Promise<string|null>} failure detail, or null on pass
  */
 async function checkReflex({ a, b }, timeoutMs) {
   let aPingDispatches = 0;
@@ -103,7 +168,14 @@ async function checkReflex({ a, b }, timeoutMs) {
 
 /**
  * Multi-hop emission: every hop of a chain produced on the receiving side
- * crosses back, not just the first.
+ * crosses back, not just the first. Verifies §10 invariant 1 — every chained
+ * AppCon is observable on every hop, so the transport's emit path sees (and
+ * forwards) chained signals; losing later hops breaks forwarding of
+ * multi-hop chains.
+ *
+ * @param {Link} link
+ * @param {number} timeoutMs
+ * @returns {Promise<string|null>} failure detail, or null on pass
  */
 async function checkMultiHop({ a, b }, timeoutMs) {
   const arrivals = [];
@@ -140,6 +212,14 @@ async function checkMultiHop({ a, b }, timeoutMs) {
 /**
  * Chain continuity: with a Tracer on both ends, one cascade crossing
  * A→B→A carries one traceId end-to-end with exact cross-process parentage.
+ * Verifies the §9 chain rules — `envelope.chain` crosses the boundary
+ * verbatim and the receiver re-enters with it, so a reducer continues the
+ * `taoTrace` key it owns instead of re-rooting: B's entry parents to A's
+ * emitting hop, and A's continuation parents to B's reply hop.
+ *
+ * @param {Link} link
+ * @param {number} timeoutMs
+ * @returns {Promise<string|null>} failure detail, or null on pass
  */
 async function checkChainContinuity({ a, b }, timeoutMs) {
   const sinkA = new InMemorySink();
@@ -199,7 +279,14 @@ async function checkChainContinuity({ a, b }, timeoutMs) {
 
 /**
  * Cascade scoping: sender-side cascade tags (process-local affinity, live
- * references) must not appear in the receiver's cascade.
+ * references) must not appear in the receiver's cascade. Verifies the §9
+ * rule that `cascade` never crosses a process boundary — the transport must
+ * *translate* affinity, not copy it — which is what keeps the §10 scoping
+ * invariants (2, 3, 7) intact across processes.
+ *
+ * @param {Link} link
+ * @param {number} timeoutMs
+ * @returns {Promise<string|null>} failure detail, or null on pass
  */
 async function checkCascadeScoping({ a, b }, timeoutMs) {
   const cascades = [];
@@ -254,16 +341,18 @@ const CHECKS = [
 ];
 
 /**
- * Run the transport conformance kit (ENVELOPE-SPEC.md §9) against a
- * transport. Framework-agnostic: returns structured results for any test
- * runner.
+ * Run the transport conformance kit (ENVELOPE-SPEC.md §9 plus the
+ * transport-relevant §10 invariants) against a transport. Framework-agnostic:
+ * returns structured results for any test runner instead of throwing.
  *
- * @param {function} makeLink - async factory producing a connected pair
- *        `{ a, b, close }` of Kernels bridged by the transport under test
- *        (loopback in-process is fine). A fresh link is created per check.
+ * @param {function(): (Link|Promise<Link>)} makeLink - factory producing a
+ *        connected pair `{ a, b, close }` of Kernels bridged by the
+ *        transport under test (loopback in-process is fine). A fresh link is
+ *        created per check and closed after it.
  * @param {Object} [opts]
  * @param {number} [opts.timeoutMs=2000] - per-check delivery timeout
- * @returns {Promise<{ pass: boolean, results: Array<{name, pass, detail}> }>}
+ * @returns {Promise<{ pass: boolean, results: ComplianceResult[] }>} one
+ *          result per check, in the order run; `pass` is the conjunction
  */
 export async function runTransportCompliance(
   makeLink,
@@ -295,6 +384,12 @@ export async function runTransportCompliance(
 /**
  * Convenience for test suites: runs the kit and throws a formatted error
  * naming every failed check.
+ *
+ * @param {function(): (Link|Promise<Link>)} makeLink - see {@link runTransportCompliance}
+ * @param {Object} [opts]
+ * @param {number} [opts.timeoutMs=2000] - per-check delivery timeout
+ * @returns {Promise<ComplianceResult[]>} every check's result (all passing)
+ * @throws {Error} listing each failed check with its detail
  */
 export async function assertTransportCompliance(makeLink, opts) {
   const { pass, results } = await runTransportCompliance(makeLink, opts);

--- a/packages/tao-transport-tck/src/compliance.js
+++ b/packages/tao-transport-tck/src/compliance.js
@@ -332,6 +332,7 @@ async function checkCascadeScoping({ a, b }, timeoutMs) {
   return detail;
 }
 
+/** @type {Array<[string, function(Link, number): Promise<?string>]>} */
 const CHECKS = [
   ['delivery', checkDelivery],
   ['echo suppression + bidirectional reflex', checkReflex],

--- a/packages/tao-transport-tck/src/index.js
+++ b/packages/tao-transport-tck/src/index.js
@@ -1,3 +1,6 @@
+/** @typedef {import('./compliance').Link} Link */
+/** @typedef {import('./compliance').ComplianceResult} ComplianceResult */
+
 export {
   runTransportCompliance,
   assertTransportCompliance,

--- a/packages/tao-transport-tck/tsconfig.types.json
+++ b/packages/tao-transport-tck/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../config/tsconfig.types.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": ["src"]
+}

--- a/packages/tao-utils/package.json
+++ b/packages/tao-utils/package.json
@@ -10,6 +10,7 @@
   },
   "main": "lib",
   "module": "dist",
+  "types": "lib/index.d.ts",
   "bundles": {
     "browser": "bundles/browser.umd.js"
   },
@@ -25,8 +26,9 @@
   "scripts": {
     "build:clean": "rimraf dist lib bundles",
     "build:package": "rollup --config",
-    "build": "npm run build:clean && npm run build:package",
-    "test:mutation": "stryker run"
+    "build": "npm run build:clean && npm run build:package && npm run build:types",
+    "test:mutation": "stryker run",
+    "build:types": "tsc -p tsconfig.types.json"
   },
   "author": "eudaimos",
   "license": "Apache-2.0",

--- a/packages/tao-utils/src/Channel.js
+++ b/packages/tao-utils/src/Channel.js
@@ -15,6 +15,29 @@ function channelControl(channelId) {
 }
 
 /**
+ * A trigram matcher in short (`t`/`a`/`o`) or long (`term`/`action`/`orient`)
+ * keys; omitted parts are wildcards.
+ *
+ * @typedef {Object} Trigram
+ * @property {string} [t] - term (short key)
+ * @property {string} [term] - term (long key)
+ * @property {string} [a] - action (short key)
+ * @property {string} [action] - action (long key)
+ * @property {string} [o] - orient (short key)
+ * @property {string} [orient] - orient (long key)
+ */
+
+/**
+ * A TAO signal handler: called with the concrete trigram handled and the
+ * signal's datagram(s); returning an `AppCtx` chains it (see `@tao.js/core`).
+ *
+ * @callback SignalHandler
+ * @param {Object} tao - the concrete `{ t, a, o }` trigram handled
+ * @param {*} data - the signal's datagram(s)
+ * @returns {(AppCtx|*)}
+ */
+
+/**
  * Filters handling of AppCons to the set of attached handlers of the Channel for only those
  * AppCons that had a preceding AppCon originate from this Channel.
  *
@@ -25,16 +48,30 @@ function channelControl(channelId) {
  * channel-attached handlers continue the cascade envelope through the main
  * network's hop engine (they do not re-enter with a fresh envelope).
  *
+ * Decoration: `onForward` on the shared network, self-filtered on
+ * `envelope.cascade.channelId`. The channel tag rides the cascade scope —
+ * one shared reference for the whole cascade — so every descendant hop of a
+ * channel entry is mirrored, wherever the chain goes.
+ *
  * @export
  * @class Channel
  */
 export default class Channel {
   /**
    *Creates an instance of Channel.
-   * @param {Kernel} kernel - an instance of a Kernel or other TAO Network on which to build a Channel by sharing the same underlying Network
-   * @param {(string|function)} [id] - pass either a desired Channel ID value as a `string` or a `function` that will be used to generate a Channel ID
+   *
+   * Surface resolution follows the utils convention
+   * (`typeof kernel.enter === 'function' ? kernel : kernel._network`): pass
+   * anything exposing the envelope gate directly (a `Network`), or a
+   * Kernel-shaped wrapper exposing `_network`. The resolved network must
+   * support `enter` and `decorate`.
+   *
+   * @param {(Kernel|Network)} kernel - an instance of a Kernel or other TAO Network on which to build a Channel by sharing the same underlying Network
+   * @param {(string|function(number): (string|number))} [id] - pass either a desired Channel ID value as a `string` or a `function` that will be used to generate a Channel ID
    *        the `function` will be called with a new Channel ID integer value to help ensure uniqueness
    * @param {boolean} [debug=false] - pass true to console.log internal activity
+   * @throws {Error} when the resolved network lacks envelope support
+   *         (`enter` + `decorate`) - upgrade `@tao.js/core`
    * @memberof Channel
    */
   constructor(kernel, id, debug = false) {
@@ -66,10 +103,15 @@ export default class Channel {
   /**
    * Clones a Channel
    *
-   * @param {(string|function)} [cloneId] - used as the cloned `Channel`'s ID,
+   * The clone shares the same underlying network, copies the private
+   * network's handler registrations, and registers its own decoration under
+   * its own Channel ID.
+   *
+   * @param {(string|function(number): (string|number))} [cloneId] - used as the cloned `Channel`'s ID,
    *          same as the `id` param to the `Channel` constructor, either an
-   *          explicit value as a `string` or a `function` used to generate the Channel ID
-   * @returns
+   *          explicit value as a `string` or a `function` used to generate the Channel ID;
+   *          falls back to the constructor's `id` generator when one was given
+   * @returns {Channel} the cloned Channel
    * @memberof Channel
    */
   clone(cloneId) {
@@ -85,6 +127,7 @@ export default class Channel {
    * Detach this Channel's decoration from the shared network. Channel
    * handlers stop receiving mirrored AppCons; entries still dispatch.
    *
+   * @returns {void}
    * @memberof Channel
    */
   dispose() {
@@ -99,6 +142,12 @@ export default class Channel {
    *
    * @param {AppCtx} ac
    * @param {Object} [opts] - `{ cascade, hop, chain }` as `Network.enter`
+   * @param {Object} [opts.cascade] - caller cascade keys; the channel tag
+   *        wins key conflicts
+   * @param {Object} [opts.hop] - entry-hop values (e.g. a transport's
+   *        `source` marker)
+   * @param {(Object|null)} [opts.chain] - prior chain state to continue
+   * @returns {void}
    * @memberof Channel
    */
   enter(ac, { cascade = {}, hop = {}, chain = null } = {}) {
@@ -109,10 +158,26 @@ export default class Channel {
     });
   }
 
+  /**
+   * Builds an AppCtx from a trigram + datagram (long-form keys win) and
+   * enters it with this Channel's cascade scoping.
+   *
+   * @param {Trigram} trigram
+   * @param {*} data - datagram(s) for the signal
+   * @returns {void}
+   * @memberof Channel
+   */
   setCtx({ t, term, a, action, o, orient }, data) {
     this.enter(new AppCtx(term || t, action || a, orient || o, data));
   }
 
+  /**
+   * Enters an existing AppCtx with this Channel's cascade scoping.
+   *
+   * @param {AppCtx} ac
+   * @returns {void}
+   * @memberof Channel
+   */
   setAppCtx(ac) {
     this.enter(ac);
   }
@@ -122,7 +187,9 @@ export default class Channel {
    * AppCons mirrored to this Channel (used by wrapping adapters like
    * Transponder). Same contract as `Network.decorate`.
    *
-   * @returns {function} dispose - removes the decoration
+   * @param {Object} spec - decoration spec as `Network.decorate` accepts
+   *        (`{ name, onDispatch, onForward, onReturn, onProceed, chain }`)
+   * @returns {function(): void} dispose - removes the decoration
    * @memberof Channel
    */
   decorate(spec) {
@@ -146,6 +213,15 @@ export default class Channel {
     }
   }
 
+  /**
+   * Attaches an InterceptHandler to this Channel's private network — runs
+   * for matching AppCons mirrored to this Channel.
+   *
+   * @param {Trigram} trigram
+   * @param {SignalHandler} handler
+   * @returns {Channel} this
+   * @memberof Channel
+   */
   addInterceptHandler({ t, term, a, action, o, orient }, handler) {
     this._channel.addInterceptHandler(
       { t, term, a, action, o, orient },
@@ -154,16 +230,42 @@ export default class Channel {
     return this;
   }
 
+  /**
+   * Attaches an AsyncHandler to this Channel's private network — runs for
+   * matching AppCons mirrored to this Channel.
+   *
+   * @param {Trigram} trigram
+   * @param {SignalHandler} handler
+   * @returns {Channel} this
+   * @memberof Channel
+   */
   addAsyncHandler({ t, term, a, action, o, orient }, handler) {
     this._channel.addAsyncHandler({ t, term, a, action, o, orient }, handler);
     return this;
   }
 
+  /**
+   * Attaches an InlineHandler to this Channel's private network — runs for
+   * matching AppCons mirrored to this Channel.
+   *
+   * @param {Trigram} trigram
+   * @param {SignalHandler} handler
+   * @returns {Channel} this
+   * @memberof Channel
+   */
   addInlineHandler({ t, term, a, action, o, orient }, handler) {
     this._channel.addInlineHandler({ t, term, a, action, o, orient }, handler);
     return this;
   }
 
+  /**
+   * Removes an InterceptHandler previously attached for the same trigram.
+   *
+   * @param {Trigram} trigram
+   * @param {SignalHandler} handler
+   * @returns {Channel} this
+   * @memberof Channel
+   */
   removeInterceptHandler({ t, term, a, action, o, orient }, handler) {
     this._channel.removeInterceptHandler(
       { t, term, a, action, o, orient },
@@ -172,6 +274,14 @@ export default class Channel {
     return this;
   }
 
+  /**
+   * Removes an AsyncHandler previously attached for the same trigram.
+   *
+   * @param {Trigram} trigram
+   * @param {SignalHandler} handler
+   * @returns {Channel} this
+   * @memberof Channel
+   */
   removeAsyncHandler({ t, term, a, action, o, orient }, handler) {
     this._channel.removeAsyncHandler(
       { t, term, a, action, o, orient },
@@ -180,6 +290,14 @@ export default class Channel {
     return this;
   }
 
+  /**
+   * Removes an InlineHandler previously attached for the same trigram.
+   *
+   * @param {Trigram} trigram
+   * @param {SignalHandler} handler
+   * @returns {Channel} this
+   * @memberof Channel
+   */
   removeInlineHandler({ t, term, a, action, o, orient }, handler) {
     this._channel.removeInlineHandler(
       { t, term, a, action, o, orient },
@@ -188,6 +306,18 @@ export default class Channel {
     return this;
   }
 
+  /**
+   * Bridges matching AppCons flowing on another Kernel's network into this
+   * Channel (via `seive`), excluding cascades that already originated from
+   * this Channel (no echo).
+   *
+   * @param {Kernel} TAO - Kernel-shaped wrapper (exposing `_network`) to bridge from
+   * @param {...*} trigrams - optional trigram filters as `trigramFilter`
+   *        accepts (optional leading `exact` boolean, then short-key
+   *        trigrams or a single array of trigrams); none bridges every AppCon
+   * @returns {function(): void} dispose - detaches the bridge
+   * @memberof Channel
+   */
   bridgeFrom(TAO, ...trigrams) {
     return seive(
       this._channelId,

--- a/packages/tao-utils/src/Channel.js
+++ b/packages/tao-utils/src/Channel.js
@@ -1,6 +1,9 @@
 import { AppCtx, Network } from '@tao.js/core';
 import seive from './seive';
 
+/** @typedef {import('@tao.js/core').Kernel} Kernel */
+/** @typedef {import('./wire').NetworkSurface} NetworkSurface */
+
 // for backwards compatibility
 const MAX_SAFE_INTEGER = Math.pow(2, 53) - 1;
 
@@ -66,7 +69,7 @@ export default class Channel {
    * Kernel-shaped wrapper exposing `_network`. The resolved network must
    * support `enter` and `decorate`.
    *
-   * @param {(Kernel|Network)} kernel - an instance of a Kernel or other TAO Network on which to build a Channel by sharing the same underlying Network
+   * @param {NetworkSurface} kernel - an instance of a Kernel or other TAO Network on which to build a Channel by sharing the same underlying Network
    * @param {(string|function(number): (string|number))} [id] - pass either a desired Channel ID value as a `string` or a `function` that will be used to generate a Channel ID
    *        the `function` will be called with a new Channel ID integer value to help ensure uniqueness
    * @param {boolean} [debug=false] - pass true to console.log internal activity
@@ -79,8 +82,9 @@ export default class Channel {
     this._channelId =
       typeof id === 'function' ? id(newChannelId()) : id || newChannelId();
     this._channel = new Network();
-    this._network =
-      typeof kernel.enter === 'function' ? kernel : kernel._network;
+    this._network = /** @type {Network} */ (
+      typeof kernel.enter === 'function' ? kernel : kernel._network
+    );
     if (
       !this._network ||
       typeof this._network.enter !== 'function' ||

--- a/packages/tao-utils/src/Relay.js
+++ b/packages/tao-utils/src/Relay.js
@@ -12,14 +12,52 @@ function sourceControl(source) {
 }
 
 /**
+ * A trigram in short (`t`/`a`/`o`) or long (`term`/`action`/`orient`) keys;
+ * long-form keys win.
+ *
+ * @typedef {Object} Trigram
+ * @property {string} [t] - term (short key)
+ * @property {string} [term] - term (long key)
+ * @property {string} [a] - action (short key)
+ * @property {string} [action] - action (long key)
+ * @property {string} [o] - orient (short key)
+ * @property {string} [orient] - orient (long key)
+ */
+
+/**
  * Like Source, but `fromSrc` is required. Implemented as a Network
  * decoration; the origin marker rides the envelope's hop scope.
- * Unexported / experimental.
+ * Decoration: `onDispatch` (phase-blind emission), self-filtered on
+ * `envelope.hop.source`. Unexported / experimental.
  *
  * @export
  * @class Relay
  */
 export default class Relay {
+  /**
+   * Creates an instance of Relay.
+   *
+   * Note the Relay resolves its network from `kernel._network` only (it
+   * does not apply the utils surface-resolution convention, so a bare
+   * `Network` is not accepted); the resolved network must support `enter`
+   * and `decorate`.
+   *
+   * @param {Kernel} kernel - Kernel-shaped wrapper (exposing `_network`) to attach the Relay to
+   * @param {function(Object, *): void} toSrc - outbound emitter called with
+   *        `(tao, data)` — the unwrapped `{ t, a, o }` trigram and the
+   *        datagram(s) — for every AppCon except those arriving from this Relay
+   * @param {(string|function)} [name] - the Relay's name, used as its
+   *        hop-scope origin marker (auto-generated `FROM<n>` when omitted);
+   *        passing a `function` here is the `fromSrc` overload
+   * @param {function(function(Trigram, *): void): void} fromSrc - binder for
+   *        the inbound side (required): called once with a setter
+   *        `(tao, data)` that enters received signals stamped with this
+   *        Relay's origin marker
+   * @throws {Error} when `kernel` (or its `_network`) is missing, when the
+   *         network lacks envelope support (`enter` + `decorate`) - upgrade
+   *         `@tao.js/core`, or when `toSrc` is missing
+   * @memberof Relay
+   */
   constructor(kernel, toSrc, name, fromSrc) {
     if (!kernel || !kernel._network) {
       throw new Error(
@@ -52,26 +90,67 @@ export default class Relay {
     });
   }
 
+  /**
+   * The Relay's name — the hop-scope origin marker it stamps on entries
+   * and filters emission on.
+   *
+   * @type {string}
+   * @memberof Relay
+   */
   get name() {
     return this._name;
   }
 
+  /**
+   * `onDispatch` decoration callback: emits every dispatched AppCon to the
+   * source except those whose arriving hop carries this Relay's origin
+   * marker. Suppression reads the hop scope only — hops after the entry
+   * reset to `{}` — so AppCons chained in response are emitted back out
+   * (the bidirectional reflex).
+   *
+   * @param {AppCtx} ac
+   * @param {Object} envelope - the dispatch envelope `{ cascade, hop, chain }`
+   * @returns {void}
+   * @memberof Relay
+   */
   handleAppCon(ac, envelope) {
     if (envelope.hop.source !== this.name) {
       this._toSrc(ac.unwrapCtx(), ac.data);
     }
   }
 
+  /**
+   * Enters a signal received from the source: builds an AppCtx (long-form
+   * trigram keys win) and enters it with this Relay's origin marker on the
+   * entry hop, suppressing the echo back to the source.
+   *
+   * @param {Trigram} trigram
+   * @param {*} data - datagram(s) for the signal
+   * @returns {void}
+   * @memberof Relay
+   */
   setCtx = ({ t, term, a, action, o, orient }, data) => {
     this._enter({ t, term, a, action, o, orient }, data);
   };
 
+  /**
+   * @param {Trigram} trigram
+   * @param {*} data
+   * @private
+   */
   _enter({ t, term, a, action, o, orient }, data) {
     this._network.enter(new AppCtx(term || t, action || a, orient || o, data), {
       hop: sourceControl(this.name),
     });
   }
 
+  /**
+   * Detach this Relay's decoration from the network: stops emitting to the
+   * source. Inbound entries via `setCtx`/`fromSrc` still dispatch.
+   *
+   * @returns {void}
+   * @memberof Relay
+   */
   dispose() {
     this._undecorate();
   }

--- a/packages/tao-utils/src/Relay.js
+++ b/packages/tao-utils/src/Relay.js
@@ -1,5 +1,7 @@
 import { AppCtx } from '@tao.js/core';
 
+/** @typedef {import('@tao.js/core').Kernel} Kernel */
+
 const DEFAULT_SOURCE = 'FROM';
 
 let sourceInstance = 0;
@@ -46,13 +48,15 @@ export default class Relay {
    * @param {function(Object, *): void} toSrc - outbound emitter called with
    *        `(tao, data)` — the unwrapped `{ t, a, o }` trigram and the
    *        datagram(s) — for every AppCon except those arriving from this Relay
-   * @param {(string|function)} [name] - the Relay's name, used as its
-   *        hop-scope origin marker (auto-generated `FROM<n>` when omitted);
-   *        passing a `function` here is the `fromSrc` overload
-   * @param {function(function(Trigram, *): void): void} fromSrc - binder for
-   *        the inbound side (required): called once with a setter
-   *        `(tao, data)` that enters received signals stamped with this
-   *        Relay's origin marker
+   * @param {(string|function(function(Trigram, *): void): void)} [name] -
+   *        the Relay's name, used as its hop-scope origin marker
+   *        (auto-generated `FROM<n>` when omitted); passing a `function`
+   *        here is the `fromSrc` overload
+   * @param {function(function(Trigram, *): void): void} [fromSrc] - binder
+   *        for the inbound side (required at runtime — supplied here or in
+   *        the `name` position): called once with a setter `(tao, data)`
+   *        that enters received signals stamped with this Relay's origin
+   *        marker
    * @throws {Error} when `kernel` (or its `_network`) is missing, when the
    *         network lacks envelope support (`enter` + `decorate`) - upgrade
    *         `@tao.js/core`, or when `toSrc` is missing

--- a/packages/tao-utils/src/Source.js
+++ b/packages/tao-utils/src/Source.js
@@ -12,6 +12,19 @@ function sourceControl(source) {
 }
 
 /**
+ * A trigram in short (`t`/`a`/`o`) or long (`term`/`action`/`orient`) keys;
+ * long-form keys win.
+ *
+ * @typedef {Object} Trigram
+ * @property {string} [t] - term (short key)
+ * @property {string} [term] - term (long key)
+ * @property {string} [a] - action (short key)
+ * @property {string} [action] - action (long key)
+ * @property {string} [o] - orient (short key)
+ * @property {string} [orient] - orient (long key)
+ */
+
+/**
  * Bridges a Network to an external source of AppCons (e.g. a socket): emits
  * every AppCon on the network to the source, except those that arrived FROM
  * the source — suppression applies to the arriving hop only, so AppCons
@@ -19,11 +32,37 @@ function sourceControl(source) {
  *
  * Implemented as a Network decoration; the origin marker rides the
  * envelope's hop scope (entry hop only) — see ENVELOPE-SPEC.md.
+ * Decoration: `onDispatch` (phase-blind emission), self-filtered on
+ * `envelope.hop.source`.
  *
  * @export
  * @class Source
  */
 export default class Source {
+  /**
+   * Creates an instance of Source.
+   *
+   * Note the Source resolves its network from `kernel._network` only (it
+   * does not apply the utils surface-resolution convention, so a bare
+   * `Network` is not accepted); the resolved network must support `enter`
+   * and `decorate`.
+   *
+   * @param {Kernel} kernel - Kernel-shaped wrapper (exposing `_network`) to attach the Source to
+   * @param {function(Object, *): void} toSrc - outbound emitter called with
+   *        `(tao, data)` — the unwrapped `{ t, a, o }` trigram and the
+   *        datagram(s) — for every AppCon except those arriving from this Source
+   * @param {(string|function)} [name] - the Source's name, used as its
+   *        hop-scope origin marker (auto-generated `FROM<n>` when omitted);
+   *        passing a `function` here is the `fromSrc` overload
+   * @param {function(function(Trigram, *): void): void} [fromSrc] - binder for
+   *        the inbound side: called once with a setter `(tao, data)` that
+   *        enters received signals stamped with this Source's origin marker
+   * @throws {Error} when `kernel` (or its `_network`) is missing, when the
+   *         network lacks envelope support (`enter` + `decorate`) - upgrade
+   *         `@tao.js/core`, when `toSrc` is missing, or when `fromSrc` is
+   *         given but not a function
+   * @memberof Source
+   */
   constructor(kernel, toSrc, name, fromSrc) {
     if (!kernel || !kernel._network) {
       throw new Error(
@@ -63,26 +102,67 @@ export default class Source {
     });
   }
 
+  /**
+   * The Source's name — the hop-scope origin marker it stamps on entries
+   * and filters emission on.
+   *
+   * @type {string}
+   * @memberof Source
+   */
   get name() {
     return this._name;
   }
 
+  /**
+   * `onDispatch` decoration callback: emits every dispatched AppCon to the
+   * source except those whose arriving hop carries this Source's origin
+   * marker. Suppression reads the hop scope only — hops after the entry
+   * reset to `{}` — so AppCons chained in response are emitted back out
+   * (the bidirectional reflex).
+   *
+   * @param {AppCtx} ac
+   * @param {Object} envelope - the dispatch envelope `{ cascade, hop, chain }`
+   * @returns {void}
+   * @memberof Source
+   */
   handleAppCon = (ac, envelope) => {
     if (envelope.hop.source !== this.name) {
       this._toSrc(ac.unwrapCtx(), ac.data);
     }
   };
 
+  /**
+   * Enters a signal received from the source: builds an AppCtx (long-form
+   * trigram keys win) and enters it with this Source's origin marker on the
+   * entry hop, suppressing the echo back to the source.
+   *
+   * @param {Trigram} trigram
+   * @param {*} data - datagram(s) for the signal
+   * @returns {void}
+   * @memberof Source
+   */
   setCtx = ({ t, term, a, action, o, orient }, data) => {
     this._enter({ t, term, a, action, o, orient }, data);
   };
 
+  /**
+   * @param {Trigram} trigram
+   * @param {*} data
+   * @private
+   */
   _enter({ t, term, a, action, o, orient }, data) {
     this._network.enter(new AppCtx(term || t, action || a, orient || o, data), {
       hop: sourceControl(this.name),
     });
   }
 
+  /**
+   * Detach this Source's decoration from the network: stops emitting to the
+   * source. Inbound entries via `setCtx`/`fromSrc` still dispatch.
+   *
+   * @returns {void}
+   * @memberof Source
+   */
   dispose() {
     this._undecorate();
   }

--- a/packages/tao-utils/src/Source.js
+++ b/packages/tao-utils/src/Source.js
@@ -1,5 +1,7 @@
 import { AppCtx } from '@tao.js/core';
 
+/** @typedef {import('@tao.js/core').Kernel} Kernel */
+
 const DEFAULT_SOURCE = 'FROM';
 
 let sourceInstance = 0;
@@ -51,9 +53,10 @@ export default class Source {
    * @param {function(Object, *): void} toSrc - outbound emitter called with
    *        `(tao, data)` — the unwrapped `{ t, a, o }` trigram and the
    *        datagram(s) — for every AppCon except those arriving from this Source
-   * @param {(string|function)} [name] - the Source's name, used as its
-   *        hop-scope origin marker (auto-generated `FROM<n>` when omitted);
-   *        passing a `function` here is the `fromSrc` overload
+   * @param {(string|function(function(Trigram, *): void): void)} [name] -
+   *        the Source's name, used as its hop-scope origin marker
+   *        (auto-generated `FROM<n>` when omitted); passing a `function`
+   *        here is the `fromSrc` overload
    * @param {function(function(Trigram, *): void): void} [fromSrc] - binder for
    *        the inbound side: called once with a setter `(tao, data)` that
    *        enters received signals stamped with this Source's origin marker

--- a/packages/tao-utils/src/Transceiver.js
+++ b/packages/tao-utils/src/Transceiver.js
@@ -21,6 +21,29 @@ function transceiverControl(transceiverId, resolve, reject) {
 }
 
 /**
+ * A trigram matcher in short (`t`/`a`/`o`) or long (`term`/`action`/`orient`)
+ * keys; omitted parts are wildcards.
+ *
+ * @typedef {Object} Trigram
+ * @property {string} [t] - term (short key)
+ * @property {string} [term] - term (long key)
+ * @property {string} [a] - action (short key)
+ * @property {string} [action] - action (long key)
+ * @property {string} [o] - orient (short key)
+ * @property {string} [orient] - orient (long key)
+ */
+
+/**
+ * A TAO signal handler: called with the concrete trigram handled and the
+ * signal's datagram(s); returning an `AppCtx` chains it (see `@tao.js/core`).
+ *
+ * @callback SignalHandler
+ * @param {Object} tao - the concrete `{ t, a, o }` trigram handled
+ * @param {*} data - the signal's datagram(s)
+ * @returns {(AppCtx|*)}
+ */
+
+/**
  * Like a Transponder, a Transceiver converts Signals on a Network to Promises.
  * Unlike a Transponder, a Transceiver allows the handlers attached to it to control
  * the behavior of the Promise.
@@ -49,6 +72,36 @@ function transceiverControl(transceiverId, resolve, reject) {
  * @class Transceiver
  */
 export default class Transceiver {
+  /**
+   * Creates an instance of Transceiver.
+   *
+   * Surface resolution follows the utils convention
+   * (`typeof network.enter === 'function' ? network : network._network`):
+   * pass anything exposing the envelope gate directly (a `Network`, or a
+   * `Channel` — entries then keep channel affinity), or a Kernel-shaped
+   * wrapper exposing `_network`. The resolved surface must support `enter`
+   * and `decorate`.
+   *
+   * Two decorations are registered: an `onForward` mirror on the underlying
+   * shared network (`surface._network || surface` — chained hops are
+   * observed there even when entries go through a Channel surface),
+   * self-filtered on `envelope.cascade.transceiverId`, mirroring matching
+   * chained AppCons onto the private signals network; and an `onReturn`
+   * settlement decoration on the signals network mapping signal-handler
+   * returns onto the Promise (see {@linkcode setAppCtx}).
+   *
+   * @param {(Kernel|Network|Channel)} network - the surface to wrap with a `Transceiver`
+   * @param {(string|function(number): (string|number))} [id] - pass either a desired Transceiver ID value as a `string` or a `function` that will be used to generate a Transceiver ID
+   *        the `function` will be called with a new Transceiver ID integer value to help ensure uniqueness
+   * @param {number} [timeoutMs=0] - a timeout to be used when awaiting `Promises`
+   *        - `0` - no timeout will be used
+   *        - `> 0` - timeout will be used to `reject` the `Promise` if it is not signaled in time
+   * @param {PromiseConstructor} [promise=Promise] - a `Promise` constructor to be used when creating promises
+   *        by a signalling method.
+   * @throws {Error} when the resolved surface lacks envelope support
+   *         (`enter` + `decorate`) - upgrade `@tao.js/core`
+   * @memberof Transceiver
+   */
   constructor(network, id, timeoutMs = 0, promise = Promise) {
     this._transceiverId =
       typeof id === 'function'
@@ -92,6 +145,17 @@ export default class Transceiver {
     this._cloneWithId = typeof id === 'function' ? id : undefined;
   }
 
+  /**
+   * Builds an AppCtx from a trigram + datagram (long-form keys win) and
+   * signals it via {@linkcode setAppCtx}.
+   *
+   * @param {Trigram} trigram
+   * @param {*} data - datagram(s) for the signal
+   * @param {Object} [opts] - as {@linkcode setAppCtx}
+   * @param {(Object|null)} [opts.chain] - prior chain state to continue
+   * @returns {Promise<*>} as {@linkcode setAppCtx}
+   * @memberof Transceiver
+   */
   setCtx = ({ t, term, a, action, o, orient }, data, opts) => {
     return this.setAppCtx(
       new AppCtx(term || t, action || a, orient || o, data),
@@ -100,11 +164,29 @@ export default class Transceiver {
   };
 
   /**
+   * Enters the AppCtx on the wrapped surface with this Transceiver's
+   * `{ transceiverId, signal }` cascade tag — the cascade (control) object
+   * is one shared reference for the whole cascade, so descendants of the
+   * entry are mirrored onto the signals network wherever the chain goes.
+   *
+   * Settlement semantics: signal handlers observe the mirrored descendants
+   * (never the entry hop itself) and their non-AppCtx returns settle the
+   * Promise through the signals network's `onReturn` hook — phase mapping:
+   * INTERCEPT (truthy return) and ERROR (thrown error / rejected async)
+   * reject; ASYNC and INLINE (non-null return) resolve. First settlement
+   * wins: it stamps `signalled` on the shared cascade and later returns are
+   * ignored. AppCtx returns chain like any handler's (continuing the
+   * cascade through the main network's hop engine) instead of settling.
+   * With no settling handler the Promise stays pending unless a `timeoutMs`
+   * was configured.
+   *
    * @param {AppCtx} ac
    * @param {Object} [opts]
-   * @param {Object} [opts.chain] - prior chain state to continue (e.g. a
+   * @param {(Object|null)} [opts.chain] - prior chain state to continue (e.g. a
    *        remote trace received over a transport — ENVELOPE-SPEC.md §9)
-   * @returns {Promise} settled by the attached signal handlers
+   * @returns {Promise<*>} settled by the attached signal handlers; rejects
+   *          with the string `reached timeout of: <ms>ms` when a
+   *          `timeoutMs` was configured and no settlement arrived in time
    * @memberof Transceiver
    */
   setAppCtx = (ac, { chain = null } = {}) => {
@@ -141,10 +223,31 @@ export default class Transceiver {
     }
   }
 
+  /**
+   * Attaches a signal handler — an InlineHandler on the private signals
+   * network, alias of {@linkcode addInlineHandler} — for matching AppCons
+   * mirrored to this Transceiver. Its return value settles the Promise as
+   * described on {@linkcode setAppCtx}; remove with
+   * {@linkcode removeInlineHandler}.
+   *
+   * @param {Trigram} trigram
+   * @param {SignalHandler} handler
+   * @returns {void}
+   * @memberof Transceiver
+   */
   addSignalHandler = ({ t, term, a, action, o, orient }, handler) => {
     this._signals.addInlineHandler({ t, term, a, action, o, orient }, handler);
   };
 
+  /**
+   * Attaches an InterceptHandler to the private signals network — a truthy
+   * non-AppCtx return rejects the Promise; a thrown error rejects it.
+   *
+   * @param {Trigram} trigram
+   * @param {SignalHandler} handler
+   * @returns {void}
+   * @memberof Transceiver
+   */
   addInterceptHandler({ t, term, a, action, o, orient }, handler) {
     this._signals.addInterceptHandler(
       { t, term, a, action, o, orient },
@@ -152,14 +255,41 @@ export default class Transceiver {
     );
   }
 
+  /**
+   * Attaches an AsyncHandler to the private signals network — a non-null
+   * non-AppCtx return resolves the Promise; a thrown error or rejection
+   * rejects it.
+   *
+   * @param {Trigram} trigram
+   * @param {SignalHandler} handler
+   * @returns {void}
+   * @memberof Transceiver
+   */
   addAsyncHandler({ t, term, a, action, o, orient }, handler) {
     this._signals.addAsyncHandler({ t, term, a, action, o, orient }, handler);
   }
 
+  /**
+   * Attaches an InlineHandler to the private signals network — a non-null
+   * non-AppCtx return resolves the Promise; a thrown error rejects it.
+   *
+   * @param {Trigram} trigram
+   * @param {SignalHandler} handler
+   * @returns {void}
+   * @memberof Transceiver
+   */
   addInlineHandler({ t, term, a, action, o, orient }, handler) {
     this._signals.addInlineHandler({ t, term, a, action, o, orient }, handler);
   }
 
+  /**
+   * Removes an InterceptHandler previously attached for the same trigram.
+   *
+   * @param {Trigram} trigram
+   * @param {SignalHandler} handler
+   * @returns {void}
+   * @memberof Transceiver
+   */
   removeInterceptHandler({ t, term, a, action, o, orient }, handler) {
     this._signals.removeInterceptHandler(
       { t, term, a, action, o, orient },
@@ -167,6 +297,14 @@ export default class Transceiver {
     );
   }
 
+  /**
+   * Removes an AsyncHandler previously attached for the same trigram.
+   *
+   * @param {Trigram} trigram
+   * @param {SignalHandler} handler
+   * @returns {void}
+   * @memberof Transceiver
+   */
   removeAsyncHandler({ t, term, a, action, o, orient }, handler) {
     this._signals.removeAsyncHandler(
       { t, term, a, action, o, orient },
@@ -174,6 +312,15 @@ export default class Transceiver {
     );
   }
 
+  /**
+   * Removes an InlineHandler previously attached for the same trigram
+   * (including handlers attached via {@linkcode addSignalHandler}).
+   *
+   * @param {Trigram} trigram
+   * @param {SignalHandler} handler
+   * @returns {void}
+   * @memberof Transceiver
+   */
   removeInlineHandler({ t, term, a, action, o, orient }, handler) {
     this._signals.removeInlineHandler(
       { t, term, a, action, o, orient },

--- a/packages/tao-utils/src/Transceiver.js
+++ b/packages/tao-utils/src/Transceiver.js
@@ -1,5 +1,7 @@
 import { AppCtx, Network, INTERCEPT, ERROR } from '@tao.js/core';
 
+/** @typedef {import('./wire').NetworkSurface} NetworkSurface */
+
 // for backwards compatibility
 const MAX_SAFE_INTEGER = Math.pow(2, 53) - 1;
 
@@ -90,7 +92,7 @@ export default class Transceiver {
    * settlement decoration on the signals network mapping signal-handler
    * returns onto the Promise (see {@linkcode setAppCtx}).
    *
-   * @param {(Kernel|Network|Channel)} network - the surface to wrap with a `Transceiver`
+   * @param {NetworkSurface} network - the surface to wrap with a `Transceiver`
    * @param {(string|function(number): (string|number))} [id] - pass either a desired Transceiver ID value as a `string` or a `function` that will be used to generate a Transceiver ID
    *        the `function` will be called with a new Transceiver ID integer value to help ensure uniqueness
    * @param {number} [timeoutMs=0] - a timeout to be used when awaiting `Promises`
@@ -108,8 +110,9 @@ export default class Transceiver {
         ? id(newTransceiverId())
         : id || newTransceiverId();
     this._signals = new Network();
-    this._surface =
-      typeof network.enter === 'function' ? network : network._network;
+    this._surface = /** @type {Network} */ (
+      typeof network.enter === 'function' ? network : network._network
+    );
     if (
       !this._surface ||
       typeof this._surface.enter !== 'function' ||
@@ -121,7 +124,9 @@ export default class Transceiver {
     }
     // mirror from the shared network (a Channel surface delegates entries to
     // it); the cascade tag filters this transceiver's cascades either way
-    this._network = this._surface._network || this._surface;
+    this._network = /** @type {Network} */ (
+      /** @type {NetworkSurface} */ (this._surface)._network || this._surface
+    );
     this._undecorateMirror = this._network.decorate({
       // Stryker disable next-line StringLiteral: decoration name is a diagnostic label with no observable behavior
       name: `transceiver:${this._transceiverId}`,

--- a/packages/tao-utils/src/Transponder.js
+++ b/packages/tao-utils/src/Transponder.js
@@ -14,6 +14,19 @@ function transponderControl(transponderId, signal) {
 }
 
 /**
+ * A trigram in short (`t`/`a`/`o`) or long (`term`/`action`/`orient`) keys;
+ * long-form keys win.
+ *
+ * @typedef {Object} Trigram
+ * @property {string} [t] - term (short key)
+ * @property {string} [term] - term (long key)
+ * @property {string} [a] - action (short key)
+ * @property {string} [action] - action (long key)
+ * @property {string} [o] - orient (short key)
+ * @property {string} [orient] - orient (long key)
+ */
+
+/**
  * Allows use of Promises with a Network by returning a Promise from a signalling method
  * that will only resolve based on one of the handlers attached to the wrapped Network
  * being called.
@@ -26,8 +39,10 @@ function transponderControl(transponderId, signal) {
  *
  * Implemented as an `onDispatch` decoration on the wrapped surface (a raw
  * Network/Kernel network, or a Channel's private network via
- * `Channel.decorate`). The transponder tag rides the cascade scope of the
- * envelope, so it survives every hop of a chain (see ENVELOPE-SPEC.md).
+ * `Channel.decorate`), self-filtered on `envelope.cascade.transponderId`.
+ * The transponder tag rides the cascade scope of the envelope, so it
+ * survives every hop of a chain (see ENVELOPE-SPEC.md); resolve-once is
+ * enforced by stamping `signalled` on the shared cascade reference.
  *
  * @export
  * @class Transponder
@@ -35,16 +50,27 @@ function transponderControl(transponderId, signal) {
 export default class Transponder {
   /**
    *Creates an instance of Transponder.
-   * @param {Network} network - the `Network` to wrap with a `Transponder`
-   * @param {(string|function)} [id] - pass either a desired Channel ID value as a `string` or a `function` that will be used to generate a Channel ID
-   *        the `function` will be called with a new Channel ID integer value to help ensure uniqueness
+   *
+   * Surface resolution follows the utils convention
+   * (`typeof network.enter === 'function' ? network : network._network`):
+   * pass anything exposing the envelope gate directly (a `Network`, or a
+   * `Channel` — whose `enter`/`decorate` scope this Transponder to the
+   * channel), or a Kernel-shaped wrapper exposing `_network`. The resolved
+   * surface must support `enter` and `decorate`.
+   *
+   * @param {(Kernel|Network|Channel)} network - the surface to wrap with a `Transponder`
+   * @param {(string|function(number): (string|number))} [id] - pass either a desired Transponder ID value as a `string` or a `function` that will be used to generate a Transponder ID
+   *        the `function` will be called with a new Transponder ID integer value to help ensure uniqueness
    * @param {number} [timeoutMs=0] - a timeout to be used when awaiting `Promises`
    *        - `0` - no timeout will be used
    *        - `> 0` - timeout will be used to `reject` the `Promise` if it is not signaled in time
    *        - use this to prevent unexpected behaviors
-   * @param {Thenable} [promise=Promise] - a `Promise` constructor to be used when creating promises
+   *        - negative and non-numeric values clamp to `0`
+   * @param {PromiseConstructor} [promise=Promise] - a `Promise` constructor to be used when creating promises
    *        by a signalling method.
    * @param {boolean} [debug=false] - pass true to console.log internal activity
+   * @throws {Error} when the resolved surface lacks envelope support
+   *         (`enter` + `decorate`) - upgrade `@tao.js/core`
    * @memberof Transponder
    */
   constructor(network, id, timeoutMs = 0, promise = Promise, debug = false) {
@@ -78,6 +104,17 @@ export default class Transponder {
     this._cloneWithId = typeof id === 'function' ? id : undefined;
   }
 
+  /**
+   * Clones a Transponder on the same wrapped surface with the same timeout,
+   * Promise constructor and debug settings. The clone registers its own
+   * decoration under its own Transponder ID.
+   *
+   * @param {(string|function(number): (string|number))} [cloneId] - used as the cloned
+   *        `Transponder`'s ID, same as the `id` param to the constructor;
+   *        falls back to the constructor's `id` generator when one was given
+   * @returns {Transponder} the cloned Transponder
+   * @memberof Transponder
+   */
   clone(cloneId) {
     const clone = new Transponder(
       this._network,
@@ -101,7 +138,7 @@ export default class Transponder {
    *
    * @see {@link detach}
    *
-   * @returns this
+   * @returns {Transponder} this
    * @memberof Transponder
    */
   attach() {
@@ -120,7 +157,7 @@ export default class Transponder {
    *
    * @see {@link attach()}
    *
-   * @returns this
+   * @returns {Transponder} this
    * @memberof Transponder
    */
   detach() {
@@ -131,6 +168,17 @@ export default class Transponder {
     return this;
   }
 
+  /**
+   * Builds an AppCtx from a trigram + datagram (long-form keys win) and
+   * signals it via {@linkcode setAppCtx}.
+   *
+   * @param {Trigram} trigram
+   * @param {*} data - datagram(s) for the signal
+   * @param {Object} [opts] - as {@linkcode setAppCtx}
+   * @param {(Object|null)} [opts.chain] - prior chain state to continue
+   * @returns {Promise<AppCtx>} as {@linkcode setAppCtx}
+   * @memberof Transponder
+   */
   setCtx({ t, term, a, action, o, orient }, data, opts) {
     return this.setAppCtx(
       new AppCtx(term || t, action || a, orient || o, data),
@@ -139,11 +187,28 @@ export default class Transponder {
   }
 
   /**
+   * Enters the AppCtx on the wrapped surface with this Transponder's
+   * `{ transponderId, signal }` cascade tag — the cascade (control) object
+   * is one shared reference for the whole cascade, so the tag survives
+   * every hop of a chain.
+   *
+   * Resolution semantics: the Promise resolves with the first AppCon the
+   * Transponder's decoration observes dispatching for this cascade — the
+   * first handled AppCon of the cascade. Attached to a bare Network/Kernel
+   * that is the entered AppCtx itself; attached to a Channel (the
+   * decoration observes the channel's private network) it is the first
+   * descendant mirrored onto the channel — the entry hop itself is not
+   * mirrored. Resolve-once: the first signal stamps `signalled` on the
+   * shared cascade, so later dispatches of the same cascade never signal
+   * again and the Promise settles at most once.
+   *
    * @param {AppCtx} ac
    * @param {Object} [opts]
-   * @param {Object} [opts.chain] - prior chain state to continue (e.g. a
+   * @param {(Object|null)} [opts.chain] - prior chain state to continue (e.g. a
    *        remote trace received over a transport — ENVELOPE-SPEC.md §9)
-   * @returns {Promise} resolves with the first handled AppCon of the cascade
+   * @returns {Promise<AppCtx>} resolves with the first handled AppCon of the
+   *          cascade; rejects with the string `reached timeout of: <ms>ms`
+   *          when a `timeoutMs` was configured and no signal arrived in time
    * @memberof Transponder
    */
   setAppCtx(ac, { chain = null } = {}) {
@@ -164,6 +229,18 @@ export default class Transponder {
     });
   }
 
+  /**
+   * `onDispatch` decoration callback: signals the awaiting Promise with the
+   * first dispatched AppCon of a matching cascade. Self-filtered on
+   * `control.transponderId`; resolve-once is enforced by stamping
+   * `signalled` on the shared cascade control.
+   *
+   * @param {AppCtx} ac
+   * @param {Object} control - the envelope's cascade scope
+   *        (`{ transponderId, signal, signalled }`)
+   * @returns {void}
+   * @memberof Transponder
+   */
   handleSignalAppCon = (ac, control) => {
     // Stryker disable all: optional debug logging
     this._debug &&

--- a/packages/tao-utils/src/Transponder.js
+++ b/packages/tao-utils/src/Transponder.js
@@ -1,5 +1,7 @@
 import { AppCtx } from '@tao.js/core';
 
+/** @typedef {import('./wire').NetworkSurface} NetworkSurface */
+
 // for backwards compatibility
 const MAX_SAFE_INTEGER = Math.pow(2, 53) - 1;
 
@@ -58,7 +60,7 @@ export default class Transponder {
    * channel), or a Kernel-shaped wrapper exposing `_network`. The resolved
    * surface must support `enter` and `decorate`.
    *
-   * @param {(Kernel|Network|Channel)} network - the surface to wrap with a `Transponder`
+   * @param {NetworkSurface} network - the surface to wrap with a `Transponder`
    * @param {(string|function(number): (string|number))} [id] - pass either a desired Transponder ID value as a `string` or a `function` that will be used to generate a Transponder ID
    *        the `function` will be called with a new Transponder ID integer value to help ensure uniqueness
    * @param {number} [timeoutMs=0] - a timeout to be used when awaiting `Promises`

--- a/packages/tao-utils/src/bridge.js
+++ b/packages/tao-utils/src/bridge.js
@@ -51,14 +51,63 @@ function bridge(type, source, destination, filters) {
     filters.forEach((trigrams) => source[detachment](trigrams, handler));
 }
 
+/**
+ * Bridges signals handled on the `source` Kernel into the `destination`
+ * Kernel via an `InterceptHandler` — the forwarded signal re-enters the
+ * destination through `setCtx` (or `setAppCtx` for AppCtx values). The
+ * bridging handler returns nothing, so an intercept bridge observes without
+ * halting the source cascade.
+ *
+ * @export
+ * @param {Kernel} source - the Kernel to bridge signals from
+ * @param {Kernel} destination - the Kernel to bridge signals into
+ * @param {...*} filters - optional leading filter function
+ *        `(tao, data) => boolean` gating which signals forward, then
+ *        trigrams (or a single array of trigrams) to bridge; with no
+ *        trigrams the bridge attaches to the wildcard `{}`
+ * @returns {function(): void} detaches the bridge from `source` (a no-op
+ *          when `source`/`destination` are not Kernel instances)
+ */
 export function interceptBridge(source, destination, ...filters) {
   return bridge(INTERCEPT, source, destination, filters);
 }
 
+/**
+ * Bridges signals handled on the `source` Kernel into the `destination`
+ * Kernel via an `AsyncHandler` — the forwarded signal re-enters the
+ * destination through `setCtx` (or `setAppCtx` for AppCtx values) on the
+ * async fork of the source cascade.
+ *
+ * @export
+ * @param {Kernel} source - the Kernel to bridge signals from
+ * @param {Kernel} destination - the Kernel to bridge signals into
+ * @param {...*} filters - optional leading filter function
+ *        `(tao, data) => boolean` gating which signals forward, then
+ *        trigrams (or a single array of trigrams) to bridge; with no
+ *        trigrams the bridge attaches to the wildcard `{}`
+ * @returns {function(): void} detaches the bridge from `source` (a no-op
+ *          when `source`/`destination` are not Kernel instances)
+ */
 export function asyncBridge(source, destination, ...filters) {
   return bridge(ASYNC, source, destination, filters);
 }
 
+/**
+ * Bridges signals handled on the `source` Kernel into the `destination`
+ * Kernel via an `InlineHandler` — the forwarded signal re-enters the
+ * destination through `setCtx` (or `setAppCtx` for AppCtx values) in the
+ * source cascade's inline spool.
+ *
+ * @export
+ * @param {Kernel} source - the Kernel to bridge signals from
+ * @param {Kernel} destination - the Kernel to bridge signals into
+ * @param {...*} filters - optional leading filter function
+ *        `(tao, data) => boolean` gating which signals forward, then
+ *        trigrams (or a single array of trigrams) to bridge; with no
+ *        trigrams the bridge attaches to the wildcard `{}`
+ * @returns {function(): void} detaches the bridge from `source` (a no-op
+ *          when `source`/`destination` are not Kernel instances)
+ */
 export function inlineBridge(source, destination, ...filters) {
   return bridge(INLINE, source, destination, filters);
 }

--- a/packages/tao-utils/src/forward-chain.js
+++ b/packages/tao-utils/src/forward-chain.js
@@ -20,15 +20,14 @@ function forward(kernel, from, to, type, opts) {
  * automatically remove it from the kernel that was passed in
  *
  * @export
- * @param  {any} kernel a TAO Kernel (TAO) that can attach handlers and receive TAO signals
- * @param  {any} from trigram representing the Application Context to chain from
- * @param  {any} to trigram representing the Application Context to chain to
- * @param {{
- *   transformTerm: function,
- *   transformAction: function,
- *   transformOrient: function,
- * }} opts optional functions to transform the datagrams in the new AppCtx
- * @return {function} the handler so that it can be removed from the kernel if needed
+ * @param {Kernel} kernel a TAO Kernel (TAO) that can attach handlers and receive TAO signals
+ * @param {Object} from trigram representing the Application Context to chain from
+ * @param {Object} to trigram representing the Application Context to chain to
+ * @param {Object} [opts] optional functions to transform the datagrams in the new AppCtx
+ * @param {function(*): *} [opts.transformTerm] transforms the term datagram
+ * @param {function(*): *} [opts.transformAction] transforms the action datagram
+ * @param {function(*): *} [opts.transformOrient] transforms the orient datagram
+ * @return {function(Object, Object): AppCtx} the handler (also exposing `.remove()`) so that it can be removed from the kernel if needed
  */
 export function forwardInline(kernel, from, to, opts) {
   return forward(kernel, from, to, INLINE, opts);
@@ -45,15 +44,14 @@ export function forwardInline(kernel, from, to, opts) {
  * automatically remove it from the kernel that was passed in
  *
  * @export
- * @param  {any} kernel a TAO Kernel (TAO) that can attach handlers and receive TAO signals
- * @param  {any} from trigram representing the Application Context to chain from
- * @param  {any} to trigram representing the Application Context to chain to
- * @param {{
- *   transformTerm: function,
- *   transformAction: function,
- *   transformOrient: function,
- * }} opts optional functions to transform the datagrams in the new AppCtx
- * @return {function} the handler so that it can be removed from the kernel if needed
+ * @param {Kernel} kernel a TAO Kernel (TAO) that can attach handlers and receive TAO signals
+ * @param {Object} from trigram representing the Application Context to chain from
+ * @param {Object} to trigram representing the Application Context to chain to
+ * @param {Object} [opts] optional functions to transform the datagrams in the new AppCtx
+ * @param {function(*): *} [opts.transformTerm] transforms the term datagram
+ * @param {function(*): *} [opts.transformAction] transforms the action datagram
+ * @param {function(*): *} [opts.transformOrient] transforms the orient datagram
+ * @return {function(Object, Object): AppCtx} the handler (also exposing `.remove()`) so that it can be removed from the kernel if needed
  */
 export function forwardAsync(kernel, from, to, opts) {
   return forward(kernel, from, to, ASYNC, opts);
@@ -70,15 +68,14 @@ export function forwardAsync(kernel, from, to, opts) {
  * automatically remove it from the kernel that was passed in
  *
  * @export
- * @param  {any} kernel a TAO Kernel (TAO) that can attach handlers and receive TAO signals
- * @param  {any} from trigram representing the Application Context to chain from
- * @param  {any} to trigram representing the Application Context to chain to
- * @param {{
- *   transformTerm: function,
- *   transformAction: function,
- *   transformOrient: function,
- * }} opts optional functions to transform the datagrams in the new AppCtx
- * @return {function} the handler so that it can be removed from the kernel if needed
+ * @param {Kernel} kernel a TAO Kernel (TAO) that can attach handlers and receive TAO signals
+ * @param {Object} from trigram representing the Application Context to chain from
+ * @param {Object} to trigram representing the Application Context to chain to
+ * @param {Object} [opts] optional functions to transform the datagrams in the new AppCtx
+ * @param {function(*): *} [opts.transformTerm] transforms the term datagram
+ * @param {function(*): *} [opts.transformAction] transforms the action datagram
+ * @param {function(*): *} [opts.transformOrient] transforms the orient datagram
+ * @return {function(Object, Object): AppCtx} the handler (also exposing `.remove()`) so that it can be removed from the kernel if needed
  */
 export function forwardIntercept(kernel, from, to, opts) {
   return forward(kernel, from, to, INTERCEPT, opts);

--- a/packages/tao-utils/src/forward-chain.js
+++ b/packages/tao-utils/src/forward-chain.js
@@ -20,7 +20,7 @@ function forward(kernel, from, to, type, opts) {
  * automatically remove it from the kernel that was passed in
  *
  * @export
- * @param {Kernel} kernel a TAO Kernel (TAO) that can attach handlers and receive TAO signals
+ * @param {import('@tao.js/core').Kernel} kernel a TAO Kernel (TAO) that can attach handlers and receive TAO signals
  * @param {Object} from trigram representing the Application Context to chain from
  * @param {Object} to trigram representing the Application Context to chain to
  * @param {Object} [opts] optional functions to transform the datagrams in the new AppCtx
@@ -44,7 +44,7 @@ export function forwardInline(kernel, from, to, opts) {
  * automatically remove it from the kernel that was passed in
  *
  * @export
- * @param {Kernel} kernel a TAO Kernel (TAO) that can attach handlers and receive TAO signals
+ * @param {import('@tao.js/core').Kernel} kernel a TAO Kernel (TAO) that can attach handlers and receive TAO signals
  * @param {Object} from trigram representing the Application Context to chain from
  * @param {Object} to trigram representing the Application Context to chain to
  * @param {Object} [opts] optional functions to transform the datagrams in the new AppCtx
@@ -68,7 +68,7 @@ export function forwardAsync(kernel, from, to, opts) {
  * automatically remove it from the kernel that was passed in
  *
  * @export
- * @param {Kernel} kernel a TAO Kernel (TAO) that can attach handlers and receive TAO signals
+ * @param {import('@tao.js/core').Kernel} kernel a TAO Kernel (TAO) that can attach handlers and receive TAO signals
  * @param {Object} from trigram representing the Application Context to chain from
  * @param {Object} to trigram representing the Application Context to chain to
  * @param {Object} [opts] optional functions to transform the datagrams in the new AppCtx

--- a/packages/tao-utils/src/forward-chain.js
+++ b/packages/tao-utils/src/forward-chain.js
@@ -27,7 +27,7 @@ function forward(kernel, from, to, type, opts) {
  * @param {function(*): *} [opts.transformTerm] transforms the term datagram
  * @param {function(*): *} [opts.transformAction] transforms the action datagram
  * @param {function(*): *} [opts.transformOrient] transforms the orient datagram
- * @return {function(Object, Object): AppCtx} the handler (also exposing `.remove()`) so that it can be removed from the kernel if needed
+ * @return {(function(Object, Object): AppCtx) & {remove: function(): void}} the handler (also exposing `.remove()`) so that it can be removed from the kernel if needed
  */
 export function forwardInline(kernel, from, to, opts) {
   return forward(kernel, from, to, INLINE, opts);
@@ -51,7 +51,7 @@ export function forwardInline(kernel, from, to, opts) {
  * @param {function(*): *} [opts.transformTerm] transforms the term datagram
  * @param {function(*): *} [opts.transformAction] transforms the action datagram
  * @param {function(*): *} [opts.transformOrient] transforms the orient datagram
- * @return {function(Object, Object): AppCtx} the handler (also exposing `.remove()`) so that it can be removed from the kernel if needed
+ * @return {(function(Object, Object): AppCtx) & {remove: function(): void}} the handler (also exposing `.remove()`) so that it can be removed from the kernel if needed
  */
 export function forwardAsync(kernel, from, to, opts) {
   return forward(kernel, from, to, ASYNC, opts);
@@ -75,7 +75,7 @@ export function forwardAsync(kernel, from, to, opts) {
  * @param {function(*): *} [opts.transformTerm] transforms the term datagram
  * @param {function(*): *} [opts.transformAction] transforms the action datagram
  * @param {function(*): *} [opts.transformOrient] transforms the orient datagram
- * @return {function(Object, Object): AppCtx} the handler (also exposing `.remove()`) so that it can be removed from the kernel if needed
+ * @return {(function(Object, Object): AppCtx) & {remove: function(): void}} the handler (also exposing `.remove()`) so that it can be removed from the kernel if needed
  */
 export function forwardIntercept(kernel, from, to, opts) {
   return forward(kernel, from, to, INTERCEPT, opts);

--- a/packages/tao-utils/src/seive.js
+++ b/packages/tao-utils/src/seive.js
@@ -15,6 +15,24 @@ function addControl(name, control) {
  * `destination` Channel's private network. Implemented as an `onDispatch`
  * decoration on the source network; chains from destination-channel
  * handlers continue the source cascade through the core hop engine.
+ *
+ * Clone-and-redirect: the destination entry carries a copy of the observed
+ * cascade with a `{ seive: name }` tag added (the source cascade object is
+ * never mutated), and passes the observed hop's `forward` continuation so
+ * chained AppCons re-join the source cascade.
+ *
+ * @param {(string|number)} name - seive tag stamped on redirected cascades
+ *        (`cascade.seive`) and used in the decoration's diagnostic name
+ * @param {Kernel} source - Kernel-shaped wrapper whose `_network` is a
+ *        `Network` to observe
+ * @param {Channel} destination - Channel whose private network (`_channel`)
+ *        receives the matching AppCons
+ * @param {...*} filters - optional leading filter function
+ *        `(ac: AppCtx, cascade: Object) => boolean`, then trigram filters as
+ *        `trigramFilter` accepts (optional `exact` boolean, then short-key
+ *        trigrams or a single array of trigrams)
+ * @returns {function(): void} dispose - detaches the decoration (a no-op
+ *          when `source`/`destination` are not the required shapes)
  */
 export default function seive(name, source, destination, ...filters) {
   if (

--- a/packages/tao-utils/src/seive.js
+++ b/packages/tao-utils/src/seive.js
@@ -1,6 +1,9 @@
 import { Network } from '@tao.js/core';
 import trigramFilter from './trigram-filter';
 
+/** @typedef {import('@tao.js/core').Kernel} Kernel */
+/** @typedef {import('./Channel').default} Channel */
+
 const NOOP = () => {};
 
 function addControl(name, control) {

--- a/packages/tao-utils/src/transfer.js
+++ b/packages/tao-utils/src/transfer.js
@@ -1,19 +1,18 @@
 import { AppCtx } from '@tao.js/core';
 
-const IDENTITY = val => val;
+const IDENTITY = (val) => val;
 
 /**
  * Transfer the trigram and datagrams into a new Signal as an AppCtx
  *
- * @param {*} tao signal trigram that you want to transfer from
- * @param {*} data signal datagram that you want to transfer from
- * @param {*} to signal trigram that you want to transfer to - any missing trigram (t, a, or o) will use the value from the `tao` argument
- * @param {{
- *   transformTerm: function,
- *   transformAction: function,
- *   transformOrient: function,
- * }} options optional functions to transform the datagrams in the new AppCtx
- * @returns AppCtx with the trigram of the `to` argument and the data from the `data` argument
+ * @param {Object} tao signal trigram that you want to transfer from (short `t`/`a`/`o` keys)
+ * @param {Object} data signal datagram that you want to transfer from
+ * @param {Object} to signal trigram that you want to transfer to - any missing trigram (t, a, or o) will use the value from the `tao` argument
+ * @param {Object} [options] optional functions to transform the datagrams in the new AppCtx
+ * @param {function(*): *} [options.transformTerm] transforms the term datagram
+ * @param {function(*): *} [options.transformAction] transforms the action datagram
+ * @param {function(*): *} [options.transformOrient] transforms the orient datagram
+ * @returns {AppCtx} AppCtx with the trigram of the `to` argument and the data from the `data` argument
  */
 export function transferToAppCtx(
   tao,
@@ -22,8 +21,8 @@ export function transferToAppCtx(
   {
     transformTerm = IDENTITY,
     transformAction = IDENTITY,
-    transformOrient = IDENTITY
-  } = {}
+    transformOrient = IDENTITY,
+  } = {},
 ) {
   const { t, term, a, action, o, orient } = to;
   return new AppCtx(
@@ -32,7 +31,7 @@ export function transferToAppCtx(
     o || orient || tao.o,
     transformTerm(data[tao.t]),
     transformAction(data[tao.a]),
-    transformOrient(data[tao.o])
+    transformOrient(data[tao.o]),
   );
 }
 
@@ -40,7 +39,7 @@ function buildErrorDatagram(tao, data, error) {
   const fail = {
     reason: typeof error === 'string' ? error : error.message,
     a: tao.a,
-    [tao.a]: data[tao.a]
+    [tao.a]: data[tao.a],
   };
   if (typeof error !== 'string') {
     fail.error = error;
@@ -55,16 +54,15 @@ function buildErrorDatagram(tao, data, error) {
  * Transfer the trigram, datagrams and an error into a new AppCtx that
  * signals the Error
  *
- * @param {*} tao signal trigram that you want to transfer from
- * @param {*} data signal datagram that you want to transfer from
- * @param {error | string} error error that is either an Error or a String message
- * @param {{
- *   action: string,
- *   transformTerm: function,
- *   transformAction: function,
- *   transformOrient: function,
- * }} options optional functions to transform the datagrams in the new AppCtx
- * @returns AppCtx with the trigram of the { `tao.t`, `action` [`'fail'`], `tao.o` }
+ * @param {Object} tao signal trigram that you want to transfer from (short `t`/`a`/`o` keys)
+ * @param {Object} data signal datagram that you want to transfer from
+ * @param {(Error|string)} error error that is either an Error or a String message
+ * @param {Object} [options] optional functions to transform the datagrams in the new AppCtx
+ * @param {string} [options.action='fail'] action used in the new trigram
+ * @param {function(*): *} [options.transformTerm] transforms the term datagram
+ * @param {function(*): *} [options.transformAction] transforms the error datagram built for the action
+ * @param {function(*): *} [options.transformOrient] transforms the orient datagram
+ * @returns {AppCtx} AppCtx with the trigram of the { `tao.t`, `action` [`'fail'`], `tao.o` }
  * argument and the datagrams from the `data` argument with the error
  */
 export function transferError(
@@ -75,8 +73,8 @@ export function transferError(
     action = 'fail',
     transformTerm = IDENTITY,
     transformAction = IDENTITY,
-    transformOrient = IDENTITY
-  } = {}
+    transformOrient = IDENTITY,
+  } = {},
 ) {
   return transferToAppCtx(
     tao,
@@ -88,7 +86,7 @@ export function transferError(
         const fail = buildErrorDatagram(tao, data, error);
         return transformAction(fail);
       },
-      transformOrient
-    }
+      transformOrient,
+    },
   );
 }

--- a/packages/tao-utils/src/trigram-filter.js
+++ b/packages/tao-utils/src/trigram-filter.js
@@ -1,8 +1,19 @@
 import { AppCtx } from '@tao.js/core';
 
+/**
+ * Builds a predicate that tests whether a value is an `AppCtx` matching any
+ * of the given trigrams (wildcard-aware via `AppCtx.isMatch`, which reads
+ * short `t`/`a`/`o` keys only).
+ *
+ * @param {...*} trigrams - optional leading `exact` boolean (require exact
+ *        key equality — wildcards only match wildcards), then trigram
+ *        objects or a single array of trigrams; with none (or a leading
+ *        `null`) the predicate matches any `AppCtx`
+ * @returns {function(*): boolean} predicate over candidate AppCons
+ */
 export default function trigramFilter(...trigrams) {
   if (!trigrams.length || trigrams[0] == null) {
-    return ac => ac instanceof AppCtx;
+    return (ac) => ac instanceof AppCtx;
   }
   let exact = false;
   if (typeof trigrams[0] === 'boolean') {
@@ -11,10 +22,10 @@ export default function trigramFilter(...trigrams) {
   if (Array.isArray(trigrams[0])) {
     trigrams = trigrams[0];
   }
-  return ac => {
+  return (ac) => {
     if (!(ac instanceof AppCtx)) {
       return false;
     }
-    return trigrams.some(trigram => ac.isMatch(trigram, exact));
+    return trigrams.some((trigram) => ac.isMatch(trigram, exact));
   };
 }

--- a/packages/tao-utils/src/wire.js
+++ b/packages/tao-utils/src/wire.js
@@ -10,8 +10,20 @@ function transportName(name) {
 /**
  * Wire-envelope version. Receivers ignore wire envelopes with an unknown
  * version (treated as absent) rather than fail — see ENVELOPE-SPEC.md §9.
+ *
+ * @type {number}
  */
 export const WIRE_VERSION = 1;
+
+/**
+ * The portable part of a dispatch envelope — what a transport serializes
+ * alongside a signal's trigram + data (ENVELOPE-SPEC.md §9).
+ *
+ * @typedef {Object} WireEnvelope
+ * @property {number} v - wire-envelope version (`WIRE_VERSION`)
+ * @property {(Object|null)} chain - the sending hop's `envelope.chain`,
+ *           verbatim (JSON-clean by construction), or `null`
+ */
 
 /**
  * The portable part of a dispatch envelope, for serializing alongside a
@@ -19,8 +31,9 @@ export const WIRE_VERSION = 1;
  * `cascade` holds live references and process-local affinity, and `hop` is
  * boundary-local (ENVELOPE-SPEC.md §9).
  *
- * @param {Object} envelope - a dispatch envelope (`{ cascade, hop, chain }`)
- * @returns {{ v: number, chain: Object|null }}
+ * @param {Object} [envelope] - a dispatch envelope (`{ cascade, hop, chain }`)
+ * @returns {WireEnvelope} `{ v: WIRE_VERSION, chain }` — `chain` is `null`
+ *          when the envelope is absent or carries none
  */
 export function wireEnvelope(envelope) {
   return {
@@ -32,10 +45,11 @@ export function wireEnvelope(envelope) {
 /**
  * Extract the continuable chain from a received wire envelope. Absent,
  * unversioned, or unknown-version envelopes yield `null` (fresh chain) —
- * one-sided backward compatibility with pre-wire senders.
+ * one-sided backward compatibility with pre-wire senders. A `chain` that is
+ * not a plain object (arrays included) also yields `null`.
  *
- * @param {Object} [wire] - a received `{ v, chain }` wire envelope
- * @returns {Object|null}
+ * @param {WireEnvelope} [wire] - a received `{ v, chain }` wire envelope
+ * @returns {(Object|null)} the received chain to continue, or `null`
  */
 export function chainFromWire(wire) {
   if (
@@ -55,12 +69,17 @@ export function chainFromWire(wire) {
  * hop-scope origin marker (echo suppression) and continues the received
  * chain through the local reducers.
  *
- * @param {Kernel|Network|Channel} network - any surface exposing `enter`
+ * Surface resolution follows the utils convention
+ * (`typeof network.enter === 'function' ? network : network._network`).
+ *
+ * @param {(Kernel|Network|Channel)} network - any surface exposing `enter`
  *        (or a Kernel exposing `_network`)
- * @param {Object} tao - trigram (short or long keys)
- * @param {Object} data - datagram
- * @param {Object} [wire] - the received `{ v, chain }` wire envelope
+ * @param {Object} tao - trigram (short or long keys; long-form keys win)
+ * @param {*} data - datagram(s)
+ * @param {(WireEnvelope|undefined)} wire - the received `{ v, chain }` wire
+ *        envelope; pass `undefined` when the sender included none
  * @param {string} sourceName - this transport's origin marker
+ * @returns {void}
  */
 export function enterFromWire(network, tao, data, wire, sourceName) {
   const net = typeof network.enter === 'function' ? network : network._network;
@@ -94,13 +113,20 @@ export function enterFromWire(network, tao, data, wire, sourceName) {
  * semantics. For a veto-respecting emitter (e.g. a per-client reply path),
  * decorate with `onProceed` directly — see `@tao.js/socket.io`.
  *
- * @param {Kernel|Network} kernel - the network to bridge. Not a Channel:
+ * @param {(Kernel|Network)} kernel - the network to bridge. Not a Channel:
  *        a duplex transport spans the whole kernel; channel-scoped reply
  *        paths belong to phase-gated emitters (see `@tao.js/socket.io`)
  * @param {Object} opts
  * @param {string} [opts.name] - origin-marker name (auto-generated if omitted)
- * @param {function} opts.send - `(tao, data, wire) => void` outbound emitter
- * @returns {{ name: string, receive: function, dispose: function }}
+ * @param {function(Object, *, WireEnvelope): void} opts.send -
+ *        `(tao, data, wire) => void` outbound emitter
+ * @returns {{ name: string, receive: function(Object, *, WireEnvelope=): void, dispose: function(): void }}
+ *          the transport handle: `name` is the origin marker, `receive`
+ *          enters an inbound signal (as `enterFromWire`), `dispose`
+ *          detaches the emitting decoration
+ * @throws {Error} when `kernel` is missing, when the resolved network lacks
+ *         envelope support (`enter` + `decorate`) - upgrade `@tao.js/core`,
+ *         or when `send` is not a function
  */
 export function createTransport(kernel, { name, send } = {}) {
   if (!kernel || (typeof kernel.enter !== 'function' && !kernel._network)) {

--- a/packages/tao-utils/src/wire.js
+++ b/packages/tao-utils/src/wire.js
@@ -1,5 +1,17 @@
 import { AppCtx } from '@tao.js/core';
 
+/**
+ * Any surface the utils surface-resolution convention resolves to a
+ * `Network` (`typeof x.enter === 'function' ? x : x._network`): a bare
+ * `Network` (exposing `enter` + `decorate`), or a Kernel-shaped wrapper
+ * exposing `_network`.
+ *
+ * @typedef {Object} NetworkSurface
+ * @property {Function} [enter] - present on a bare Network (and on Channel's channel-scoped gate)
+ * @property {Function} [decorate] - present on a bare Network
+ * @property {import('@tao.js/core').Network} [_network] - present on Kernel-shaped wrappers
+ */
+
 const DEFAULT_TRANSPORT = 'WIRE';
 
 let transportInstance = 0;
@@ -72,8 +84,9 @@ export function chainFromWire(wire) {
  * Surface resolution follows the utils convention
  * (`typeof network.enter === 'function' ? network : network._network`).
  *
- * @param {(Kernel|Network|Channel)} network - any surface exposing `enter`
- *        (or a Kernel exposing `_network`)
+ * @param {NetworkSurface} network - any surface exposing `enter` (a
+ *        `Network` or `Channel`) or a Kernel-shaped wrapper exposing
+ *        `_network`
  * @param {Object} tao - trigram (short or long keys; long-form keys win)
  * @param {*} data - datagram(s)
  * @param {(WireEnvelope|undefined)} wire - the received `{ v, chain }` wire
@@ -113,13 +126,15 @@ export function enterFromWire(network, tao, data, wire, sourceName) {
  * semantics. For a veto-respecting emitter (e.g. a per-client reply path),
  * decorate with `onProceed` directly — see `@tao.js/socket.io`.
  *
- * @param {(Kernel|Network)} kernel - the network to bridge. Not a Channel:
- *        a duplex transport spans the whole kernel; channel-scoped reply
- *        paths belong to phase-gated emitters (see `@tao.js/socket.io`)
- * @param {Object} opts
+ * @param {NetworkSurface} kernel - the Kernel (or bare Network) to bridge.
+ *        Not a Channel: a duplex transport spans the whole kernel;
+ *        channel-scoped reply paths belong to phase-gated emitters (see
+ *        `@tao.js/socket.io`)
+ * @param {Object} [opts]
  * @param {string} [opts.name] - origin-marker name (auto-generated if omitted)
- * @param {function(Object, *, WireEnvelope): void} opts.send -
- *        `(tao, data, wire) => void` outbound emitter
+ * @param {function(Object, *, WireEnvelope): void} [opts.send] -
+ *        `(tao, data, wire) => void` outbound emitter (required at runtime:
+ *        omitting it throws the setup Error below)
  * @returns {{ name: string, receive: function(Object, *, WireEnvelope=): void, dispose: function(): void }}
  *          the transport handle: `name` is the origin marker, `receive`
  *          enters an inbound signal (as `enterFromWire`), `dispose`

--- a/packages/tao-utils/tsconfig.types.json
+++ b/packages/tao-utils/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../config/tsconfig.types.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": ["src"]
+}

--- a/packages/tao/package.json
+++ b/packages/tao/package.json
@@ -10,6 +10,7 @@
   },
   "main": "lib",
   "module": "dist",
+  "types": "lib/index.d.ts",
   "bundles": {
     "browser": "bundles/browser.umd.js"
   },
@@ -25,7 +26,8 @@
   "scripts": {
     "build:clean": "rimraf dist lib bundles",
     "build:package": "rollup --config",
-    "build": "npm run build:clean && npm run build:package",
+    "build:types": "tsc -p tsconfig.types.json",
+    "build": "npm run build:clean && npm run build:package && npm run build:types",
     "test:mutation": "stryker run"
   },
   "author": "eudaimos",

--- a/packages/tao/src/AppCtx.js
+++ b/packages/tao/src/AppCtx.js
@@ -1,5 +1,18 @@
 import AppCtxRoot from './AppCtxRoot';
 
+/**
+ * Build the datum object from constructor data args: a single array spreads
+ * as positional `[term, action, orient]` data; a single non-array object is
+ * checked for tuple keys (`term`/`t`, `action`/`a`, `orient`/`o`, or the
+ * actual part names) and extracted per part when found, otherwise keyed
+ * whole under the term name; multiple args are positional per part.
+ *
+ * @param {string} term - the trigram's term (datum key for term data)
+ * @param {string} action - the trigram's action (datum key for action data)
+ * @param {string} orient - the trigram's orient (datum key for orient data)
+ * @param {...*} data - the raw data args
+ * @returns {Object} datum keyed by the trigram's part names (may be empty)
+ */
 function _cleanDatum(term, action, orient, ...data) {
   const datum = {};
   // Stryker disable next-line all: empty data still yields {} via the positional path below
@@ -104,7 +117,21 @@ function _cleanDatum(term, action, orient, ...data) {
 //   }
 // }
 
+/**
+ * A concrete Application Context (AppCon): a trigram plus the data it
+ * carries. Setting an AppCtx on a Kernel/Network runs matching handlers,
+ * which receive `(tao, data)` built from this instance; handlers chain by
+ * returning another AppCtx.
+ */
 export default class AppCtx extends AppCtxRoot {
+  /**
+   * @param {string} [term] - the thing (missing = WILDCARD)
+   * @param {string} [action] - the operation (missing = WILDCARD)
+   * @param {string} [orient] - the perspective (missing = WILDCARD)
+   * @param {...*} data - context data; see `_cleanDatum` for the inference
+   *        rules (single object → tuple-key extraction or keyed under the
+   *        term name; array or multiple args → positional per part)
+   */
   constructor(term, action, orient, ...data) {
     super(term, action, orient);
     // TODO: figure out how to deal with associated AppCon data <-- what did I mean by this?
@@ -112,10 +139,17 @@ export default class AppCtx extends AppCtxRoot {
     this.datum = _cleanDatum(term, action, orient, ...data);
   }
 
+  /** The context's data — always an object, possibly empty. @returns {Object} */
   get data() {
     return this.datum;
   }
 
+  /**
+   * The trigram as a plain object.
+   * @param {boolean} [verbose=false] - long keys (`{term, action, orient}`)
+   *        instead of short (`{t, a, o}`)
+   * @returns {{t: string, a: string, o: string}|{term: string, action: string, orient: string}}
+   */
   unwrapCtx(verbose = false) {
     return !verbose
       ? { t: this.t, a: this.a, o: this.o }

--- a/packages/tao/src/AppCtxHandlers.js
+++ b/packages/tao/src/AppCtxHandlers.js
@@ -3,12 +3,45 @@ import AppCtx from './AppCtx';
 import { INTERCEPT, ASYNC, INLINE, ERROR } from './constants';
 import { isIterable } from './utils';
 
+/** @typedef {import('./Network').Forward} Forward */
+
+/**
+ * A TAO handler: receives the concrete trigram (short keys) and the
+ * signal's data (always an object, possibly empty). Returning — or
+ * resolving to — an AppCtx chains that context onto the cascade. Other
+ * returns are phase-dependent: a truthy intercept return halts the signal;
+ * non-null async/inline returns go to settlement (`onReturn`) when hooks
+ * are attached, and are otherwise discarded.
+ *
+ * @callback Handler
+ * @param {{t: string, a: string, o: string}} tao - the trigram being handled
+ * @param {Object} data - the context data (never null/undefined)
+ * @returns {AppCtx|Promise<AppCtx>|*}
+ */
+
+/**
+ * Local no-op console standing in for the loop's debug logging.
+ * @type {{error: (...args: any[]) => void, log: (...args: any[]) => void}}
+ */
 const console = {
   error: () => 1,
   log: () => 1,
 };
 
+/**
+ * The handler group for one trigram key: holds the intercept/async/inline
+ * handler sets and runs the three-phase dispatch for matching AppCons.
+ * Wildcard groups track their concrete "leaf" groups and propagate handler
+ * add/remove to them, so dispatch only ever executes a concrete group.
+ */
 export default class AppCtxHandlers extends AppCtxRoot {
+  /**
+   * @param {string} [term] - the term (missing = WILDCARD)
+   * @param {string} [action] - the action (missing = WILDCARD)
+   * @param {string} [orient] - the orient (missing = WILDCARD)
+   * @param {Iterable<AppCtxHandlers>} [leafAppConHandlers] - initial concrete
+   *        leaf groups this (wildcard) group propagates its handlers to
+   */
   constructor(term, action, orient, leafAppConHandlers) {
     super(term, action, orient);
 
@@ -18,6 +51,13 @@ export default class AppCtxHandlers extends AppCtxRoot {
     this._inline = new Set();
   }
 
+  /**
+   * Track a concrete leaf group under this wildcard group (no-op unless this
+   * group is wild, the leaf is concrete, and the leaf matches this trigram)
+   * and copy this group's current handlers onto it.
+   * @param {AppCtxHandlers} leafAch
+   * @throws {Error} when `leafAch` is not an AppCtxHandlers
+   */
   addLeafHandler(leafAch) {
     if (!(leafAch instanceof AppCtxHandlers)) {
       throw new Error("'leafAch' is not an instance of AppCtxHandlers");
@@ -39,6 +79,10 @@ export default class AppCtxHandlers extends AppCtxRoot {
     }
   }
 
+  /**
+   * Add one leaf group or an iterable of them via {@link AppCtxHandlers#addLeafHandler}.
+   * @param {AppCtxHandlers|Iterable<AppCtxHandlers>} leafAches
+   */
   addLeafHandlers(leafAches) {
     if (!isIterable(leafAches)) {
       this.addLeafHandler(leafAches);
@@ -49,6 +93,11 @@ export default class AppCtxHandlers extends AppCtxRoot {
     }
   }
 
+  /**
+   * Register an intercept-phase handler (propagates to leaf groups).
+   * @param {Handler} handler
+   * @throws {Error} when `handler` is not a function
+   */
   addInterceptHandler(handler) {
     if (typeof handler !== 'function') {
       throw new Error('An InterceptHandler can only be a function');
@@ -59,6 +108,10 @@ export default class AppCtxHandlers extends AppCtxRoot {
     );
   }
 
+  /**
+   * Unregister an intercept-phase handler (propagates to leaf groups).
+   * @param {Handler} handler
+   */
   removeInterceptHandler(handler) {
     this._intercept.delete(handler);
     this._leafAppConHandlers.forEach((leafAch) =>
@@ -66,6 +119,11 @@ export default class AppCtxHandlers extends AppCtxRoot {
     );
   }
 
+  /**
+   * Register an async-phase handler (propagates to leaf groups).
+   * @param {Handler} handler
+   * @throws {Error} when `handler` is not a function
+   */
   addAsyncHandler(handler) {
     if (typeof handler !== 'function') {
       throw new Error('An AsyncHandler can only be a function');
@@ -76,6 +134,10 @@ export default class AppCtxHandlers extends AppCtxRoot {
     );
   }
 
+  /**
+   * Unregister an async-phase handler (propagates to leaf groups).
+   * @param {Handler} handler
+   */
   removeAsyncHandler(handler) {
     this._async.delete(handler);
     this._leafAppConHandlers.forEach((leafAch) =>
@@ -83,6 +145,11 @@ export default class AppCtxHandlers extends AppCtxRoot {
     );
   }
 
+  /**
+   * Register an inline-phase handler (propagates to leaf groups).
+   * @param {Handler} handler
+   * @throws {Error} when `handler` is not a function
+   */
   addInlineHandler(handler) {
     if (typeof handler !== 'function') {
       throw new Error('An InlineHandler can only be a function');
@@ -93,6 +160,10 @@ export default class AppCtxHandlers extends AppCtxRoot {
     );
   }
 
+  /**
+   * Unregister an inline-phase handler (propagates to leaf groups).
+   * @param {Handler} handler
+   */
   removeInlineHandler(handler) {
     this._inline.delete(handler);
     this._leafAppConHandlers.forEach((leafAch) =>
@@ -103,14 +174,17 @@ export default class AppCtxHandlers extends AppCtxRoot {
   // Might need but removing to have accurate code coverage metric
   // populateHandlersFromWildcards() {}
 
+  /** The registered intercept handlers. @returns {IterableIterator<Handler>} */
   get interceptHandlers() {
     return this._intercept.values();
   }
 
+  /** The registered async handlers. @returns {IterableIterator<Handler>} */
   get asyncHandlers() {
     return this._async.values();
   }
 
+  /** The registered inline handlers. @returns {IterableIterator<Handler>} */
   get inlineHandlers() {
     return this._inline.values();
   }
@@ -129,6 +203,18 @@ export default class AppCtxHandlers extends AppCtxRoot {
    *
    * `setAppCtx` receives the producing phase as a third argument so the
    * hop engine can stamp `hop.via` on chained hops (§4).
+   *
+   * @param {AppCtx} ac - the Application Context to handle
+   * @param {Forward} setAppCtx - continuation for handler-chained AppCtxs
+   *        (the hop engine's forward, or an adapter override); called as
+   *        `setAppCtx(nextAc, control, phase)`
+   * @param {Object} control - the cascade scope (`envelope.cascade`), passed
+   *        through to `setAppCtx`
+   * @param {{onReturn?: (phase: string, value: any, ac: AppCtx) => void, onProceed?: () => void}} [hooks]
+   *        settlement hooks built by the Network from decorations
+   * @returns {Promise<void>} settles after the intercept and inline phases
+   *        complete (async handlers are forked, not awaited); rejects on a
+   *        dispatch error only when no `onReturn` hook is present
    */
   async handleAppCon(ac, setAppCtx, control, hooks) {
     const { t, a, o, data } = ac;
@@ -157,6 +243,21 @@ export default class AppCtxHandlers extends AppCtxRoot {
     }
   }
 
+  /**
+   * Run the three phases in order: await intercepts (halt/divert
+   * short-circuits), fork async handlers, await inline handlers, settle
+   * inline returns, then set the spooled chained AppCtxs.
+   *
+   * @param {AppCtx} ac - the Application Context being handled
+   * @param {Forward} setAppCtx - continuation for chained AppCtxs
+   * @param {Object} control - the cascade scope, threaded to `setAppCtx`
+   * @param {((phase: string, value: any, ac: AppCtx) => void)|null} onReturn - settlement sink
+   * @param {(() => void)|null} onProceed - intercept-phase-passed hook
+   * @param {string} t - the term (from `ac`)
+   * @param {string} a - the action (from `ac`)
+   * @param {string} o - the orient (from `ac`)
+   * @param {Object} data - the context data (from `ac`)
+   */
   async _handlePhases(
     ac,
     setAppCtx,

--- a/packages/tao/src/AppCtxRoot.js
+++ b/packages/tao/src/AppCtxRoot.js
@@ -1,36 +1,83 @@
 import { WILDCARD } from './constants';
 
+/**
+ * A trigram names an Application Context: the thing (term), the operation on
+ * it (action), and the perspective of the interaction (orient). Short
+ * (`t`/`a`/`o`) and long (`term`/`action`/`orient`) keys are interchangeable
+ * — supply one style per part. A missing, empty, or `'*'` part is a wildcard.
+ *
+ * @typedef {Object} Trigram
+ * @property {string} [t] - the term (short key)
+ * @property {string} [term] - the term: the domain thing
+ * @property {string} [a] - the action (short key)
+ * @property {string} [action] - the action: the operation on the term
+ * @property {string} [o] - the orient (short key)
+ * @property {string} [orient] - the orient: perspective / role / surface
+ */
+
+/**
+ * Whether a single trigram part is wild (missing, empty, or the WILDCARD).
+ * @param {string} [val] - the trigram part
+ * @returns {boolean}
+ */
 function isPartWild(val) {
   return !val || WILDCARD === val;
 }
 
+/**
+ * Base of the trigram-keyed classes: holds the three parts (missing parts
+ * become WILDCARD) and answers wildcard / matching questions. Key format:
+ * `` `${term}|${action}|${orient}` ``.
+ */
 export default class AppCtxRoot {
+  /**
+   * @param {string} [term] - the term (missing = WILDCARD)
+   * @param {string} [action] - the action (missing = WILDCARD)
+   * @param {string} [orient] - the orient (missing = WILDCARD)
+   */
   constructor(term, action, orient) {
     this._term = term || WILDCARD;
     this._action = action || WILDCARD;
     this._orient = orient || WILDCARD;
   }
 
+  /** The `term|action|orient` key for this trigram. @returns {string} */
   get key() {
     return AppCtxRoot.getKey(this._term, this._action, this._orient);
   }
 
+  /** The term. @returns {string} */
   get t() {
     return this._term;
   }
 
+  /** The action. @returns {string} */
   get a() {
     return this._action;
   }
 
+  /** The orient. @returns {string} */
   get o() {
     return this._orient;
   }
 
+  /**
+   * Build the `term|action|orient` key; missing parts become WILDCARD.
+   * @param {string} [term]
+   * @param {string} [action]
+   * @param {string} [orient]
+   * @returns {string}
+   */
   static getKey(term, action, orient) {
     return `${term || WILDCARD}|${action || WILDCARD}|${orient || WILDCARD}`;
   }
 
+  /**
+   * Whether any part of a trigram is wild (missing, empty, or WILDCARD).
+   * Both key styles are accepted; short keys win when both are present.
+   * @param {Trigram} [ac]
+   * @returns {boolean}
+   */
   // static isWildcard({ term = WILDCARD, action = WILDCARD, orient = WILDCARD } = {}) {
   static isWildcard(ac = {}) {
     const { t, term, a, action, o, orient } = ac;
@@ -50,10 +97,26 @@ export default class AppCtxRoot {
     );
   }
 
+  /**
+   * Whether every part of a trigram is concrete (no wildcards).
+   * @param {Trigram} [ac]
+   * @returns {boolean}
+   */
   static isConcrete(ac = {}) {
     return !AppCtxRoot.isWildcard(ac);
   }
 
+  /**
+   * Whether an AppCtx(-like) matches a trigram, honoring wildcards on both
+   * sides unless `exact`. NOTE: `trigram` is read with short keys
+   * (`t`/`a`/`o`) only — long keys are not consulted here, so a
+   * long-key-only trigram is treated as all-wild.
+   *
+   * @param {AppCtxRoot|Trigram} ac - the context being tested (both key styles accepted)
+   * @param {{t: (string|undefined), a: (string|undefined), o: (string|undefined)}} trigram - the trigram to match against (short keys only)
+   * @param {boolean} [exact=false] - require exact key equality (wildcards only match wildcards)
+   * @returns {boolean}
+   */
   // TODO: write TESTS for this
   static isMatch(ac, trigram, exact = false) {
     // Stryker disable next-line ConditionalExpression: re-wrapping an AppCtxRoot is observationally identical
@@ -79,26 +142,37 @@ export default class AppCtxRoot {
     return matchTerm && matchAction && matchOrient;
   }
 
+  /** Whether the term is wild. @returns {boolean} */
   get isTermWild() {
     return isPartWild(this._term);
   }
 
+  /** Whether the action is wild. @returns {boolean} */
   get isActionWild() {
     return isPartWild(this._action);
   }
 
+  /** Whether the orient is wild. @returns {boolean} */
   get isOrientWild() {
     return isPartWild(this._orient);
   }
 
+  /** Whether any part is wild. @returns {boolean} */
   get isWildcard() {
     return this.isTermWild || this.isActionWild || this.isOrientWild;
   }
 
+  /** Whether every part is concrete. @returns {boolean} */
   get isConcrete() {
     return !this.isWildcard;
   }
 
+  /**
+   * Instance form of {@link AppCtxRoot.isMatch} with this as the context.
+   * @param {{t: (string|undefined), a: (string|undefined), o: (string|undefined)}} trigram - the trigram to match against (short keys only)
+   * @param {boolean} [exact=false]
+   * @returns {boolean}
+   */
   isMatch(trigram, exact = false) {
     return AppCtxRoot.isMatch(this, trigram, exact);
   }

--- a/packages/tao/src/AppCtxRoot.js
+++ b/packages/tao/src/AppCtxRoot.js
@@ -120,25 +120,22 @@ export default class AppCtxRoot {
   // TODO: write TESTS for this
   static isMatch(ac, trigram, exact = false) {
     // Stryker disable next-line ConditionalExpression: re-wrapping an AppCtxRoot is observationally identical
-    if (!(ac instanceof AppCtxRoot)) {
-      ac = new AppCtxRoot(
-        ac.t || ac.term,
-        ac.a || ac.action,
-        ac.o || ac.orient,
-      );
-    }
-    if (ac.key === AppCtxRoot.getKey(trigram.t, trigram.a, trigram.o)) {
+    const root =
+      ac instanceof AppCtxRoot
+        ? ac
+        : new AppCtxRoot(ac.t || ac.term, ac.a || ac.action, ac.o || ac.orient);
+    if (root.key === AppCtxRoot.getKey(trigram.t, trigram.a, trigram.o)) {
       return true;
     }
     if (exact) {
       return false;
     }
     const matchTerm =
-      ac.isTermWild || isPartWild(trigram.t) || ac.t === trigram.t;
+      root.isTermWild || isPartWild(trigram.t) || root.t === trigram.t;
     const matchAction =
-      ac.isActionWild || isPartWild(trigram.a) || ac.a === trigram.a;
+      root.isActionWild || isPartWild(trigram.a) || root.a === trigram.a;
     const matchOrient =
-      ac.isOrientWild || isPartWild(trigram.o) || ac.o === trigram.o;
+      root.isOrientWild || isPartWild(trigram.o) || root.o === trigram.o;
     return matchTerm && matchAction && matchOrient;
   }
 

--- a/packages/tao/src/Kernel.js
+++ b/packages/tao/src/Kernel.js
@@ -3,16 +3,38 @@ import AppCtxRoot from './AppCtxRoot';
 import AppCtx from './AppCtx';
 import { _cleanAC } from './utils';
 
+/** @typedef {import('./AppCtxRoot').Trigram} Trigram */
+/** @typedef {import('./AppCtxHandlers').Handler} Handler */
+
+/**
+ * The app-facing veneer over a Network: signal Application Contexts
+ * (`setCtx` / `setAppCtx`) and register handlers in the three phases
+ * (intercept / async / inline). The default export of @tao.js/core is a
+ * shared Kernel instance (`TAO`); create your own for isolation.
+ */
 export default class Kernel {
+  /**
+   * @param {boolean} [canSetWildcard=false] - allow wildcard AppCtxs to be
+   *        set on (and chained within) this kernel; otherwise they are
+   *        silently ignored
+   */
   constructor(canSetWildcard = false) {
     this._network = new Network(canSetWildcard);
     this._canSetWildcard = canSetWildcard;
   }
 
+  /** Whether wildcard AppCtxs may be set on this kernel. @returns {boolean} */
   get canSetWildcard() {
     return this._canSetWildcard;
   }
 
+  /**
+   * An independent Kernel whose Network has every handler registration
+   * copied; decorations on the underlying Network are not copied.
+   * @param {boolean} [canSetWildcard] - override for the clone; defaults to
+   *        this kernel's setting
+   * @returns {Kernel}
+   */
   clone(canSetWildcard) {
     const cloned = new Kernel(
       typeof canSetWildcard !== 'undefined'
@@ -23,6 +45,15 @@ export default class Kernel {
     return cloned;
   }
 
+  /**
+   * Signal an Application Context from trigram parts plus data. Wildcard
+   * trigrams are silently ignored unless the kernel `canSetWildcard`.
+   * @param {Trigram} trigram - both key styles accepted; long keys win
+   * @param {*} [data] - context data; a single object is keyed per the
+   *        AppCtx datum inference rules, an array is positional
+   *        `[term, action, orient]` data
+   * @returns {void}
+   */
   setCtx({ t, term, a, action, o, orient }, data) {
     // get the hash for the ac
     const acIn = _cleanAC({ t, term, a, action, o, orient });
@@ -34,6 +65,13 @@ export default class Kernel {
     this._network.enter(new AppCtx(acIn.term, acIn.action, acIn.orient, data));
   }
 
+  /**
+   * Signal an already-constructed AppCtx. Wildcard AppCtxs are silently
+   * ignored unless the kernel `canSetWildcard`.
+   * @param {AppCtx} appCtx
+   * @returns {void}
+   * @throws {Error} when `appCtx` is not an AppCtx instance
+   */
   setAppCtx(appCtx) {
     // Stryker disable next-line all: Network.enter throws the same error
     if (!(appCtx instanceof AppCtx)) {
@@ -47,6 +85,15 @@ export default class Kernel {
     this._network.enter(appCtx);
   }
 
+  /**
+   * Register an intercept-phase handler: runs first; a truthy return halts
+   * the signal, an AppCtx return diverts it. Omitted trigram parts are
+   * wildcards.
+   * @param {Trigram} trigram
+   * @param {Handler} handler
+   * @returns {Kernel} this
+   * @throws {Error} when `handler` is missing or not a function
+   */
   addInterceptHandler({ t, term, a, action, o, orient }, handler) {
     this._network.addInterceptHandler(
       { t, term, a, action, o, orient },
@@ -55,16 +102,41 @@ export default class Kernel {
     return this;
   }
 
+  /**
+   * Register an async-phase handler: forked outside the caller's
+   * synchronous flow after intercepts pass; may return an AppCtx to chain.
+   * Omitted trigram parts are wildcards.
+   * @param {Trigram} trigram
+   * @param {Handler} handler
+   * @returns {Kernel} this
+   * @throws {Error} when `handler` is missing or not a function
+   */
   addAsyncHandler({ t, term, a, action, o, orient }, handler) {
     this._network.addAsyncHandler({ t, term, a, action, o, orient }, handler);
     return this;
   }
 
+  /**
+   * Register an inline-phase handler: runs in the caller's execution
+   * context after async handlers are forked; returned AppCtxs are spooled,
+   * then set. Omitted trigram parts are wildcards.
+   * @param {Trigram} trigram
+   * @param {Handler} handler
+   * @returns {Kernel} this
+   * @throws {Error} when `handler` is missing or not a function
+   */
   addInlineHandler({ t, term, a, action, o, orient }, handler) {
     this._network.addInlineHandler({ t, term, a, action, o, orient }, handler);
     return this;
   }
 
+  /**
+   * Unregister an intercept-phase handler for a trigram.
+   * @param {Trigram} trigram
+   * @param {Handler} handler
+   * @returns {Kernel} this
+   * @throws {Error} when `handler` is missing or not a function
+   */
   removeInterceptHandler({ t, term, a, action, o, orient }, handler) {
     this._network.removeInterceptHandler(
       { t, term, a, action, o, orient },
@@ -73,6 +145,13 @@ export default class Kernel {
     return this;
   }
 
+  /**
+   * Unregister an async-phase handler for a trigram.
+   * @param {Trigram} trigram
+   * @param {Handler} handler
+   * @returns {Kernel} this
+   * @throws {Error} when `handler` is missing or not a function
+   */
   removeAsyncHandler({ t, term, a, action, o, orient }, handler) {
     this._network.removeAsyncHandler(
       { t, term, a, action, o, orient },
@@ -81,6 +160,13 @@ export default class Kernel {
     return this;
   }
 
+  /**
+   * Unregister an inline-phase handler for a trigram.
+   * @param {Trigram} trigram
+   * @param {Handler} handler
+   * @returns {Kernel} this
+   * @throws {Error} when `handler` is missing or not a function
+   */
   removeInlineHandler({ t, term, a, action, o, orient }, handler) {
     this._network.removeInlineHandler(
       { t, term, a, action, o, orient },

--- a/packages/tao/src/Network.js
+++ b/packages/tao/src/Network.js
@@ -4,7 +4,83 @@ import AppCtx from './AppCtx';
 import AppCtxHandlers from './AppCtxHandlers';
 import { _cleanAC, _validateHandler } from './utils';
 
+/** @typedef {import('./AppCtxRoot').Trigram} Trigram */
+/** @typedef {import('./AppCtxHandlers').Handler} Handler */
+
+/**
+ * The per-dispatch envelope (ENVELOPE-SPEC.md §4): three scopes with
+ * explicit lifetimes. Handlers never see it — only decorations and
+ * adapters do.
+ *
+ * @typedef {Object} Envelope
+ * @property {Object} cascade - cascade lifetime: one shared mutable
+ *           reference for the whole cascade (the `control` object).
+ *           Adapter affinity keys (`channelId`, transponder
+ *           `signal`/`signalled`, …) live here as top-level properties.
+ *           Never crosses a process boundary
+ * @property {Object} hop - single-hop lifetime, replaced on every hop:
+ *           entry hops carry caller-supplied values (e.g. `Source`'s
+ *           `source` echo-suppression marker) and never `via`; chained
+ *           hops carry `{ via }` — the phase constant that produced them.
+ *           Boundary-local
+ * @property {Object} chain - derived parent→child on each hop by the
+ *           registered reducers, keyed by reducer namespace.
+ *           JSON-serializable by design — the only scope that crosses a
+ *           process boundary (§9)
+ */
+
+/**
+ * Continuation that chains an AppCtx onto the current cascade — the hop
+ * engine's own forward, or the `enter()`/`mirror()` override. Handler
+ * returns are handed to it by `AppCtxHandlers.handleAppCon`; non-AppCtx
+ * values are ignored, and wildcard AppCtxs are dropped unless the network
+ * allows wildcards (parity with `Kernel.setAppCtx`).
+ *
+ * @callback Forward
+ * @param {AppCtx} chainedAc - the AppCtx to dispatch as the next hop
+ * @param {Object} [control] - legacy call-shape parity; ignored by the core
+ *        forward (the cascade is already threaded via the envelope)
+ * @param {string} [via] - the producing phase constant, stamped as
+ *        `hop.via` on the chained hop
+ * @returns {void}
+ */
+
+/**
+ * An additive, non-competitive Network decoration (ENVELOPE-SPEC.md §5).
+ * All capabilities are optional but at least one is required; a throwing
+ * decoration callback never breaks dispatch.
+ *
+ * @typedef {Object} DecorationSpec
+ * @property {string} [name] - diagnostic label
+ * @property {(ac: AppCtx, envelope: Envelope, handler: AppCtxHandlers, forward: Forward) => void} [onDispatch]
+ *           observe every dispatch; `forward(chainedAc)` continues this
+ *           hop's cascade through the core hop engine
+ * @property {(nextAc: AppCtx, envelope: Envelope, meta: {from: Envelope, forward: Forward}) => void} [onForward]
+ *           mirror/route a chained AppCon before core dispatches it;
+ *           `meta.from` is the producing hop's envelope and
+ *           `meta.forward(chainedAc)` continues the cascade from the
+ *           chained hop; must never re-enter the main dispatch
+ * @property {(phase: string, value: any, ac: AppCtx, envelope: Envelope) => void} [onReturn]
+ *           settle non-AppCtx handler returns and errors (phase is one of
+ *           the INTERCEPT/ASYNC/INLINE/ERROR constants)
+ * @property {(ac: AppCtx, envelope: Envelope) => void} [onProceed]
+ *           fires when the intercept phase passes without halting or
+ *           diverting, before async/inline run (veto-respecting emitters)
+ * @property {{key: string, next: (prev: any, ac: AppCtx, prevEnvelope: Envelope | null) => any}} [chain]
+ *           per-hop reducer for `envelope.chain[key]`; `next(prev, ac,
+ *           prevEnvelope)` receives the parent hop's value for `key` and
+ *           the parent hop's envelope (both empty/null at entry). Keys are
+ *           exclusive per network
+ */
+
 // Stryker disable all: multi-axis leaf/wildcard indexing is redundant; single-axis mutants are equivalent
+/**
+ * Collect leaf groups from one axis index into `leavesTo` — the groups
+ * under `taoism`, or every group when the part is wild.
+ * @param {Map<string, Set<AppCtxHandlers>>} leavesFrom - one axis of the leaf index
+ * @param {Set<AppCtxHandlers>} leavesTo - accumulator
+ * @param {string} [taoism] - the trigram part value (falsy = wild)
+ */
 function _appendLeaves(leavesFrom, leavesTo, taoism) {
   if (taoism) {
     if (leavesFrom.has(taoism) && leavesFrom.get(taoism).size) {
@@ -17,6 +93,13 @@ function _appendLeaves(leavesFrom, leavesTo, taoism) {
   }
 }
 
+/**
+ * Collect wildcard groups from one axis index into `wildcardsTo` — the
+ * groups under `taoism` plus the groups indexed under WILDCARD itself.
+ * @param {Map<string, Set<AppCtxHandlers>>} wildcardsFrom - one axis of the wildcard index
+ * @param {Set<AppCtxHandlers>} wildcardsTo - accumulator
+ * @param {string} taoism - the trigram part value
+ */
 function _appendWildcards(wildcardsFrom, wildcardsTo, taoism) {
   if (wildcardsFrom.has(taoism)) {
     wildcardsFrom.get(taoism).forEach((wc) => wildcardsTo.add(wc));
@@ -26,6 +109,12 @@ function _appendWildcards(wildcardsFrom, wildcardsTo, taoism) {
   }
 }
 
+/**
+ * Index a concrete group under one axis value of the leaf index.
+ * @param {Map<string, Set<AppCtxHandlers>>} leaves - one axis of the leaf index
+ * @param {string} taoism - the trigram part value
+ * @param {AppCtxHandlers} ach - the concrete group
+ */
 function _addLeaf(leaves, taoism, ach) {
   if (!leaves.has(taoism)) {
     leaves.set(taoism, new Set());
@@ -34,6 +123,12 @@ function _addLeaf(leaves, taoism, ach) {
 }
 // Stryker restore all
 
+/**
+ * Index a wildcard group under one axis value of the wildcard index.
+ * @param {Map<string, Set<AppCtxHandlers>>} wildcards - one axis of the wildcard index
+ * @param {string} taoism - the trigram part value (WILDCARD for a wild part)
+ * @param {AppCtxHandlers} ach - the wildcard group
+ */
 function _addWildcard(wildcards, taoism, ach) {
   if (!wildcards.has(taoism)) {
     wildcards.set(taoism, new Set());
@@ -41,6 +136,17 @@ function _addWildcard(wildcards, taoism, ach) {
   wildcards.get(taoism).add(ach);
 }
 
+/**
+ * Get or create the AppCtxHandlers group for a trigram, wiring the
+ * wildcard↔leaf cross-links on creation (a new wildcard group adopts all
+ * matching leaves; a new concrete group is adopted by matching wildcards).
+ * @param {Network} tao - the owning network (unused; kept for call-shape)
+ * @param {Map<string, AppCtxHandlers>} taoHandlers - groups by trigram key
+ * @param {{t: Map, a: Map, o: Map}} taoLeaves - per-axis leaf index
+ * @param {{t: Map, a: Map, o: Map}} taoWildcards - per-axis wildcard index
+ * @param {{term: (string|undefined), action: (string|undefined), orient: (string|undefined)}} trigram - long-key trigram (from `_cleanAC`)
+ * @returns {AppCtxHandlers}
+ */
 function _addACHandler(
   tao,
   taoHandlers,
@@ -86,6 +192,14 @@ function _addACHandler(
   return ach;
 }
 
+/**
+ * Remove a handler of the given phase from the group for a trigram, if
+ * that group exists.
+ * @param {Map<string, AppCtxHandlers>} taoHandlers - groups by trigram key
+ * @param {{term: (string|undefined), action: (string|undefined), orient: (string|undefined)}} trigram - long-key trigram (from `_cleanAC`)
+ * @param {Handler} handler
+ * @param {string} type - INTERCEPT, ASYNC, or INLINE constant
+ */
 function _removeHandler(taoHandlers, { term, action, orient }, handler, type) {
   _validateHandler(handler);
   // guard is currently impossible to hit so removing to get 100% test coverage
@@ -113,7 +227,19 @@ function _removeHandler(taoHandlers, { term, action, orient }, handler, type) {
 //   );
 // }
 
+/**
+ * The wiring surface of the TAO: a trigram-indexed handler registry plus
+ * the envelope hop engine. `enter()` is the only dispatch gate and
+ * `decorate()` the only extension surface (ENVELOPE-SPEC.md). Application
+ * code should use a Kernel; adapters (utils, bridges) compose against the
+ * Network.
+ */
 export default class Network {
+  /**
+   * @param {boolean} [canSetWildcard=false] - allow wildcard AppCtxs
+   *        chained by handlers to dispatch (parity with the owning
+   *        Kernel's setting); coerced to boolean
+   */
   constructor(canSetWildcard = false) {
     this._handlers = new Map();
     this._leaves = {
@@ -152,7 +278,10 @@ export default class Network {
    *
    * A throwing decorator callback never breaks dispatch.
    *
-   * @returns {function} dispose - removes the decoration
+   * @param {DecorationSpec} spec
+   * @returns {() => void} dispose - removes the decoration
+   * @throws {Error} on a malformed spec, a spec with no capability, or a
+   *         `chain.key` already reduced on this network
    * @memberof Network
    */
   decorate(spec) {
@@ -218,14 +347,17 @@ export default class Network {
    * @param {Object} [opts]
    * @param {Object} [opts.cascade] - shared for the whole cascade (the
    *        `control` object; same reference every hop)
-   * @param {Object} [opts.hop] - entry-hop values; hops after the entry get {}
-   * @param {Object} [opts.chain] - prior chain state to continue (e.g. from a
-   *        remote process); reducers derive the entry's chain from it
-   * @param {function} [opts.forward] - network-composition plumbing: routes
+   * @param {Object} [opts.hop] - entry-hop values; hops after the entry get
+   *        a fresh hop carrying only `via` (the producing phase)
+   * @param {?Object} [opts.chain] - prior chain state to continue (e.g.
+   *        from a remote process); reducers derive the entry's chain from it
+   * @param {Forward} [opts.forward] - network-composition plumbing: routes
    *        handler-returned AppCons to the given continuation instead of this
    *        network's own hop engine. Used by adapters that mirror a cascade
    *        onto a private network while its chains continue on the main one
    *        (Channel, Transceiver); not an application-level surface
+   * @returns {void}
+   * @throws {Error} when `appCtx` is not an AppCtx instance
    * @memberof Network
    */
   enter(appCtx, { cascade = {}, hop = {}, chain = null, forward } = {}) {
@@ -252,8 +384,10 @@ export default class Network {
    * should follow (normally the mirroring hop's `meta.forward`).
    *
    * @param {AppCtx} appCtx
-   * @param {Object} envelope - the observed `{ cascade, hop, chain }`
-   * @param {function} [forward]
+   * @param {Envelope} envelope - the observed `{ cascade, hop, chain }`
+   * @param {Forward} [forward]
+   * @returns {void}
+   * @throws {Error} when `appCtx` is not an AppCtx or `envelope` is missing
    * @memberof Network
    */
   mirror(appCtx, envelope, forward) {
@@ -270,6 +404,14 @@ export default class Network {
     );
   }
 
+  /**
+   * Run one hop: resolve (or lazily create) the handler group for the
+   * AppCtx's key, notify `onDispatch` decorations, then execute the phases.
+   * @param {AppCtx} appCtx
+   * @param {Envelope} envelope - this hop's envelope
+   * @param {Forward} [forward] - continuation override for chained AppCtxs;
+   *        defaults to this network's hop engine
+   */
   _dispatch(appCtx, envelope, forward) {
     const isWild = appCtx.isWildcard;
     if (!this._handlers.has(appCtx.key) && !isWild) {
@@ -293,6 +435,14 @@ export default class Network {
     handler.handleAppCon(appCtx, coreForward, envelope.cascade, hooks);
   }
 
+  /**
+   * The hop engine: derive the chained hop's envelope (shared cascade,
+   * `{ via }` hop, reduced chain), notify `onForward` decorations, then
+   * dispatch the chained AppCtx exactly once.
+   * @param {AppCtx} nextAc - the chained AppCtx (non-AppCtx values ignored)
+   * @param {Envelope} prevEnvelope - the producing hop's envelope
+   * @param {string} [via] - the phase constant that produced the chain
+   */
   _forwardNext(nextAc, prevEnvelope, via) {
     // guard parity with the legacy NOOP forward: handlers may hand the core
     // forward non-AppCtx values
@@ -327,6 +477,15 @@ export default class Network {
     this._dispatch(nextAc, nextEnvelope);
   }
 
+  /**
+   * Derive a hop's chain scope by running every registered reducer against
+   * the parent's value under its own key; a throwing reducer contributes
+   * nothing.
+   * @param {?Object} prevChain - the parent hop's chain (null at entry)
+   * @param {AppCtx} ac - the AppCtx being dispatched
+   * @param {?Envelope} prevEnvelope - the parent hop's envelope (null at entry)
+   * @returns {Object} the new chain, keyed by reducer namespace
+   */
   _reduceChain(prevChain, ac, prevEnvelope) {
     const next = {};
     for (const [key, reduceNext] of this._chainReducers) {
@@ -343,6 +502,15 @@ export default class Network {
     return next;
   }
 
+  /**
+   * Bridge `onReturn`/`onProceed` decorations into the settlement hooks
+   * `AppCtxHandlers.handleAppCon` accepts; undefined when no decoration
+   * needs them. Each decoration call is guarded — a throw never breaks
+   * dispatch.
+   * @param {AppCtx} appCtx - the AppCtx being dispatched
+   * @param {Envelope} envelope - this hop's envelope (appended to each call)
+   * @returns {{onReturn?: (phase: string, value: any, ac: AppCtx) => void, onProceed?: () => void}|undefined}
+   */
   _buildHooks(appCtx, envelope) {
     let settlers = null;
     let proceeders = null;
@@ -393,6 +561,14 @@ export default class Network {
     return hooks;
   }
 
+  /**
+   * Invoke every decoration's `onDispatch` in registration order, guarding
+   * against throws.
+   * @param {AppCtx} appCtx
+   * @param {Envelope} envelope
+   * @param {AppCtxHandlers} handler - the group about to execute
+   * @param {Forward} forward - the continuation for this hop's chains
+   */
   _notifyDispatch(appCtx, envelope, handler, forward) {
     for (const decorator of this._decorators) {
       // Stryker disable next-line ConditionalExpression: equivalent - calling a missing onDispatch throws inside the guarded try, so observable behavior is identical
@@ -406,6 +582,11 @@ export default class Network {
     }
   }
 
+  /**
+   * An independent Network with every handler registration copied across
+   * all three phases. Decorations and chain reducers are not copied.
+   * @returns {Network}
+   */
   clone() {
     const cloned = new Network(this._canSetWildcard);
     for (let trigram of this._handlers.values()) {
@@ -422,6 +603,14 @@ export default class Network {
     return cloned;
   }
 
+  /**
+   * Register an intercept-phase handler for a trigram (omitted parts are
+   * wildcards).
+   * @param {Trigram} trigram
+   * @param {Handler} handler
+   * @returns {Network} this
+   * @throws {Error} when `handler` is missing or not a function
+   */
   addInterceptHandler({ t, term, a, action, o, orient }, handler) {
     _validateHandler(handler);
     const ach = _addACHandler(
@@ -435,6 +624,14 @@ export default class Network {
     return this;
   }
 
+  /**
+   * Register an async-phase handler for a trigram (omitted parts are
+   * wildcards).
+   * @param {Trigram} trigram
+   * @param {Handler} handler
+   * @returns {Network} this
+   * @throws {Error} when `handler` is missing or not a function
+   */
   addAsyncHandler({ t, term, a, action, o, orient }, handler) {
     _validateHandler(handler);
     const ach = _addACHandler(
@@ -448,6 +645,14 @@ export default class Network {
     return this;
   }
 
+  /**
+   * Register an inline-phase handler for a trigram (omitted parts are
+   * wildcards).
+   * @param {Trigram} trigram
+   * @param {Handler} handler
+   * @returns {Network} this
+   * @throws {Error} when `handler` is missing or not a function
+   */
   addInlineHandler({ t, term, a, action, o, orient }, handler) {
     _validateHandler(handler);
     const ach = _addACHandler(
@@ -461,6 +666,15 @@ export default class Network {
     return this;
   }
 
+  /**
+   * Unregister a handler for a trigram from one phase, or from all three
+   * when `type` is omitted.
+   * @param {Trigram} trigram
+   * @param {Handler} handler
+   * @param {string} [type] - INTERCEPT, ASYNC, or INLINE constant
+   * @returns {Network} this
+   * @throws {Error} when `handler` is missing or not a function
+   */
   removeHandler({ t, term, a, action, o, orient }, handler, type) {
     const ac = _cleanAC({ t, term, a, action, o, orient });
     if (type) {
@@ -473,6 +687,13 @@ export default class Network {
     return this;
   }
 
+  /**
+   * Unregister an intercept-phase handler for a trigram.
+   * @param {Trigram} trigram
+   * @param {Handler} handler
+   * @returns {Network} this
+   * @throws {Error} when `handler` is missing or not a function
+   */
   removeInterceptHandler({ t, term, a, action, o, orient }, handler) {
     _removeHandler(
       this._handlers,
@@ -483,6 +704,13 @@ export default class Network {
     return this;
   }
 
+  /**
+   * Unregister an async-phase handler for a trigram.
+   * @param {Trigram} trigram
+   * @param {Handler} handler
+   * @returns {Network} this
+   * @throws {Error} when `handler` is missing or not a function
+   */
   removeAsyncHandler({ t, term, a, action, o, orient }, handler) {
     _removeHandler(
       this._handlers,
@@ -493,6 +721,13 @@ export default class Network {
     return this;
   }
 
+  /**
+   * Unregister an inline-phase handler for a trigram.
+   * @param {Trigram} trigram
+   * @param {Handler} handler
+   * @returns {Network} this
+   * @throws {Error} when `handler` is missing or not a function
+   */
   removeInlineHandler({ t, term, a, action, o, orient }, handler) {
     _removeHandler(
       this._handlers,

--- a/packages/tao/src/constants.js
+++ b/packages/tao/src/constants.js
@@ -1,5 +1,10 @@
+/** Trigram part that matches any value; a missing or empty part means the same. */
 export const WILDCARD = '*';
+/** Handler phase: runs first; a truthy return halts the signal, an AppCtx return diverts it. */
 export const INTERCEPT = 'Intercept';
+/** Handler phase: forked outside the caller's synchronous flow after intercepts pass. */
 export const ASYNC = 'Async';
+/** Handler phase: runs in the caller's execution context; returned AppCtxs spool, then set. */
 export const INLINE = 'Inline';
+/** Settlement phase reported to `onReturn` for thrown handler errors (not a handler phase). */
 export const ERROR = 'Error';

--- a/packages/tao/src/index.js
+++ b/packages/tao/src/index.js
@@ -1,8 +1,21 @@
+/**
+ * @tao.js/core — the TAO signal network.
+ *
+ * Applications are built as handlers attached to trigram-named Application
+ * Contexts (Term / Action / Orient). Setting an {@link AppCtx} on a
+ * {@link Kernel} (or the shared default `TAO`) runs matching handlers in
+ * three phases — `INTERCEPT`, `ASYNC`, `INLINE` — and handlers chain by
+ * returning another AppCtx. {@link Network} is the lower-level wiring
+ * surface (`enter()` + `decorate()`) for adapters; see ENVELOPE-SPEC.md.
+ *
+ * @module @tao.js/core
+ */
 import AppCtx from './AppCtx';
 import Network from './Network';
 import Kernel from './Kernel';
 export { INTERCEPT, ASYNC, INLINE, ERROR } from './constants';
 
+/** The shared default Kernel instance. */
 const TAO = new Kernel();
 export default TAO;
 export { AppCtx, Network, Kernel };

--- a/packages/tao/src/index.js
+++ b/packages/tao/src/index.js
@@ -10,6 +10,17 @@
  *
  * @module @tao.js/core
  */
+
+/**
+ * Shared shapes re-exported for typed consumers (the JSDoc typedefs are the
+ * source of truth at their defining modules).
+ *
+ * @typedef {import('./AppCtxRoot').Trigram} Trigram
+ * @typedef {import('./AppCtxHandlers').Handler} Handler
+ * @typedef {import('./Network').Envelope} Envelope
+ * @typedef {import('./Network').Forward} Forward
+ * @typedef {import('./Network').DecorationSpec} DecorationSpec
+ */
 import AppCtx from './AppCtx';
 import Network from './Network';
 import Kernel from './Kernel';

--- a/packages/tao/src/utils.js
+++ b/packages/tao/src/utils.js
@@ -1,4 +1,13 @@
+/** @typedef {import('./AppCtxRoot').Trigram} Trigram */
+/** @typedef {import('./AppCtxHandlers').Handler} Handler */
+
 // taken from http://stackoverflow.com/questions/18884249/checking-whether-something-is-iterable
+/**
+ * Whether a value is iterable — strings excluded on purpose (a string arg
+ * is a trigram part, never a collection).
+ * @param {*} obj
+ * @returns {obj is Iterable<any>}
+ */
 export function isIterable(obj) {
   // checks for null and undefined
   if (obj == null) {
@@ -10,6 +19,12 @@ export function isIterable(obj) {
   return typeof obj[Symbol.iterator] === 'function';
 }
 
+/**
+ * Normalize a trigram to long keys only; long keys win when both styles
+ * are present. Missing parts stay undefined (wild).
+ * @param {Trigram} ac
+ * @returns {{term: (string|undefined), action: (string|undefined), orient: (string|undefined)}}
+ */
 export function _cleanAC({ t, term, a, action, o, orient }) {
   return {
     term: term || t,
@@ -18,6 +33,11 @@ export function _cleanAC({ t, term, a, action, o, orient }) {
   };
 }
 
+/**
+ * Throw unless the handler is a function.
+ * @param {Handler} handler
+ * @throws {Error} when `handler` is missing or not a function
+ */
 export function _validateHandler(handler) {
   if (!handler) {
     throw new Error('cannot do anything with missing handler');

--- a/packages/tao/tsconfig.types.json
+++ b/packages/tao/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../config/tsconfig.types.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,7 +64,7 @@ importers:
         version: file:examples/patois.api(@tao.js/telemetry@file:packages/tao-telemetry(@tao.js/core@file:packages/tao))
       patois.web:
         specifier: file:examples/patois.web
-        version: link:examples/patois.web
+        version: file:examples/patois.web(@tao.js/telemetry@file:packages/tao-telemetry(@tao.js/core@file:packages/tao))(eslint@9.32.0(jiti@2.5.1))(prop-types@15.8.1)(typescript@5.9.3)
     devDependencies:
       '@babel/cli':
         specifier: 7.1.5
@@ -107,16 +107,16 @@ importers:
         version: 30.4.1
       '@nx/eslint':
         specifier: 23.1.0
-        version: 23.1.0(@babel/traverse@7.29.7)(@nx/jest@23.1.0(@babel/traverse@7.29.7)(@types/node@24.1.0)(babel-plugin-macros@3.1.0)(jest@30.4.2(@types/node@24.1.0)(babel-plugin-macros@3.1.0))(nx@23.1.0)(typescript@6.0.3))(@zkochan/js-yaml@0.0.7)(eslint@9.32.0(jiti@2.5.1))(nx@23.1.0)
+        version: 23.1.0(@babel/traverse@7.29.7)(@nx/jest@23.1.0(@babel/traverse@7.29.7)(@types/node@24.1.0)(babel-plugin-macros@3.1.0)(jest@30.4.2(@types/node@24.1.0)(babel-plugin-macros@3.1.0))(nx@23.1.0)(typescript@5.9.3))(@zkochan/js-yaml@0.0.7)(eslint@9.32.0(jiti@2.5.1))(nx@23.1.0)
       '@nx/jest':
         specifier: 23.1.0
-        version: 23.1.0(@babel/traverse@7.29.7)(@types/node@24.1.0)(babel-plugin-macros@3.1.0)(jest@30.4.2(@types/node@24.1.0)(babel-plugin-macros@3.1.0))(nx@23.1.0)(typescript@6.0.3)
+        version: 23.1.0(@babel/traverse@7.29.7)(@types/node@24.1.0)(babel-plugin-macros@3.1.0)(jest@30.4.2(@types/node@24.1.0)(babel-plugin-macros@3.1.0))(nx@23.1.0)(typescript@5.9.3)
       '@nx/js':
         specifier: 23.1.0
         version: 23.1.0(@babel/traverse@7.29.7)(nx@23.1.0)
       '@nx/rollup':
         specifier: 23.1.0
-        version: 23.1.0(@babel/core@7.28.0)(@babel/traverse@7.29.7)(@types/babel__core@7.20.5)(nx@23.1.0)(rollup@4.62.2)(typescript@6.0.3)
+        version: 23.1.0(@babel/core@7.28.0)(@babel/traverse@7.29.7)(@types/babel__core@7.20.5)(nx@23.1.0)(rollup@4.62.2)(typescript@5.9.3)
       '@rollup/plugin-babel':
         specifier: ^6.0.4
         version: 6.0.4(@babel/core@7.28.0)(@types/babel__core@7.20.5)(rollup@4.62.2)
@@ -237,6 +237,9 @@ importers:
       rollup-plugin-peer-deps-external:
         specifier: ^2.2.4
         version: 2.2.4(rollup@4.62.2)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
 
   examples/patois.api:
     dependencies:
@@ -2853,6 +2856,11 @@ packages:
       prop-types: '*'
       react: ^18.2.0 || ^19.0.0
       react-dom: ^18.2.0 || ^19.0.0
+
+  '@tao.js/router@file:packages/tao-router':
+    resolution: {directory: packages/tao-router, type: directory}
+    peerDependencies:
+      '@tao.js/core': '*'
 
   '@tao.js/socket.io@file:packages/tao-socket-io':
     resolution: {directory: packages/tao-socket-io, type: directory}
@@ -8515,6 +8523,9 @@ packages:
   patois.api@file:examples/patois.api:
     resolution: {directory: examples/patois.api, type: directory}
 
+  patois.web@file:examples/patois.web:
+    resolution: {directory: examples/patois.web, type: directory}
+
   pbkdf2@3.1.3:
     resolution: {integrity: sha512-wfRLBZ0feWRhCIkoMB6ete7czJcnNnqRpcoWQBLqatqXXmelSRqfdDK4F3u9T2s2cXas/hQJcryI/4lAL+XTlA==}
     engines: {node: '>=0.12'}
@@ -10416,6 +10427,11 @@ packages:
 
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
 
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
@@ -13605,7 +13621,7 @@ snapshots:
       yaml: 2.9.0
       yargs-parser: 21.1.1
 
-  '@nx/eslint@23.1.0(@babel/traverse@7.29.7)(@nx/jest@23.1.0(@babel/traverse@7.29.7)(@types/node@24.1.0)(babel-plugin-macros@3.1.0)(jest@30.4.2(@types/node@24.1.0)(babel-plugin-macros@3.1.0))(nx@23.1.0)(typescript@6.0.3))(@zkochan/js-yaml@0.0.7)(eslint@9.32.0(jiti@2.5.1))(nx@23.1.0)':
+  '@nx/eslint@23.1.0(@babel/traverse@7.29.7)(@nx/jest@23.1.0(@babel/traverse@7.29.7)(@types/node@24.1.0)(babel-plugin-macros@3.1.0)(jest@30.4.2(@types/node@24.1.0)(babel-plugin-macros@3.1.0))(nx@23.1.0)(typescript@5.9.3))(@zkochan/js-yaml@0.0.7)(eslint@9.32.0(jiti@2.5.1))(nx@23.1.0)':
     dependencies:
       '@nx/devkit': 23.1.0(nx@23.1.0)
       '@nx/js': 23.1.0(@babel/traverse@7.29.7)(nx@23.1.0)
@@ -13614,7 +13630,7 @@ snapshots:
       tslib: 2.8.1
       typescript: 6.0.3
     optionalDependencies:
-      '@nx/jest': 23.1.0(@babel/traverse@7.29.7)(@types/node@24.1.0)(babel-plugin-macros@3.1.0)(jest@30.4.2(@types/node@24.1.0)(babel-plugin-macros@3.1.0))(nx@23.1.0)(typescript@6.0.3)
+      '@nx/jest': 23.1.0(@babel/traverse@7.29.7)(@types/node@24.1.0)(babel-plugin-macros@3.1.0)(jest@30.4.2(@types/node@24.1.0)(babel-plugin-macros@3.1.0))(nx@23.1.0)(typescript@5.9.3)
       '@zkochan/js-yaml': 0.0.7
     transitivePeerDependencies:
       - '@babel/traverse'
@@ -13625,13 +13641,13 @@ snapshots:
       - supports-color
       - verdaccio
 
-  '@nx/jest@23.1.0(@babel/traverse@7.29.7)(@types/node@24.1.0)(babel-plugin-macros@3.1.0)(jest@30.4.2(@types/node@24.1.0)(babel-plugin-macros@3.1.0))(nx@23.1.0)(typescript@6.0.3)':
+  '@nx/jest@23.1.0(@babel/traverse@7.29.7)(@types/node@24.1.0)(babel-plugin-macros@3.1.0)(jest@30.4.2(@types/node@24.1.0)(babel-plugin-macros@3.1.0))(nx@23.1.0)(typescript@5.9.3)':
     dependencies:
       '@jest/reporters': 30.4.1
       '@jest/test-result': 30.4.1
       '@nx/devkit': 23.1.0(nx@23.1.0)
       '@nx/js': 23.1.0(@babel/traverse@7.29.7)(nx@23.1.0)
-      '@phenomnomnominal/tsquery': 6.2.0(typescript@6.0.3)
+      '@phenomnomnominal/tsquery': 6.2.0(typescript@5.9.3)
       identity-obj-proxy: 3.0.0
       jest-config: 30.4.2(@types/node@24.1.0)(babel-plugin-macros@3.1.0)
       jest-resolve: 30.4.1
@@ -13725,17 +13741,17 @@ snapshots:
   '@nx/nx-win32-x64-msvc@23.1.0':
     optional: true
 
-  '@nx/rollup@23.1.0(@babel/core@7.28.0)(@babel/traverse@7.29.7)(@types/babel__core@7.20.5)(nx@23.1.0)(rollup@4.62.2)(typescript@6.0.3)':
+  '@nx/rollup@23.1.0(@babel/core@7.28.0)(@babel/traverse@7.29.7)(@types/babel__core@7.20.5)(nx@23.1.0)(rollup@4.62.2)(typescript@5.9.3)':
     dependencies:
       '@nx/devkit': 23.1.0(nx@23.1.0)
       '@nx/js': 23.1.0(@babel/traverse@7.29.7)(nx@23.1.0)
-      '@phenomnomnominal/tsquery': 6.2.0(typescript@6.0.3)
+      '@phenomnomnominal/tsquery': 6.2.0(typescript@5.9.3)
       '@rollup/plugin-babel': 6.0.4(@babel/core@7.28.0)(@types/babel__core@7.20.5)(rollup@4.62.2)
       '@rollup/plugin-commonjs': 25.0.8(rollup@4.62.2)
       '@rollup/plugin-image': 3.0.3(rollup@4.62.2)
       '@rollup/plugin-json': 6.1.0(rollup@4.62.2)
       '@rollup/plugin-node-resolve': 15.3.1(rollup@4.62.2)
-      '@rollup/plugin-typescript': 12.1.4(rollup@4.62.2)(tslib@2.8.1)(typescript@6.0.3)
+      '@rollup/plugin-typescript': 12.1.4(rollup@4.62.2)(tslib@2.8.1)(typescript@5.9.3)
       autoprefixer: 10.4.21(postcss@8.5.6)
       concat-with-sourcemaps: 1.1.0
       picocolors: 1.1.1
@@ -13774,11 +13790,11 @@ snapshots:
 
   '@opentelemetry/api@1.9.1': {}
 
-  '@phenomnomnominal/tsquery@6.2.0(typescript@6.0.3)':
+  '@phenomnomnominal/tsquery@6.2.0(typescript@5.9.3)':
     dependencies:
       '@types/esquery': 1.5.4
       esquery: 1.7.0
-      typescript: 6.0.3
+      typescript: 5.9.3
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -13854,11 +13870,11 @@ snapshots:
     optionalDependencies:
       rollup: 4.62.2
 
-  '@rollup/plugin-typescript@12.1.4(rollup@4.62.2)(tslib@2.8.1)(typescript@6.0.3)':
+  '@rollup/plugin-typescript@12.1.4(rollup@4.62.2)(tslib@2.8.1)(typescript@5.9.3)':
     dependencies:
       '@rollup/pluginutils': 5.2.0(rollup@4.62.2)
       resolve: 1.22.10
-      typescript: 6.0.3
+      typescript: 5.9.3
     optionalDependencies:
       rollup: 4.62.2
       tslib: 2.8.1
@@ -14104,6 +14120,16 @@ snapshots:
       prop-types: 15.8.1
       react: 16.14.0
       react-dom: 16.14.0(react@16.14.0)
+
+  '@tao.js/router@file:packages/tao-router(@tao.js/core@file:packages/tao)':
+    dependencies:
+      '@tao.js/core': file:packages/tao
+      get-value: 3.0.1
+      history: 4.10.1
+      path-to-regexp: 2.4.0
+      routington: 1.0.3
+      set-value: 3.0.3
+      url-pattern: 1.0.3
 
   '@tao.js/socket.io@file:packages/tao-socket-io(@tao.js/core@file:packages/tao)(@tao.js/utils@file:packages/tao-utils(@tao.js/core@file:packages/tao)(@tao.js/telemetry@file:packages/tao-telemetry(@tao.js/core@file:packages/tao)))':
     dependencies:
@@ -16885,6 +16911,18 @@ snapshots:
   eslint-config-prettier@10.1.8(eslint@9.32.0(jiti@2.5.1)):
     dependencies:
       eslint: 9.32.0(jiti@2.5.1)
+
+  eslint-config-react-app@3.0.8(babel-eslint@9.0.0)(eslint-plugin-flowtype@2.50.1(eslint@9.32.0(jiti@2.5.1)))(eslint-plugin-import@2.14.0(eslint@9.32.0(jiti@2.5.1)))(eslint-plugin-jsx-a11y@6.1.2(eslint@9.32.0(jiti@2.5.1)))(eslint-plugin-react@7.11.1(eslint@9.32.0(jiti@2.5.1)))(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.3):
+    dependencies:
+      babel-eslint: 9.0.0
+      confusing-browser-globals: 1.0.11
+      eslint: 9.32.0(jiti@2.5.1)
+      eslint-plugin-flowtype: 2.50.1(eslint@9.32.0(jiti@2.5.1))
+      eslint-plugin-import: 2.14.0(eslint@9.32.0(jiti@2.5.1))
+      eslint-plugin-jsx-a11y: 6.1.2(eslint@9.32.0(jiti@2.5.1))
+      eslint-plugin-react: 7.11.1(eslint@9.32.0(jiti@2.5.1))
+    optionalDependencies:
+      typescript: 5.9.3
 
   eslint-config-react-app@3.0.8(babel-eslint@9.0.0)(eslint-plugin-flowtype@2.50.1(eslint@9.32.0(jiti@2.5.1)))(eslint-plugin-import@2.14.0(eslint@9.32.0(jiti@2.5.1)))(eslint-plugin-jsx-a11y@6.1.2(eslint@9.32.0(jiti@2.5.1)))(eslint-plugin-react@7.11.1(eslint@9.32.0(jiti@2.5.1)))(eslint@9.32.0(jiti@2.5.1))(typescript@6.0.3):
     dependencies:
@@ -21119,6 +21157,34 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  patois.web@file:examples/patois.web(@tao.js/telemetry@file:packages/tao-telemetry(@tao.js/core@file:packages/tao))(eslint@9.32.0(jiti@2.5.1))(prop-types@15.8.1)(typescript@5.9.3):
+    dependencies:
+      '@tao.js/core': file:packages/tao
+      '@tao.js/react': file:packages/react-tao(@tao.js/core@file:packages/tao)(prop-types@15.8.1)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
+      '@tao.js/router': file:packages/tao-router(@tao.js/core@file:packages/tao)
+      '@tao.js/socket.io': file:packages/tao-socket-io(@tao.js/core@file:packages/tao)(@tao.js/utils@file:packages/tao-utils(@tao.js/core@file:packages/tao)(@tao.js/telemetry@file:packages/tao-telemetry(@tao.js/core@file:packages/tao)))
+      '@tao.js/utils': file:packages/tao-utils(@tao.js/core@file:packages/tao)(@tao.js/telemetry@file:packages/tao-telemetry(@tao.js/core@file:packages/tao))
+      axios: 0.18.1
+      lodash.isempty: 4.4.0
+      lodash.merge: 4.6.2
+      react: 16.14.0
+      react-dom: 16.14.0(react@16.14.0)
+      react-scripts: 2.0.5(eslint@9.32.0(jiti@2.5.1))(react@16.14.0)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@tao.js/telemetry'
+      - '@typescript-eslint/parser'
+      - bufferutil
+      - canvas
+      - eslint
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - prop-types
+      - supports-color
+      - typescript
+      - utf-8-validate
+      - webpack-cli
+      - webpack-command
+
   pbkdf2@3.1.3:
     dependencies:
       create-hash: 1.1.3
@@ -21847,6 +21913,38 @@ snapshots:
       raf: 3.4.0
       whatwg-fetch: 3.0.0
 
+  react-dev-utils@6.1.1(typescript@5.9.3)(webpack@4.19.1):
+    dependencies:
+      '@babel/code-frame': 7.0.0
+      address: 1.0.3
+      browserslist: 4.1.1
+      chalk: 2.4.1
+      cross-spawn: 6.0.5
+      detect-port-alt: 1.1.6
+      escape-string-regexp: 1.0.5
+      filesize: 3.6.1
+      find-up: 3.0.0
+      global-modules: 1.0.0
+      globby: 8.0.1
+      gzip-size: 5.0.0
+      immer: 1.7.2
+      inquirer: 6.2.0
+      is-root: 2.0.0
+      loader-utils: 1.1.0
+      opn: 5.4.0
+      pkg-up: 2.0.0
+      react-error-overlay: 5.1.6
+      recursive-readdir: 2.2.2
+      shell-quote: 1.6.1
+      sockjs-client: 1.1.5(supports-color@5.5.0)
+      strip-ansi: 4.0.0
+      text-table: 0.2.0
+      webpack: 4.19.1
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   react-dev-utils@6.1.1(typescript@6.0.3)(webpack@4.19.1):
     dependencies:
       '@babel/code-frame': 7.0.0
@@ -21911,6 +22009,69 @@ snapshots:
       set-cookie-parser: 2.7.2
     optionalDependencies:
       react-dom: 19.2.7(react@19.2.7)
+
+  react-scripts@2.0.5(eslint@9.32.0(jiti@2.5.1))(react@16.14.0)(typescript@5.9.3):
+    dependencies:
+      '@babel/core': 7.1.0
+      '@svgr/webpack': 2.4.1
+      babel-core: 7.0.0-bridge.0(@babel/core@7.1.0)
+      babel-eslint: 9.0.0
+      babel-jest: 23.6.0(babel-core@7.0.0-bridge.0(@babel/core@7.1.0))
+      babel-loader: 8.0.4(@babel/core@7.1.0)(webpack@4.19.1)
+      babel-plugin-named-asset-import: 0.2.3(@babel/core@7.1.0)
+      babel-preset-react-app: 5.0.4(webpack@4.19.1)
+      bfj: 6.1.1
+      case-sensitive-paths-webpack-plugin: 2.1.2
+      chalk: 2.4.1
+      css-loader: 1.0.0(webpack@4.19.1)
+      dotenv: 6.0.0
+      dotenv-expand: 4.2.0
+      eslint: 9.32.0(jiti@2.5.1)
+      eslint-config-react-app: 3.0.8(babel-eslint@9.0.0)(eslint-plugin-flowtype@2.50.1(eslint@9.32.0(jiti@2.5.1)))(eslint-plugin-import@2.14.0(eslint@9.32.0(jiti@2.5.1)))(eslint-plugin-jsx-a11y@6.1.2(eslint@9.32.0(jiti@2.5.1)))(eslint-plugin-react@7.11.1(eslint@9.32.0(jiti@2.5.1)))(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.3)
+      eslint-loader: 2.1.1(eslint@9.32.0(jiti@2.5.1))(webpack@4.19.1)
+      eslint-plugin-flowtype: 2.50.1(eslint@9.32.0(jiti@2.5.1))
+      eslint-plugin-import: 2.14.0(eslint@9.32.0(jiti@2.5.1))
+      eslint-plugin-jsx-a11y: 6.1.2(eslint@9.32.0(jiti@2.5.1))
+      eslint-plugin-react: 7.11.1(eslint@9.32.0(jiti@2.5.1))
+      file-loader: 2.0.0(webpack@4.19.1)
+      fs-extra: 7.0.0
+      html-webpack-plugin: 4.0.0-alpha.2(webpack@4.19.1)
+      identity-obj-proxy: 3.0.0
+      jest: 23.6.0
+      jest-pnp-resolver: 1.0.1(jest-resolve@23.6.0)
+      jest-resolve: 23.6.0
+      mini-css-extract-plugin: 0.4.3(webpack@4.19.1)
+      optimize-css-assets-webpack-plugin: 5.0.1(webpack@4.19.1)
+      pnp-webpack-plugin: 1.1.0
+      postcss-flexbugs-fixes: 4.1.0
+      postcss-loader: 3.0.0
+      postcss-preset-env: 6.0.6
+      postcss-safe-parser: 4.0.1
+      react: 16.14.0
+      react-app-polyfill: 0.1.3
+      react-dev-utils: 6.1.1(typescript@5.9.3)(webpack@4.19.1)
+      resolve: 1.8.1
+      sass-loader: 7.1.0(webpack@4.19.1)
+      style-loader: 0.23.0
+      terser-webpack-plugin: 1.1.0(webpack@4.19.1)
+      url-loader: 1.1.1(webpack@4.19.1)
+      webpack: 4.19.1
+      webpack-dev-server: 3.1.9(webpack@4.19.1)
+      webpack-manifest-plugin: 2.0.4(webpack@4.19.1)
+      workbox-webpack-plugin: 3.6.2(webpack@4.19.1)
+    optionalDependencies:
+      fsevents: 1.2.4
+    transitivePeerDependencies:
+      - '@typescript-eslint/parser'
+      - bufferutil
+      - canvas
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+      - typescript
+      - utf-8-validate
+      - webpack-cli
+      - webpack-command
 
   react-scripts@2.0.5(eslint@9.32.0(jiti@2.5.1))(react@16.14.0)(typescript@6.0.3):
     dependencies:
@@ -23470,6 +23631,8 @@ snapshots:
   typedarray-to-buffer@1.0.4: {}
 
   typedarray@0.0.6: {}
+
+  typescript@5.9.3: {}
 
   typescript@6.0.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,7 +143,13 @@ importers:
         version: 6.9.1
       '@testing-library/react':
         specifier: ^16.3.2
-        version: 16.3.2(@testing-library/dom@10.4.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
       babel-jest:
         specifier: 30.3.0
         version: 30.3.0(@babel/core@7.28.0)
@@ -548,14 +554,13 @@ importers:
         version: link:../tao
 
   packages/tao-transport-tck:
-    dependencies:
-      '@tao.js/telemetry':
-        specifier: file:../tao-telemetry
-        version: link:../tao-telemetry
     devDependencies:
       '@tao.js/core':
         specifier: file:../tao
         version: link:../tao
+      '@tao.js/telemetry':
+        specifier: file:../tao-telemetry
+        version: link:../tao-telemetry
       '@tao.js/utils':
         specifier: file:../tao-utils
         version: link:../tao-utils
@@ -2984,6 +2989,14 @@ packages:
   '@types/q@1.5.8':
     resolution: {integrity: sha512-hroOstUScF6zhIi+5+x0dzqrHA1EJi+Irri6b1fxolMTqqHIV/Cg77EtnQcZqZCu8hR3mX2BzIxN4/GzI68Kfw==}
 
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.17':
+    resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
+
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
 
@@ -4595,6 +4608,9 @@ packages:
   cssstyle@4.6.0:
     resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
     engines: {node: '>=18'}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   cyclist@1.0.2:
     resolution: {integrity: sha512-0sVXIohTfLqVIW3kb/0n6IiWF3Ifj5nm2XaSrLq2DI6fKIGa2fYAZdk917rUneaeLVpYfFcyXE2ft0fe3remsA==}
@@ -14165,12 +14181,15 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.28.2
       '@testing-library/dom': 10.4.1
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@tybys/wasm-util@0.10.0':
     dependencies:
@@ -14271,6 +14290,14 @@ snapshots:
   '@types/parse-json@4.0.2': {}
 
   '@types/q@1.5.8': {}
+
+  '@types/react-dom@19.2.3(@types/react@19.2.17)':
+    dependencies:
+      '@types/react': 19.2.17
+
+  '@types/react@19.2.17':
+    dependencies:
+      csstype: 3.2.3
 
   '@types/resolve@1.20.2': {}
 
@@ -16294,6 +16321,8 @@ snapshots:
     dependencies:
       '@asamuzakjp/css-color': 3.2.0
       rrweb-cssom: 0.8.0
+
+  csstype@3.2.3: {}
 
   cyclist@1.0.2: {}
 

--- a/tools/types-consumer/run.cjs
+++ b/tools/types-consumer/run.cjs
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+/*
+ * Clean-room TypeScript consumer check for the release group.
+ *
+ * Packs every release-group package with `pnpm pack` (so the check exercises
+ * the published artifact: the `files` allowlist, the `types` field, and the
+ * emitted lib/*.d.ts — not the workspace layout), installs the tarballs plus
+ * the host libraries into a scratch project outside the repo, and compiles
+ * typical usage of every package with `tsc --noEmit` under `strict`.
+ *
+ * The consumer sources (./src) carry IsAny type assertions on the key
+ * published types, so a declaration degrading to `any` fails the build even
+ * where skipLibCheck would hide the underlying resolution error.
+ *
+ * Run after a full `pnpm build`:  pnpm run test:types
+ */
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+
+// npm name -> workspace directory (the 13-package fixed release group)
+const PACKAGES = {
+  '@tao.js/core': 'packages/tao',
+  '@tao.js/utils': 'packages/tao-utils',
+  '@tao.js/react': 'packages/react-tao',
+  '@tao.js/router': 'packages/tao-router',
+  '@tao.js/socket.io': 'packages/tao-socket-io',
+  '@tao.js/koa': 'packages/koa-tao',
+  '@tao.js/telemetry': 'packages/tao-telemetry',
+  '@tao.js/opentelemetry': 'packages/tao-opentelemetry',
+  '@tao.js/routing-core': 'packages/tao-routing-core',
+  '@tao.js/routing-react-router': 'packages/tao-routing-react-router',
+  '@tao.js/routing-tanstack-router': 'packages/tao-routing-tanstack',
+  '@tao.js/routing-next': 'packages/tao-routing-next',
+  '@tao.js/transport-tck': 'packages/tao-transport-tck',
+};
+
+// Host libraries the packed declarations reference from consumer land.
+const HOST_DEPS = {
+  react: '^19.2.7',
+  'react-dom': '^19.2.7',
+  '@types/react': '^19.0.0',
+  '@types/react-dom': '^19.0.0',
+  'react-router': '^7.6.0',
+  '@tanstack/react-router': '^1.120.0',
+  next: '16.2.10',
+  '@opentelemetry/api': '^1.9.1',
+};
+
+function run(cmd, args, opts) {
+  return execFileSync(cmd, args, { encoding: 'utf8', ...opts });
+}
+
+// 1. Every package must be built (rollup lib + emitted declarations).
+const unbuilt = Object.entries(PACKAGES).filter(
+  ([, dir]) => !fs.existsSync(path.join(ROOT, dir, 'lib', 'index.d.ts')),
+);
+if (unbuilt.length) {
+  console.error(
+    'Missing lib/index.d.ts for:\n' +
+      unbuilt.map(([name]) => `  - ${name}`).join('\n') +
+      '\nRun `pnpm build` first.',
+  );
+  process.exit(1);
+}
+
+// 2. Scratch project outside the repo (keeps pnpm workspace detection away).
+const work = fs.mkdtempSync(path.join(os.tmpdir(), 'tao-types-consumer-'));
+const tarballDir = path.join(work, 'tarballs');
+fs.mkdirSync(tarballDir);
+console.log(`clean-room consumer: ${work}`);
+
+// 3. Pack every package.
+const deps = {};
+for (const [name, dir] of Object.entries(PACKAGES)) {
+  const out = run('pnpm', ['pack', '--pack-destination', tarballDir], {
+    cwd: path.join(ROOT, dir),
+  });
+  const lines = out.trim().split('\n');
+  const tarball = lines[lines.length - 1].trim();
+  if (!fs.existsSync(tarball)) {
+    console.error(`pack of ${name} did not produce a tarball (got: ${tarball})`);
+    process.exit(1);
+  }
+  deps[name] = `file:${tarball}`;
+  console.log(`packed ${name} -> ${path.basename(tarball)}`);
+}
+
+// 4. Consumer project: package.json + tsconfig + sources.
+fs.writeFileSync(
+  path.join(work, 'package.json'),
+  JSON.stringify(
+    {
+      name: 'tao-types-consumer',
+      private: true,
+      dependencies: { ...deps, ...HOST_DEPS },
+      devDependencies: { typescript: '^5.9.3' },
+    },
+    null,
+    2,
+  ),
+);
+fs.copyFileSync(
+  path.join(__dirname, 'tsconfig.consumer.json'),
+  path.join(work, 'tsconfig.json'),
+);
+fs.cpSync(path.join(__dirname, 'src'), path.join(work, 'src'), {
+  recursive: true,
+});
+
+// 5. Install (shared pnpm store makes this mostly offline) and compile.
+run('pnpm', ['install', '--prefer-offline', '--reporter=append-only'], {
+  cwd: work,
+  stdio: ['ignore', 'inherit', 'inherit'],
+});
+try {
+  run(path.join(work, 'node_modules', '.bin', 'tsc'), ['-p', '.'], {
+    cwd: work,
+    stdio: 'inherit',
+  });
+} catch {
+  console.error('\ntypes consumer FAILED — see tsc errors above');
+  console.error(`scratch project retained for inspection: ${work}`);
+  process.exit(1);
+}
+
+console.log('\ntypes consumer OK: every package resolved with real types');
+fs.rmSync(work, { recursive: true, force: true });

--- a/tools/types-consumer/src/core.ts
+++ b/tools/types-consumer/src/core.ts
@@ -1,0 +1,69 @@
+import TAO, {
+  AppCtx,
+  Kernel,
+  Network,
+  INTERCEPT,
+  ASYNC,
+  INLINE,
+} from '@tao.js/core';
+import type {
+  Trigram,
+  Handler,
+  Envelope,
+  Forward,
+  DecorationSpec,
+} from '@tao.js/core';
+import type { AssertFalse, IsAny } from './helpers';
+
+type _kernel = AssertFalse<IsAny<Kernel>>;
+type _trigram = AssertFalse<IsAny<Trigram>>;
+type _handler = AssertFalse<IsAny<Handler>>;
+type _envelope = AssertFalse<IsAny<Envelope>>;
+type _forward = AssertFalse<IsAny<Forward>>;
+type _decorationSpec = AssertFalse<IsAny<DecorationSpec>>;
+
+const kernel = new Kernel();
+const wildKernel = new Kernel(true);
+
+const trigram: Trigram = { t: 'User', a: 'Find', o: 'Portal' };
+const longTrigram: Trigram = { term: 'User', action: 'Find', orient: 'Portal' };
+
+const handler: Handler = (tao, data) =>
+  new AppCtx('User', 'View', 'Portal', { User: data.User });
+
+kernel.addInlineHandler(trigram, handler);
+kernel.addAsyncHandler({ a: 'Find' }, () => undefined);
+kernel.addInterceptHandler(longTrigram, () => true);
+kernel.setCtx({ t: 'User', a: 'Find', o: 'Portal' }, { User: { id: '1' } });
+kernel.setAppCtx(new AppCtx('User', 'Find', 'Portal', { User: { id: '42' } }));
+kernel.removeInlineHandler(trigram, handler);
+kernel.removeAsyncHandler({ a: 'Find' }, handler);
+kernel.removeInterceptHandler(longTrigram, handler);
+const clone: Kernel = kernel.clone(true);
+clone.setCtx({ t: 'App', a: 'Enter', o: 'Portal' });
+TAO.setCtx({ t: 'App', a: 'Enter', o: 'Portal' });
+
+const ac = new AppCtx('User', 'Find', 'Portal', { User: { id: '42' } });
+const key: string = ac.key;
+const term: string = ac.t;
+const unwrapped = ac.unwrapCtx();
+type _unwrapped = AssertFalse<IsAny<typeof unwrapped>>;
+
+const network = new Network(true);
+const spec: DecorationSpec = {
+  name: 'consumer',
+  onDispatch: (dispatchedAc, envelope) => {
+    const e: Envelope = envelope;
+    void e;
+    void dispatchedAc;
+  },
+};
+const undecorate = network.decorate(spec);
+network.enter(new AppCtx('User', 'Find', 'Portal'));
+undecorate();
+
+const phases: string[] = [INTERCEPT, ASYNC, INLINE];
+void phases;
+void wildKernel;
+void key;
+void term;

--- a/tools/types-consumer/src/helpers.ts
+++ b/tools/types-consumer/src/helpers.ts
@@ -1,0 +1,8 @@
+/*
+ * Type-level assertion helpers. `AssertFalse<IsAny<T>>` fails to compile
+ * when T is `any` — the degradation mode skipLibCheck can otherwise hide
+ * (e.g. a declaration whose cross-package import silently failed to
+ * resolve).
+ */
+export type IsAny<T> = 0 extends 1 & T ? true : false;
+export type AssertFalse<T extends false> = T;

--- a/tools/types-consumer/src/koa.ts
+++ b/tools/types-consumer/src/koa.ts
@@ -1,0 +1,31 @@
+import taoHttpMiddleware, {
+  simpleMiddleware,
+  enhancedMiddleware,
+} from '@tao.js/koa';
+import type {
+  KoaContextLike,
+  KoaMiddleware,
+  TaoSignaler,
+  TrigramSets,
+} from '@tao.js/koa';
+import { Kernel } from '@tao.js/core';
+import type { AssertFalse, IsAny } from './helpers';
+
+type _default = AssertFalse<IsAny<typeof taoHttpMiddleware>>;
+type _simple = AssertFalse<IsAny<typeof simpleMiddleware>>;
+type _enhanced = AssertFalse<IsAny<typeof enhancedMiddleware>>;
+type _ctxLike = AssertFalse<IsAny<KoaContextLike>>;
+type _koaMw = AssertFalse<IsAny<KoaMiddleware>>;
+type _signaler = AssertFalse<IsAny<TaoSignaler>>;
+type _trigramSets = AssertFalse<IsAny<TrigramSets>>;
+
+const kernel = new Kernel();
+const middleware = taoHttpMiddleware(kernel, {});
+type _middleware = AssertFalse<IsAny<typeof middleware>>;
+const simple = simpleMiddleware(kernel, {});
+type _simpleMw = AssertFalse<IsAny<typeof simple>>;
+const enhanced = enhancedMiddleware(kernel, {});
+type _enhancedMw = AssertFalse<IsAny<typeof enhanced>>;
+void middleware;
+void simple;
+void enhanced;

--- a/tools/types-consumer/src/opentelemetry.ts
+++ b/tools/types-consumer/src/opentelemetry.ts
@@ -1,0 +1,18 @@
+import { trace } from '@opentelemetry/api';
+import { Kernel } from '@tao.js/core';
+import { Tracer } from '@tao.js/telemetry';
+import OpenTelemetrySink, {
+  OpenTelemetrySink as NamedSink,
+} from '@tao.js/opentelemetry';
+import type { AssertFalse, IsAny } from './helpers';
+
+type _sink = AssertFalse<IsAny<OpenTelemetrySink>>;
+type _sameExport = AssertFalse<IsAny<typeof NamedSink>>;
+
+const otelTracer = trace.getTracer('tao-consumer');
+const sink = new OpenTelemetrySink(otelTracer, { endImmediately: true });
+
+// integration: the OTel sink satisfies telemetry's sink contract
+const kernel = new Kernel();
+const tracer = new Tracer(kernel, { sinks: [sink] });
+void tracer;

--- a/tools/types-consumer/src/react.tsx
+++ b/tools/types-consumer/src/react.tsx
@@ -1,0 +1,54 @@
+import { Kernel } from '@tao.js/core';
+import {
+  TaoProvider,
+  DataHandler,
+  RenderHandler,
+  SwitchHandler,
+  createContextHandler,
+  withContext,
+  useTaoContext,
+  useTaoData,
+  useTaoInlineHandler,
+  useTaoAsyncHandler,
+  useTaoInterceptHandler,
+} from '@tao.js/react';
+import type { AssertFalse, IsAny } from './helpers';
+
+type _provider = AssertFalse<IsAny<typeof TaoProvider>>;
+type _dataHandler = AssertFalse<IsAny<typeof DataHandler>>;
+type _renderHandler = AssertFalse<IsAny<typeof RenderHandler>>;
+type _switchHandler = AssertFalse<IsAny<typeof SwitchHandler>>;
+type _createContextHandler = AssertFalse<IsAny<typeof createContextHandler>>;
+type _withContext = AssertFalse<IsAny<typeof withContext>>;
+type _useTaoData = AssertFalse<IsAny<typeof useTaoData>>;
+type _useTaoAsyncHandler = AssertFalse<IsAny<typeof useTaoAsyncHandler>>;
+type _useTaoInterceptHandler = AssertFalse<IsAny<typeof useTaoInterceptHandler>>;
+
+const kernel = new Kernel();
+
+function View() {
+  const TAO = useTaoContext();
+  type _tao = AssertFalse<IsAny<typeof TAO>>;
+  const user = useTaoData('user');
+  useTaoInlineHandler({ t: 'User', a: 'View', o: 'Portal' }, (tao, data) => {
+    void tao;
+    void data;
+  });
+  return <span>{JSON.stringify(user)}</span>;
+}
+
+export const app = (
+  <TaoProvider TAO={kernel}>
+    <DataHandler name="user" t="User" a="*" o="Portal">
+      <SwitchHandler t="User" a={['Find', 'View']} o="Portal">
+        <RenderHandler t="User" a="View" o="Portal">
+          {(tao, data) => {
+            void tao;
+            void data;
+            return <View />;
+          }}
+        </RenderHandler>
+      </SwitchHandler>
+    </DataHandler>
+  </TaoProvider>
+);

--- a/tools/types-consumer/src/router.ts
+++ b/tools/types-consumer/src/router.ts
@@ -1,0 +1,13 @@
+import init, { route } from '@tao.js/router';
+import type { HistoryLike, RouterOptions, RouteConfig } from '@tao.js/router';
+import { Kernel } from '@tao.js/core';
+import type { AssertFalse, IsAny } from './helpers';
+
+type _init = AssertFalse<IsAny<typeof init>>;
+type _route = AssertFalse<IsAny<typeof route>>;
+type _history = AssertFalse<IsAny<HistoryLike>>;
+type _options = AssertFalse<IsAny<RouterOptions>>;
+type _routeConfig = AssertFalse<IsAny<RouteConfig>>;
+
+const kernel = new Kernel();
+init(kernel);

--- a/tools/types-consumer/src/routing-adapters.ts
+++ b/tools/types-consumer/src/routing-adapters.ts
@@ -1,0 +1,34 @@
+import {
+  importLoader as rrImportLoader,
+  useLoaderSignal as rrUseLoaderSignal,
+} from '@tao.js/routing-react-router';
+import {
+  importLoader as tsImportLoader,
+  useLoaderSignal as tsUseLoaderSignal,
+} from '@tao.js/routing-tanstack-router';
+import {
+  importLoader as nextImportLoader,
+  useRouteSignal,
+  enterRoute,
+} from '@tao.js/routing-next';
+import type { AssertFalse, IsAny } from './helpers';
+
+type _rrImportLoader = AssertFalse<IsAny<typeof rrImportLoader>>;
+type _rrUseLoaderSignal = AssertFalse<IsAny<typeof rrUseLoaderSignal>>;
+type _tsImportLoader = AssertFalse<IsAny<typeof tsImportLoader>>;
+type _tsUseLoaderSignal = AssertFalse<IsAny<typeof tsUseLoaderSignal>>;
+type _nextImportLoader = AssertFalse<IsAny<typeof nextImportLoader>>;
+type _useRouteSignal = AssertFalse<IsAny<typeof useRouteSignal>>;
+type _enterRoute = AssertFalse<IsAny<typeof enterRoute>>;
+
+import { Kernel } from '@tao.js/core';
+const kernel = new Kernel();
+const rrLoader = rrImportLoader(kernel);
+type _rrLoader = AssertFalse<IsAny<typeof rrLoader>>;
+const tsLoader = tsImportLoader(kernel);
+type _tsLoader = AssertFalse<IsAny<typeof tsLoader>>;
+const nextLoader = nextImportLoader(kernel);
+type _nextLoader = AssertFalse<IsAny<typeof nextLoader>>;
+void rrLoader;
+void tsLoader;
+void nextLoader;

--- a/tools/types-consumer/src/routing-core.ts
+++ b/tools/types-consumer/src/routing-core.ts
@@ -1,0 +1,30 @@
+import {
+  applySignal,
+  getSignal,
+  createImportLoader,
+  createUseSignalEffect,
+  createUseRouteSignal,
+} from '@tao.js/routing-core';
+import type {
+  RouteSignal,
+  SignalTuple,
+  SignalDescriptor,
+  SignalTarget,
+  ImportLoader,
+  ImportLoaderOptions,
+  LoaderResult,
+} from '@tao.js/routing-core';
+import type { AssertFalse, IsAny } from './helpers';
+
+type _applySignal = AssertFalse<IsAny<typeof applySignal>>;
+type _getSignal = AssertFalse<IsAny<typeof getSignal>>;
+type _createImportLoader = AssertFalse<IsAny<typeof createImportLoader>>;
+type _createUseSignalEffect = AssertFalse<IsAny<typeof createUseSignalEffect>>;
+type _createUseRouteSignal = AssertFalse<IsAny<typeof createUseRouteSignal>>;
+type _routeSignal = AssertFalse<IsAny<RouteSignal>>;
+type _signalTuple = AssertFalse<IsAny<SignalTuple>>;
+type _signalDescriptor = AssertFalse<IsAny<SignalDescriptor>>;
+type _signalTarget = AssertFalse<IsAny<SignalTarget>>;
+type _importLoader = AssertFalse<IsAny<ImportLoader>>;
+type _importLoaderOptions = AssertFalse<IsAny<ImportLoaderOptions>>;
+type _loaderResult = AssertFalse<IsAny<LoaderResult>>;

--- a/tools/types-consumer/src/socket-io.ts
+++ b/tools/types-consumer/src/socket-io.ts
@@ -1,0 +1,16 @@
+import wireTaoJsToSocketIO from '@tao.js/socket.io';
+import type {
+  SocketLike,
+  SocketIoServerLike,
+  SocketIoClientFactory,
+  WireOptions,
+} from '@tao.js/socket.io';
+import type { AssertFalse, IsAny } from './helpers';
+
+type _wire = AssertFalse<IsAny<typeof wireTaoJsToSocketIO>>;
+type _kernelParam = AssertFalse<IsAny<Parameters<typeof wireTaoJsToSocketIO>[0]>>;
+type _ioParam = AssertFalse<IsAny<Parameters<typeof wireTaoJsToSocketIO>[1]>>;
+type _socketLike = AssertFalse<IsAny<SocketLike>>;
+type _serverLike = AssertFalse<IsAny<SocketIoServerLike>>;
+type _clientFactory = AssertFalse<IsAny<SocketIoClientFactory>>;
+type _wireOptions = AssertFalse<IsAny<WireOptions>>;

--- a/tools/types-consumer/src/telemetry.ts
+++ b/tools/types-consumer/src/telemetry.ts
@@ -1,0 +1,46 @@
+import { Kernel } from '@tao.js/core';
+import {
+  Tracer,
+  InMemorySink,
+  ConsoleSink,
+  TaoLogger,
+  TRACE_CHAIN,
+  newTraceId,
+  newSignalId,
+  toTraceparent,
+  parseTraceparent,
+} from '@tao.js/telemetry';
+import type { TraceRecord, TraceTreeNode } from '@tao.js/telemetry';
+import type { AssertFalse, IsAny } from './helpers';
+
+type _traceRecord = AssertFalse<IsAny<TraceRecord>>;
+type _traceTreeNode = AssertFalse<IsAny<TraceTreeNode>>;
+type _tracer = AssertFalse<IsAny<Tracer>>;
+
+const kernel = new Kernel();
+const sink = new InMemorySink({ limit: 100 });
+const tracer = new Tracer(kernel, { sinks: [sink] });
+type _tracerKernelParam = AssertFalse<IsAny<ConstructorParameters<typeof Tracer>[0]>>;
+
+const records: TraceRecord[] = sink.records;
+const first: TraceRecord | undefined = records[0];
+if (first) {
+  const traceId: string = first.traceId;
+  const parent: string | null = first.parentId;
+  void traceId;
+  void parent;
+}
+const rendered: string = sink.format({ showData: true });
+void rendered;
+
+const chainKey: string = TRACE_CHAIN;
+const traceId: string = newTraceId();
+const signalId: string = newSignalId();
+const header: string = toTraceparent({ traceId, signalId });
+const parsed = parseTraceparent(header);
+type _parsed = AssertFalse<IsAny<typeof parsed>>;
+
+void chainKey;
+void tracer;
+type _consoleSink = AssertFalse<IsAny<typeof ConsoleSink>>;
+type _taoLogger = AssertFalse<IsAny<typeof TaoLogger>>;

--- a/tools/types-consumer/src/transport-tck.ts
+++ b/tools/types-consumer/src/transport-tck.ts
@@ -1,0 +1,35 @@
+import { Kernel } from '@tao.js/core';
+import {
+  runTransportCompliance,
+  assertTransportCompliance,
+} from '@tao.js/transport-tck';
+import type { Link, ComplianceResult } from '@tao.js/transport-tck';
+import type { AssertFalse, IsAny } from './helpers';
+
+type _link = AssertFalse<IsAny<Link>>;
+type _complianceResult = AssertFalse<IsAny<ComplianceResult>>;
+
+async function check(): Promise<void> {
+  const makeLink = (): Link => ({
+    a: new Kernel(),
+    b: new Kernel(),
+    close: () => {},
+  });
+
+  const res = await runTransportCompliance(makeLink, { timeoutMs: 500 });
+  const ok: boolean = res.pass;
+  const results: ComplianceResult[] = res.results;
+  for (const r of results) {
+    const name: string = r.name;
+    const passed: boolean = r.pass;
+    void name;
+    void passed;
+  }
+  void ok;
+
+  const all: ComplianceResult[] = await assertTransportCompliance(makeLink, {
+    timeoutMs: 500,
+  });
+  void all;
+}
+void check;

--- a/tools/types-consumer/src/utils.ts
+++ b/tools/types-consumer/src/utils.ts
@@ -1,0 +1,84 @@
+import { Kernel } from '@tao.js/core';
+import {
+  Channel,
+  Source,
+  Transponder,
+  Transceiver,
+  trigramFilter,
+  seive,
+  createTransport,
+  enterFromWire,
+  wireEnvelope,
+  forwardInline,
+  forwardAsync,
+  forwardIntercept,
+} from '@tao.js/utils';
+import type { WireEnvelope, NetworkSurface } from '@tao.js/utils';
+import type { AssertFalse, IsAny } from './helpers';
+
+type _wireEnvelope = AssertFalse<IsAny<WireEnvelope>>;
+type _networkSurface = AssertFalse<IsAny<NetworkSurface>>;
+type _channel = AssertFalse<IsAny<Channel>>;
+type _transponder = AssertFalse<IsAny<Transponder>>;
+
+const kernel = new Kernel();
+
+const channel = new Channel(kernel, 'chan-1');
+channel.setCtx({ t: 'User', a: 'Find', o: 'Portal' }, { User: {} });
+const clonedChannel: Channel = channel.clone('chan-2');
+void clonedChannel;
+
+const transponder = new Transponder(kernel, undefined, 3000);
+const settled = transponder.setCtx(
+  { t: 'User', a: 'Find', o: 'Portal' },
+  { User: { id: '1' } },
+);
+type _settled = AssertFalse<IsAny<typeof settled>>;
+
+const transceiver = new Transceiver(kernel);
+void transceiver;
+
+const source = new Source(
+  kernel,
+  (tao, data) => {
+    void tao;
+    void data;
+  },
+  'SRC',
+  (setter) => {
+    setter({ t: 'User', a: 'Find', o: 'Portal' }, { User: {} });
+  },
+);
+void source;
+
+const transport = createTransport(kernel, {
+  name: 'wire1',
+  send: (tao, data, wire) => {
+    const w: WireEnvelope = wire;
+    void w;
+    void tao;
+    void data;
+  },
+});
+transport.receive({ t: 'User', a: 'Find', o: 'Portal' }, {}, undefined);
+transport.dispose();
+
+enterFromWire(
+  kernel,
+  { t: 'User', a: 'Find', o: 'Portal' },
+  {},
+  undefined,
+  'WIRE9',
+);
+type _wireEnvelopeFn = AssertFalse<IsAny<typeof wireEnvelope>>;
+type _trigramFilter = AssertFalse<IsAny<typeof trigramFilter>>;
+type _seive = AssertFalse<IsAny<typeof seive>>;
+
+const fwd = forwardInline(
+  kernel,
+  { t: 'User', a: 'Found', o: 'Portal' },
+  { t: 'User', a: 'View', o: 'Portal' },
+);
+fwd.remove();
+type _forwardAsync = AssertFalse<IsAny<typeof forwardAsync>>;
+type _forwardIntercept = AssertFalse<IsAny<typeof forwardIntercept>>;

--- a/tools/types-consumer/tsconfig.consumer.json
+++ b/tools/types-consumer/tsconfig.consumer.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM"],
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## What this is

The 0.21 type-definitions train: every package published in 0.20 now ships its own TypeScript declarations, **emitted from JSDoc** — no hand-written `.d.ts` anywhere. This lands the JSDoc typedef pass split out of #63 (its first non-spec commit, cherry-picked verbatim) plus the JSDoc pass for the eight packages it didn't cover, and wires `d.ts` emission into every build.

Per #63's split plan: the `@tao.js/typed` v1 prototype, its tests, and TYPED-SPEC.md stay on `feat/typescript-wrapper` unmerged, as reference for the §7 v2 rewrite. Nothing from the prototype is in here and `@tao.js/typed` is **not** added to the release group.

## How it works

- Each package: `tsconfig.types.json` (extends `config/tsconfig.types.json`) runs `tsc --allowJs --checkJs --declaration --emitDeclarationOnly` over `src/` into `lib/`, chained as `build:types` after rollup; `"types": "lib/index.d.ts"` (already inside the `files` allowlist).
- `typescript` pinned `^5.9.3` at the root (bare `typescript` resolves to the native TS7 compiler with no JS API — the toolchain fact recorded in TYPED-SPEC §7.8). `@types/react@19` added at the root for the react/routing-hook emissions.
- **`checkJs` stays on as the JSDoc/behavior drift gate.** Emission fails the build if the docs and the code disagree.

## What the drift gate surfaced (all fixed here)

- `AppCtxRoot.isMatch` narrows via a fresh `const` instead of param reassignment — TS assignment-narrowing can never apply because `AppCtxRoot` structurally *is* a `Trigram` (it has a `t` getter). Behavior-identical.
- utils' duck-typed surface params are now honestly typed by an exported **`NetworkSurface`** shape — the `typeof x.enter === 'function' ? x : x._network` convention stated as a type; telemetry's Tracer gets the analogous **`TraceableSurface`** (its `kernel` param previously emitted as `any`).
- Relay/Source's `name`-position overload and `createTransport`'s runtime-required `send` are typed as actually accepted; Tracer assembles its `TraceRecord` in one typed literal; the TCK's `CHECKS` table is a typed tuple list.
- koa docs: `opt.promise` is a **PromiseConstructor**; `enhancedMiddleware` has no Channel, uses a Transceiver, and defaults to no timeout; handler-registration trigrams accept arrays per part (cartesian) — now typed as `TrigramSets`.
- react: `normalizeAC` long-key precedence (opposite of core's short-key `isMatch`), `RenderHandler`'s `shouldRender`-without-`initialTao` behavior, and `Adapter.addComponentHandler`'s unreachable `instanceof React.Component` branch are all documented as they actually behave.
- Deprecated surfaces (`RenderHandler.context`, `DataConsumer`, `Provider`, `useTaoDataContext`, utils' `TaoLogger` re-export) carry `@deprecated` tags — their **removal** is the next PR in the 0.21 train.

## Shared shapes, importable from package roots

`Trigram` / `Handler` / `Envelope` / `Forward` / `DecorationSpec` (core), `WireEnvelope` / `NetworkSurface` (utils), `TraceRecord` / `TraceTreeNode` (telemetry), `Link` / `ComplianceResult` (transport-tck), the loader/signal contract shapes (routing-core, re-exported by all three adapters), structural host shapes (`SocketIoServerLike`…, `KoaContextLike`…), and the react prop/handler types (`RenderHandlerProps`, `TaoDataHandler<S>`, …).

## Shipped bug found and fixed: transport-tck 0.20.0 is uninstallable under pnpm

The harness's first real run caught it: the published `@tao.js/transport-tck@0.20.0` manifest carries the workspace's `"@tao.js/telemetry": "file:../tao-telemetry"` as a runtime dependency. pnpm consumers get `ERR_PNPM_LINKED_PKG_DIR_NOT_FOUND` (cannot install at all); npm "succeeds" by creating an empty `@tao.js/telemetry` symlink to a nonexistent sibling — runtime only survived because rollup had silently **bundled telemetry into tck's lib** (a second tracer copy). Fixed here per the convention utils already follows: telemetry becomes a peer (`>=0.20.0`) + `file:` devDependency, externalized in the UMD build. Verified empirically against the npm registry (`npm view` + a real install probe). 0.21 publishes the corrected manifest.

## Verification

- All 17 test projects green; no test file touched (the JSDoc pass is comments + a handful of comment-casts; the two behavior-identical micro-refactors are called out inline above).
- **Clean-room consumer** (`pnpm run test:types`, new `tools/types-consumer`): packs all 13 tarballs with `pnpm pack` (so the check exercises the *published* artifact — `files`, `types`, emitted d.ts), installs them + host libs (react 19, react-router 7, TanStack Router, Next 16, @opentelemetry/api) into a scratch project outside the repo, compiles strict-mode typical usage of every package, with `IsAny` type-assertions so any declaration degrading to `any` fails even under `skipLibCheck`. **Passing for all 13** — and it caught the tck manifest bug above plus one JSDoc gap (`forwardInline`'s documented `.remove()` was missing from the emitted return type; fixed).
- Full coverage + mutation runs happen at release-verification time on the assembled 0.21 train (mutation on all 13, run last, per AGENTS.md).

## Peer floors

Unchanged, deliberately: the emitted declarations add no runtime dependence on any sibling package's new behavior (comments only). A consumer pairing utils 0.21 with core 0.20 loses type resolution inside d.ts (invisible under `skipLibCheck`, which is effectively universal) but runs identically; the fixed release group upgrades them together anyway. Flagging it here in case you want floors bumped for type-resolution completeness instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit f539ac376d0e5c58b9487f3bb7dd07796f0c491b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->