### PR TITLE
chore(serena): bootstrap agent LSP for Cursor and Claude

### DIFF
--- a/.agents/skills/serena/SKILL.md
+++ b/.agents/skills/serena/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: serena
+description: Bootstrap and use Serena as this repo's agent LSP (symbolic find, overview, references, rename). Use at the start of a coding session, when Serena MCP tools are missing, when navigating or editing code symbols, or when the user mentions Serena, LSP, or agent language intelligence.
+---
+
+# Serena (agent LSP)
+
+Canonical bootstrap for every agent. Client adapters (Cursor rules, Claude hooks) point here.
+
+Backend is **LSP**. Never JetBrains (`language_backend: JetBrains` or `serena init -b JetBrains`).
+
+## Session start
+
+1. Run `bash scripts/serena-bootstrap.sh --check` from the repo root.
+2. If it exits non-zero, run `bash scripts/serena-bootstrap.sh` (installs `uv` + `serena-agent`, then `serena init` with LSP).
+3. Tell the user to reload MCP (Cursor: MCP Restart Servers; Claude Code: `/mcp` reconnect).
+4. Prefer Serena symbol tools over grep/full-file reads for code structure.
+
+Do not install Serena from an MCP/plugin marketplace. Do not skip a failed check silently.
+
+## After install
+
+- Project config: `.serena/project.yml` (`language_backend: LSP`, TypeScript LS for JS+TS).
+- Cursor MCP: `.cursor/mcp.json` → `scripts/serena-mcp.sh` (`SERENA_CONTEXT` defaults to `ide`).
+- Claude Code MCP: `.mcp.json` → same launcher with `SERENA_CONTEXT=claude-code`.
+- Universal contract: `AGENTS.md` § Serena.
+
+Keep using Nx MCP for Nx graph/docs/generators. Source + tests remain the API source of truth.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,46 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash scripts/serena-hooks.sh remind --client=claude-code"
+          }
+        ]
+      },
+      {
+        "matcher": "mcp__serena__*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash scripts/serena-hooks.sh auto-approve --client=claude-code"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash scripts/serena-hooks.sh activate --client=claude-code"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash scripts/serena-hooks.sh cleanup --client=claude-code"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/serena
+++ b/.claude/skills/serena
@@ -1,0 +1,1 @@
+../../.agents/skills/serena

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -3,6 +3,10 @@
     "nx-mcp": {
       "command": "npx",
       "args": ["-y", "nx-mcp@latest"]
+    },
+    "serena": {
+      "command": "bash",
+      "args": ["scripts/serena-mcp.sh"]
     }
   }
 }

--- a/.cursor/rules/serena.mdc
+++ b/.cursor/rules/serena.mdc
@@ -1,0 +1,18 @@
+---
+description: Serena agent LSP — bootstrap check, symbolic tools, LSP backend only (never JetBrains)
+alwaysApply: true
+---
+
+# Serena (agent LSP)
+
+Follow **AGENTS.md** § Serena and the project skill `.agents/skills/serena` (also at `.cursor/skills/serena`).
+
+Backend is **LSP**. Never JetBrains.
+
+## Session start
+
+1. Run `bash scripts/serena-bootstrap.sh --check`.
+2. If it fails, run `bash scripts/serena-bootstrap.sh`, then tell the user to reload Cursor MCP servers.
+3. Do not skip a failed check silently. Do not install Serena from an MCP marketplace.
+
+When Serena tools are available, prefer them for symbol navigation/edits over grep/full-file reads. Keep using Nx MCP for Nx graph/docs/generators.

--- a/.cursor/skills/serena
+++ b/.cursor/skills/serena
@@ -1,0 +1,1 @@
+../../.agents/skills/serena

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "serena": {
+      "command": "bash",
+      "args": ["scripts/serena-mcp.sh"],
+      "env": {
+        "SERENA_CONTEXT": "claude-code"
+      }
+    }
+  }
+}

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,7 @@ dist
 build
 
 .nx/self-healing
