### PR TITLE
chore: wire up CodeRabbit for OSS PR reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -10,11 +10,9 @@ language: en-US
 early_access: false
 enable_free_tier: true
 tone_instructions: >-
-  You are reviewing tao.js, a JavaScript implementation of the TAO paradigm
-  (trigrams: term / action / orient). Prefer source and tests over docs-site
-  copy when APIs disagree. Do not invent public APIs. Cite TAO-SPEC.md for
-  paradigm claims and ENVELOPE-SPEC.md for this engine. Be concise. Skip style
-  nits already covered by prettier or ESLint.
+  Review tao.js (trigrams: term/action/orient). Prefer source+tests over
+  docs-site copy. Do not invent APIs. Cite TAO-SPEC.md for paradigm,
+  ENVELOPE-SPEC.md for this engine. Skip prettier/ESLint nits.
 
 reviews:
   profile: chill

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,126 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+#
+# CodeRabbit reviews PRs on this public repo. Open-source repos get Pro+
+# features at no cost once the GitHub App is installed on zzyzxlab/tao.js.
+# Docs: https://docs.coderabbit.ai/getting-started/yaml-configuration
+#
+# Manual triggers on a PR: `@coderabbitai review` / `@coderabbitai full review`
+
+language: en-US
+early_access: false
+enable_free_tier: true
+tone_instructions: >-
+  You are reviewing tao.js, a JavaScript implementation of the TAO paradigm
+  (trigrams: term / action / orient). Prefer source and tests over docs-site
+  copy when APIs disagree. Do not invent public APIs. Cite TAO-SPEC.md for
+  paradigm claims and ENVELOPE-SPEC.md for this engine. Be concise. Skip style
+  nits already covered by prettier or ESLint.
+
+reviews:
+  profile: chill
+  request_changes_workflow: false
+  high_level_summary: true
+  review_status: true
+  collapse_walkthrough: true
+  changed_files_summary: true
+  sequence_diagrams: true
+  estimate_code_review_effort: true
+  poem: false
+  in_progress_fortune: false
+  enable_prompt_for_ai_agents: true
+  path_filters:
+    - '!**/lib/**'
+    - '!**/bundles/**'
+    - '!**/coverage/**'
+    - '!**/reports/**'
+    - '!**/stryker-tmp/**'
+    - '!packages/docs/src/content/coverage/**'
+    - '!**/*.chunk.*.js'
+    - '!**/chunk-*.js'
+  path_instructions:
+    - path: 'packages/*/src/**'
+      instructions: |
+        Confirm exports against packages/*/src/index.js and behavior against packages/*/test/**.
+        Public core surface is default TAO plus { AppCtx, Network, Kernel, INTERCEPT, ASYNC, INLINE }.
+        Trigram args must accept both { t, a, o } and { term, action, orient }.
+        Handler signature is (tao, data) with tao = { t, a, o }.
+        Do not invent APIs. Do not treat engine scheduling as paradigm contract.
+        JSDoc is the d.ts source of truth — flag @param {Object} (emits as any) and missing typedefs.
+        Prefer Kernel APIs in application-facing code; Network.enter / decorate for adapters.
+    - path: 'packages/*/test/**/*.spec.js'
+      instructions: |
+        Jest via @nx/jest. Assert behavior, not only coverage.
+        White-box adapter tests assert threading mechanics — rewrite intent, do not delete.
+        Stryker disable comments must use `: reason` (not `--`); disable-inside-try does not cover catch.
+        istanbul ignore pragmas (not c8) for babel-provider coverage.
+    - path: 'packages/react-tao/**'
+      instructions: |
+        Prefer function components + hooks. Named export TaoProvider.
+        DataHandler is tree-scoped by name; consumers use useTaoData('name').
+        RenderHandler child stays (tao, data) => … — no extra positional data-handler args.
+        Do not reintroduce Provider alias, DataConsumer, or RenderHandler.context.
+    - path: '{TAO,ENVELOPE,MESH}-SPEC.md'
+      instructions: |
+        Cite TAO-SPEC.md for paradigm claims, ENVELOPE-SPEC.md for this JS engine, MESH-SPEC.md for the mesh floor.
+        Every contract section needs a normative Plainly block.
+        Do not read engine scheduling (serialized intercept loop, queue order) back into the paradigm.
+        Cross-doc §-references are deep links to heading anchors — do not leave broken inbound links.
+    - path: 'packages/docs/**'
+      instructions: |
+        Do not rewrite the docs site unless the PR is explicitly about docs.
+        Prefer source + tests over marketing copy when APIs disagree.
+  auto_review:
+    enabled: true
+    drafts: false
+    auto_incremental_review: true
+    auto_pause_after_reviewed_commits: 5
+    base_branches:
+      - master
+    ignore_title_keywords:
+      - WIP
+      - '[skip review]'
+    ignore_usernames:
+      - dependabot[bot]
+      - renovate[bot]
+  pre_merge_checks:
+    docstrings:
+      mode: off
+    title:
+      mode: warning
+      requirements: >-
+        Prefer Conventional Commits: type(scope): subject. Types: feat, fix,
+        docs, style, refactor, perf, test, build, ci, chore. Scope is optional.
+    description:
+      mode: warning
+  tools:
+    eslint:
+      enabled: true
+      config_file: eslint.config.cjs
+    github-checks:
+      enabled: true
+    shellcheck:
+      enabled: true
+    gitleaks:
+      enabled: true
+    markdownlint:
+      enabled: false
+    languagetool:
+      enabled: false
+    yamllint:
+      enabled: false
+
+chat:
+  art: false
+  auto_reply: true
+  allow_non_org_members: true
+
+knowledge_base:
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - files: TAO-SPEC.md
+        applyTo: 'packages/**/*.{js,cjs,mjs,ts,tsx,md},TAO-SPEC.md,ENVELOPE-SPEC.md,MESH-SPEC.md,AGENTS.md'
+      - files: ENVELOPE-SPEC.md
+        applyTo: 'packages/tao/**,packages/tao-utils/**,packages/tao-socket-io/**,packages/koa-tao/**,packages/tao-telemetry/**,packages/tao-opentelemetry/**,packages/tao-transport-tck/**,packages/tao-http-client/**,ENVELOPE-SPEC.md'
+      - files: MESH-SPEC.md
+        applyTo: 'packages/tao-socket-io/**,packages/tao-transport-tck/**,packages/koa-tao/**,MESH-SPEC.md'

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -16,7 +16,9 @@ tone_instructions: >-
 
 reviews:
   profile: chill