+
+# Serena writes project memories, cache, and local YAML here.
+# Never let prettier rewrite those files on commit or format-all.
+.serena

--- a/.serena/.gitignore
+++ b/.serena/.gitignore
@@ -1,0 +1,2 @@
+/cache
+/project.local.yml

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,0 +1,28 @@
+# Serena project config for tao.js.
+# Version this file. Local overrides go in project.local.yml (gitignored).
+# Docs: https://oraios.github.io/serena/02-usage/040_workflow.html
+
+project_name: tao.js
+
+# This workspace uses Serena's LSP backend (Cursor, Claude Code, and other
+# MCP clients). Never switch this to JetBrains.
+language_backend: LSP
+
+# JavaScript is served by the TypeScript language server.
+language_servers:
+  - typescript
+
+encoding: utf-8
+ignore_all_files_in_gitignore: true
+read_only: false
+
+# Index the monorepo root. node_modules / coverage / stryker sandboxes
+# are already excluded via gitignore.
+ls_workspace_folders:
+  - "."
+
+ignored_paths: []
+excluded_tools: []
+included_optional_tools: []
+ls_specific_settings: {}
+initial_prompt: ""

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -284,6 +284,37 @@ packages through their built `lib/`, so run `pnpm build` first in a fresh
 checkout/worktree or cross-package suites fail confusingly (see the
 2026-07-24 agent note on worktree fall-through).
 