-  request_changes_workflow: false
+  # Submit GitHub review verdicts: CHANGES_REQUESTED while comments are open,
+  # APPROVED once they are resolved (and pre-merge checks are not failing).
+  request_changes_workflow: true
   high_level_summary: true
   review_status: true
   collapse_walkthrough: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -353,6 +353,12 @@ Affected packages:
 - Optional: `ISSUES CLOSED: #123`, `BREAKING CHANGE: …`
 - Hooks: `pre-commit` → lint-staged; `prepare-commit-msg` → wizard if TTY and no `-m`; `commit-msg` → `scripts/validate-commit-msg.js`
 
+### Code review (CodeRabbit)
+
+This public repo is reviewed by the [CodeRabbit](https://coderabbit.ai) GitHub App (OSS Pro+ tier — no paid plan). Config lives at [`.coderabbit.yaml`](./.coderabbit.yaml). It already reads `AGENTS.md`, `CLAUDE.md`, and `.cursor/rules/*`; the YAML also maps `TAO-SPEC.md` / `ENVELOPE-SPEC.md` / `MESH-SPEC.md` as review guidelines.
+
+On a PR: `@coderabbitai review` (incremental) or `@coderabbitai full review`. Skip with `WIP` / `[skip review]` in the title, or `@coderabbitai pause`.
+
 ### Editing guidance
 
 - Match existing style (plain JS classes in core; Jest + mocks in tests). Prefer function components + hooks for new `@tao.js/react` Current API work (see Switch/Render modernization).
@@ -414,6 +420,8 @@ Append durable findings to **Agent notes** below (API quirks, migration status, 
 ## 6. Agent notes
 
 _Append learnings for the next agent. Newest first._
+
+- **2026-08-17** — CodeRabbit GitHub App reviews PRs on this public OSS repo (Pro+ OSS tier, no paid plan). Repo config is `.coderabbit.yaml`. Manual trigger: `@coderabbitai review`. Do not add a GitHub Actions workflow for it — the native GitHub App is the integration.
 
 - **2026-08-13** — Serena is the agent LSP (`language_backend: LSP` in `.serena/project.yml`; never JetBrains). Any agent bootstraps with `bash scripts/serena-bootstrap.sh` (`--check` at session start). Cursor: `.cursor/mcp.json` + `.cursor/rules/serena.mdc`. Claude Code: `.mcp.json` + `.claude/settings.json`. Shared skill: `.agents/skills/serena`. Do not install from an MCP marketplace. `.serena/` is in `.prettierignore`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -359,6 +359,8 @@ This public repo is reviewed by the [CodeRabbit](https://coderabbit.ai) GitHub A
 
 On a PR: `@coderabbitai review` (incremental) or `@coderabbitai full review`. CodeRabbit submits a GitHub review verdict (`CHANGES_REQUESTED` while its comments are open, `APPROVED` once they are resolved). `@coderabbitai approve` resolves its threads and approves when that workflow is enabled. Skip automatic reviews with `WIP` / `[skip review]` in the title, or `@coderabbitai pause`. Explicit `@coderabbitai review` still works.
 
+The repo ruleset **Default (main)** (`~DEFAULT_BRANCH`) requires that to merge: 1 approving review, all review threads resolved, last-push approval (the last pusher cannot be the approver), stale reviews dismissed on push, squash-only. There is no bypass. CodeRabbit’s `APPROVED` / `CHANGES_REQUESTED` reviews count. After you push, wait for CodeRabbit to re-review — a prior approval is stale.
+
 ### Editing guidance
 
 - Match existing style (plain JS classes in core; Jest + mocks in tests). Prefer function components + hooks for new `@tao.js/react` Current API work (see Switch/Render modernization).
@@ -421,7 +423,7 @@ Append durable findings to **Agent notes** below (API quirks, migration status, 
 
 _Append learnings for the next agent. Newest first._
 
-- **2026-08-18** — CodeRabbit `reviews.request_changes_workflow` is on: it submits GitHub review verdicts (`CHANGES_REQUESTED` / `APPROVED`), not comment-only. `@coderabbitai approve` works. Pre-merge title/description checks stay `warning` (non-blocking).
+- **2026-08-18** — Ruleset **Default (main)** requires 1 approving review, resolved threads, last-push approval, dismiss-stale-on-push, squash-only; no bypass. CodeRabbit’s GitHub review verdicts satisfy it. After a push, wait for a fresh CodeRabbit approval. CodeRabbit `reviews.request_changes_workflow` is on (`CHANGES_REQUESTED` / `APPROVED`), not comment-only. `@coderabbitai approve` works. Pre-merge title/description checks stay `warning` (non-blocking).
 - **2026-08-17** — CodeRabbit GitHub App reviews PRs on this public OSS repo (Pro+ OSS tier, no paid plan). Repo config is `.coderabbit.yaml`. Manual trigger: `@coderabbitai review`. Do not add a GitHub Actions workflow for it — the native GitHub App is the integration.
 
 - **2026-08-13** — Serena is the agent LSP (`language_backend: LSP` in `.serena/project.yml`; never JetBrains). Any agent bootstraps with `bash scripts/serena-bootstrap.sh` (`--check` at session start). Cursor: `.cursor/mcp.json` + `.cursor/rules/serena.mdc`. Claude Code: `.mcp.json` + `.claude/settings.json`. Shared skill: `.agents/skills/serena`. Do not install from an MCP marketplace. `.serena/` is in `.prettierignore`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -357,7 +357,7 @@ Affected packages:
 
 This public repo is reviewed by the [CodeRabbit](https://coderabbit.ai) GitHub App (OSS Pro+ tier — no paid plan). Config lives at [`.coderabbit.yaml`](./.coderabbit.yaml). It already reads `AGENTS.md`, `CLAUDE.md`, and `.cursor/rules/*`; the YAML also maps `TAO-SPEC.md` / `ENVELOPE-SPEC.md` / `MESH-SPEC.md` as review guidelines.
 
-On a PR: `@coderabbitai review` (incremental) or `@coderabbitai full review`. Skip automatic reviews with `WIP` / `[skip review]` in the title, or `@coderabbitai pause`. Explicit `@coderabbitai review` still works.
+On a PR: `@coderabbitai review` (incremental) or `@coderabbitai full review`. CodeRabbit submits a GitHub review verdict (`CHANGES_REQUESTED` while its comments are open, `APPROVED` once they are resolved). `@coderabbitai approve` resolves its threads and approves when that workflow is enabled. Skip automatic reviews with `WIP` / `[skip review]` in the title, or `@coderabbitai pause`. Explicit `@coderabbitai review` still works.
 
 ### Editing guidance
 
@@ -421,6 +421,7 @@ Append durable findings to **Agent notes** below (API quirks, migration status, 
 
 _Append learnings for the next agent. Newest first._
 
+- **2026-08-18** — CodeRabbit `reviews.request_changes_workflow` is on: it submits GitHub review verdicts (`CHANGES_REQUESTED` / `APPROVED`), not comment-only. `@coderabbitai approve` works. Pre-merge title/description checks stay `warning` (non-blocking).
 - **2026-08-17** — CodeRabbit GitHub App reviews PRs on this public OSS repo (Pro+ OSS tier, no paid plan). Repo config is `.coderabbit.yaml`. Manual trigger: `@coderabbitai review`. Do not add a GitHub Actions workflow for it — the native GitHub App is the integration.
 
 - **2026-08-13** — Serena is the agent LSP (`language_backend: LSP` in `.serena/project.yml`; never JetBrains). Any agent bootstraps with `bash scripts/serena-bootstrap.sh` (`--check` at session start). Cursor: `.cursor/mcp.json` + `.cursor/rules/serena.mdc`. Claude Code: `.mcp.json` + `.claude/settings.json`. Shared skill: `.agents/skills/serena`. Do not install from an MCP marketplace. `.serena/` is in `.prettierignore`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -357,7 +357,7 @@ Affected packages:
 
 This public repo is reviewed by the [CodeRabbit](https://coderabbit.ai) GitHub App (OSS Pro+ tier — no paid plan). Config lives at [`.coderabbit.yaml`](./.coderabbit.yaml). It already reads `AGENTS.md`, `CLAUDE.md`, and `.cursor/rules/*`; the YAML also maps `TAO-SPEC.md` / `ENVELOPE-SPEC.md` / `MESH-SPEC.md` as review guidelines.
 
-On a PR: `@coderabbitai review` (incremental) or `@coderabbitai full review`. Skip with `WIP` / `[skip review]` in the title, or `@coderabbitai pause`.
+On a PR: `@coderabbitai review` (incremental) or `@coderabbitai full review`. Skip automatic reviews with `WIP` / `[skip review]` in the title, or `@coderabbitai pause`. Explicit `@coderabbitai review` still works.
 
 ### Editing guidance
 


### PR DESCRIPTION
## Summary
- Add `.coderabbit.yaml` so CodeRabbit reviews this public repo with TAO-specific path instructions and spec guidelines (`TAO-SPEC.md` / `ENVELOPE-SPEC.md` / `MESH-SPEC.md`).
- Document the GitHub App integration in `AGENTS.md`. Public OSS repos get Pro+ reviews at no cost; no GitHub Actions workflow is required.

**Org-owner step (required for reviews to start):** install the CodeRabbit GitHub App on **only** `zzyzxlab/tao.js`:

https://github.com/apps/coderabbitai/installations/new/permissions?target_id=13932822

Choose **Only select repositories** → `tao.js` → **Install & Authorize**. No credit card.

After that, CodeRabbit will review this PR (or comment `@coderabbitai review` if it does not pick it up automatically).

## Test plan
- [ ] GitHub App is installed on `zzyzxlab/tao.js` (org Settings → GitHub Apps, or CodeRabbit dashboard)
- [ ] This PR receives a CodeRabbit walkthrough comment (or `@coderabbitai review` triggers one)
- [ ] `@coderabbitai configuration` on this PR shows `.coderabbit.yaml` as a source
- [ ] Confirm dependabot PRs stay skipped (`ignore_usernames`)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added repository guidance for automated code reviews, including commands, verdicts, approval behavior, and pause or skip controls.
  * Documented review workflows, integration details, merge requirements, and repository-specific instructions.
  * Added dated notes covering review processes and integration recommendations.

* **Chores**
  * Added centralized review settings for language, tone, behavior, exclusions, tools, automation, and knowledge-base file patterns.
  * Configured path-specific guidance and pre-merge review policies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->