+### Serena (agent LSP)
+
+This repo uses [Serena](https://github.com/oraios/serena) as an **agent LSP**
+(symbolic find/overview/references/rename). Backend is
+**`language_backend: LSP`** in `.serena/project.yml` — never JetBrains.
+
+**Universal bootstrap** (every agent, every client):
+
+```sh
+bash scripts/serena-bootstrap.sh --check    # session start; exit 1 + install steps if missing
+bash scripts/serena-bootstrap.sh            # install uv + serena-agent, then `serena init` (LSP)
+```
+
+Do **not** install Serena from an MCP/plugin marketplace. Do **not** pass
+`-b JetBrains`. If the check fails, tell the user and run bootstrap; do not
+skip silently. After a first-time install, reload MCP in the client.
+
+Client wiring (all call `scripts/serena-mcp.sh`):
+
+| Client            | Config                               | Notes                                                                 |
+| ----------------- | ------------------------------------ | --------------------------------------------------------------------- |
+| Any / Claude Code | `.mcp.json`                          | `SERENA_CONTEXT=claude-code`; hooks in `.claude/settings.json`        |
+| Cursor            | `.cursor/mcp.json`                   | context defaults to `ide`                                             |
+| Everyone          | `AGENTS.md`, `.agents/skills/serena` | Cursor/Claude skill links; Cursor also has `.cursor/rules/serena.mdc` |
+
+Official quick start: https://github.com/oraios/serena#quick-start
+
+Prefer Serena symbol tools over grep for code structure. Keep using Nx MCP
+for Nx graph/docs/generators, and source + tests as the API source of truth.
+`.serena/` is prettier-ignored so Serena-written files are never rewritten.
+
 ### Commit messages
 
 This repo keeps a **Commitizen-compatible message contract** for changelog history. The interactive wizard (`pnpm run commit` / husky `prepare-commit-msg`) needs a TTY and is for humans. Agents should use `git commit -m` with the same shape; husky `commit-msg` validates it (not Cursor-specific — any non-interactive Git client).
@@ -367,6 +398,7 @@ Append durable findings to **Agent notes** below (API quirks, migration status, 
 
 _Append learnings for the next agent. Newest first._
 
+- **2026-08-13** — Serena is the agent LSP (`language_backend: LSP` in `.serena/project.yml`; never JetBrains). Any agent bootstraps with `bash scripts/serena-bootstrap.sh` (`--check` at session start). Cursor: `.cursor/mcp.json` + `.cursor/rules/serena.mdc`. Claude Code: `.mcp.json` + `.claude/settings.json`. Shared skill: `.agents/skills/serena`. Do not install from an MCP marketplace. `.serena/` is in `.prettierignore`.
 - **2026-07-24 (b)** — Coverage measurement overhauled for 0.21 (see the commit "build(coverage)"). Facts that cost hours: (1) a **stale `stryker-tmp/` sandbox left in a package dir poisons everything** — jest haste-maps the sandbox copies, doubling suites and scrambling coverage attribution; if numbers look insane, `rm -rf packages/*/stryker-tmp` first. (2) The lerna-era root **`.babelrc` injected `babel-plugin-istanbul` in the test env** (so did `babel.config.cjs`) — that double-instrumented every babel-provider coverage run into `cov_x is not a function` crashes; both removed, don't re-add. (3) The **v8 coverage provider keeps only one isolated module copy per test file** — suites built on `jest.isolateModules` (socket.io) lose whole branches; the preset now uses `coverageProvider: "babel"` (istanbul counters merge across copies) and that is the accuracy standard. (4) istanbul honors `/* istanbul ignore */` pragmas, NOT `c8 ignore`; for a default-arg branch the pragma goes **before the parameter name**. (5) The aggregate docs-site report is produced by `tools/coverage/report.cjs` (`pnpm run test:coverage`): per-package JSON coverage merged into one istanbul HTML report at `packages/docs/src/content/coverage`, scoped to the release group. The old `nx run-many --coverage` path fragmented reports into per-package junk dirs (`packages/<p>/packages/docs/...`) and could never aggregate.
 - **2026-07-24** — d.ts emission wired for all 13 release packages (see §5 “TypeScript declarations”). Gotchas from the wiring: (1) TS narrowing cannot survive `param = new X(...)` reassignment when X structurally overlaps the param's other union members (AppCtxRoot has a `t` getter, so it IS a `Trigram`) — use a fresh `const`; (2) TanStack's `useLoaderData` typings require an options arg the adapter deliberately omits — comment-cast at the call site, documented; (3) `typescript` is pinned `^5.9.3` (bare `typescript` resolves to the native TS7 compiler, no JS API); (4) @types/react@19 at the root serves react-tao and the routing hooks' emissions. **Worktree fall-through trap:** a worktree nested inside the main repo resolves missing/unbuilt workspace deps through the MAIN repo's `node_modules` (pnpm symlink realpaths escape the worktree) — jest then mixes main-repo builds with worktree sources and `instanceof AppCtx` fails across the two core instances, and tsc type-checks the main repo's untyped bundles. Always `pnpm install && pnpm build` in a fresh worktree before testing.
 - **2026-07-19** — `@tao.js/react`: prefer named export `TaoProvider`; `Provider` remains a deprecated alias (dev once-warning via `deprecations.js`). Default export of `src/Provider.js` is `TaoProvider`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,21 @@
+# Claude Code
+
+Follow **[AGENTS.md](AGENTS.md)** — that is this repo’s agent contract (Nx + pnpm monorepo for `@tao.js/*`).
+
+## Serena (agent LSP)
+
+At the start of a coding session:
+
+```sh
+bash scripts/serena-bootstrap.sh --check
+```
+
+If that fails:
+
+```sh
+bash scripts/serena-bootstrap.sh
+```
+
+Then reconnect MCP (`/mcp`). Backend is **LSP** only — never JetBrains.
+
+Project MCP lives in `.mcp.json`. Session hooks live in `.claude/settings.json`. The shared skill is `.agents/skills/serena` (also linked from `.claude/skills/serena`).

--- a/scripts/serena-bootstrap.sh
+++ b/scripts/serena-bootstrap.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Idempotent Serena bootstrap for any agent (Cursor, Claude Code, Codex, …).
+# This repo uses the LSP backend only — never JetBrains.
+#
+#   bash scripts/serena-bootstrap.sh --check   # exit 0 if ready, 1 + instructions if not
+#   bash scripts/serena-bootstrap.sh           # install uv + serena-agent and init LSP
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+export PATH="${HOME}/.local/bin:${HOME}/.cargo/bin:/opt/homebrew/bin:/usr/local/bin:${PATH}"
+
+CHECK_ONLY=false
+if [[ "${1:-}" == "--check" ]]; then
+  CHECK_ONLY=true
+fi
+
+install_help() {
+  cat >&2 <<'EOF'
+Serena is not bootstrapped. This repo uses Serena as an agent LSP (language_backend: LSP).
+Do not install it from an MCP/plugin marketplace, and do not use the JetBrains backend.
+
+Run this from the repo root:
+
+  bash scripts/serena-bootstrap.sh
+
+That will:
+  1. Install uv if needed (https://docs.astral.sh/uv/getting-started/installation/)
+  2. Install Serena: uv tool install -p 3.13 serena-agent
+  3. Initialise Serena with the LSP backend (serena init — do NOT pass -b JetBrains)
+
+Then reload MCP in your client:
+  - Cursor: Command Palette → MCP: Restart Servers (or restart Cursor)
+  - Claude Code: /mcp → reconnect Serena
+  - Other clients: restart the MCP server / session
+
+Official docs: https://oraios.github.io/serena/
+Quick start:   https://github.com/oraios/serena#quick-start
+EOF
+}
+
+need() {
+  if [[ "${CHECK_ONLY}" == true ]]; then
+    install_help
+    exit 1
+  fi
+}
+
+if ! command -v uv >/dev/null 2>&1; then
+  need
+  echo "Installing uv…" >&2
+  if command -v brew >/dev/null 2>&1; then
+    brew install uv
+  else
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+  fi
+  export PATH="${HOME}/.local/bin:${HOME}/.cargo/bin:/opt/homebrew/bin:/usr/local/bin:${PATH}"
+fi
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "uv installed but not on PATH. Add \$HOME/.local/bin to PATH and re-run." >&2
+  exit 1
+fi
+
+SERENA=""
+if command -v serena >/dev/null 2>&1; then
+  SERENA="$(command -v serena)"
+elif [[ -x "${HOME}/.local/bin/serena" ]]; then
+  SERENA="${HOME}/.local/bin/serena"
+fi
+
+if [[ -z "${SERENA}" ]]; then
+  need
+  echo "Installing serena-agent (Python 3.13, LSP backend)…" >&2
+  uv tool install -p 3.13 serena-agent
+  SERENA="${HOME}/.local/bin/serena"
+  if ! [[ -x "${SERENA}" ]] && command -v serena >/dev/null 2>&1; then
+    SERENA="$(command -v serena)"
+  fi
+fi
+
+if [[ -z "${SERENA}" || ! -x "${SERENA}" ]]; then
+  echo "serena binary not found after install. Add \$HOME/.local/bin to PATH and re-run." >&2
+  exit 1
+fi
+
+if [[ ! -f "${HOME}/.serena/serena_config.yml" ]]; then
+  need
+  echo "Initialising Serena (LSP backend; not JetBrains)…" >&2
+  "${SERENA}" init
+fi
+
+PROJECT_YML="${ROOT}/.serena/project.yml"
+if [[ ! -f "${PROJECT_YML}" ]]; then
+  echo "Missing ${PROJECT_YML} — this file is versioned with the repo." >&2
+  exit 1
+fi
+
+if ! grep -q '^language_backend:[[:space:]]*LSP[[:space:]]*$' "${PROJECT_YML}"; then
+  echo "Refusing to proceed: ${PROJECT_YML} must set language_backend: LSP (never JetBrains)." >&2
+  exit 1
+fi
+
+if grep -q '^language_backend:[[:space:]]*JetBrains[[:space:]]*$' "${HOME}/.serena/serena_config.yml" 2>/dev/null; then
+  echo "Note: global ~/.serena/serena_config.yml is JetBrains; this repo overrides to LSP via project.yml and the MCP launcher." >&2
+fi
+
+echo "Serena is ready (LSP backend)."
+echo "Binary: ${SERENA}"
+echo "Project: ${PROJECT_YML}"
+if [[ "${CHECK_ONLY}" != true ]]; then
+  echo "Reload MCP in your client if this was the first install."
+fi

--- a/scripts/serena-hooks.sh
+++ b/scripts/serena-hooks.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# PATH-safe wrapper so Claude Code hooks can find `serena-hooks` when the
+# GUI client does not inherit ~/.local/bin.
+set -euo pipefail
+
+export PATH="${HOME}/.local/bin:${HOME}/.cargo/bin:/opt/homebrew/bin:/usr/local/bin:${PATH}"
+
+if ! command -v serena-hooks >/dev/null 2>&1; then
+  echo "serena-hooks not found; run bash scripts/serena-bootstrap.sh" >&2
+  exit 0
+fi
+
+exec serena-hooks "$@"

--- a/scripts/serena-mcp.sh
+++ b/scripts/serena-mcp.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Launch Serena MCP for this workspace (LSP backend, never JetBrains).
+# Cursor: .cursor/mcp.json  Claude Code / others: .mcp.json
+# SERENA_CONTEXT defaults to `ide` (Cursor and other IDEs). Claude Code sets
+# SERENA_CONTEXT=claude-code in .mcp.json.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+export PATH="${HOME}/.local/bin:${HOME}/.cargo/bin:/opt/homebrew/bin:/usr/local/bin:${PATH}"
+
+CONTEXT="${SERENA_CONTEXT:-ide}"
+
+if ! command -v serena >/dev/null 2>&1 && [[ ! -x "${HOME}/.local/bin/serena" ]]; then
+  exec bash "${ROOT}/scripts/serena-bootstrap.sh" --check
+fi
+
+SERENA="$(command -v serena 2>/dev/null || true)"
+if [[ -z "${SERENA}" ]]; then
+  SERENA="${HOME}/.local/bin/serena"
+fi
+
+exec "${SERENA}" start-mcp-server \
+  --context "${CONTEXT}" \
+  --project "${ROOT}" \
+  --language-backend LSP \
+  --open-web-dashboard false \
+  "$@"


### PR DESCRIPTION
## Summary
- Adds a shared Serena **LSP** bootstrap (`scripts/serena-bootstrap.sh`) so any agent that clones the repo can check (`--check`) and install Serena. Backend is pinned to LSP — never JetBrains.
- Universal contract lives in `AGENTS.md` plus `.agents/skills/serena`. Cursor gets `.cursor/mcp.json` + an always-on rule; Claude Code gets `.mcp.json`, `CLAUDE.md`, and `.claude/settings.json` hooks. Both skill dirs symlink to the shared skill.
- Prettier ignores `.serena/` so memories/config Serena writes are never rewritten on commit.

## Test plan
- [ ] Fresh clone / this branch: `bash scripts/serena-bootstrap.sh --check` succeeds when Serena is installed, and prints install steps when it is not
- [ ] `bash scripts/serena-bootstrap.sh` is idempotent and leaves `.serena/project.yml` at `language_backend: LSP`
- [ ] Cursor: reload MCP servers and confirm Serena tools appear (do not use JetBrains)
- [ ] Claude Code: `/mcp` shows Serena; session hooks run without requiring `~/.local/bin` on the GUI PATH
- [ ] Stage a dummy `.serena/memories/foo.md` and confirm `prettier --write` / lint-staged does not rewrite it


Made with [Cursor](https://cursor.com)